### PR TITLE
query distinct points

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ python manage.py createsuperuser
 honcho start -f Procfile.dev
 ```
 
+Honcho démarrera les containers Docker s'ils ne sont pas déjà démarrés
+
 ### Ajout et modification de package pip-tools
 
 Ajouter les dépendances aux fichiers `requirements.in` et `dev-requirements.in`

--- a/static/to_compile/src/map_controller.ts
+++ b/static/to_compile/src/map_controller.ts
@@ -8,7 +8,7 @@ export default class extends Controller<HTMLElement> {
     static values = { location: { type: Object, default: {} } }
     declare readonly locationValue: object
 
-    initialize() {
+    connect() {
         new EconomieCirculaireSolutionMap({
             location: this.locationValue,
             economiecirculaireacteurs: this.economiecirculaireacteurTargets,


### PR DESCRIPTION
sometimes too few points are displayed, missing a distinct on query