### PR TITLE
remove useless collectstatic

### DIFF
--- a/bin/post_deploy
+++ b/bin/post_deploy
@@ -2,5 +2,4 @@
 
 python manage.py migrate
 python manage.py loaddata categories actions acteur_services acteur_types
-python manage.py collectstatic --noinput
 python manage.py clearsessions


### PR DESCRIPTION
Collect statics is done in post-compile script, it is useless in post-deploy script