### PR TITLE
re-organize search form

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Les autres paramètres disponibles pour afficher la page principale de l'applica
 Exemple:
 
 ```txt
-http://localhost:8000/?direction=jecherche&action_list=emprunter%7Cechanger%7Clouer%7Cacheter+d%27occasion&sous_categorie_objet=&adresse=145+Avenue+Pierre+Brossolette+92120+Montrouge&latitude=48.815679&longitude=2.305116&overwritten_direction=jecherche
+http://localhost:8000/?direction=jecherche&action_list=emprunter%7Cechanger%7Clouer%7Cacheter+d%27occasion&sous_categorie_objet=&adresse=145+Avenue+Pierre+Brossolette+92120+Montrouge&latitude=48.815679&longitude=2.305116
 
 ```
 

--- a/integration_tests/qfdmo/test_reemploi_solution.py
+++ b/integration_tests/qfdmo/test_reemploi_solution.py
@@ -30,7 +30,6 @@ class TestReemploiSolutionView:
             "sous_categorie_objet": None,
             "adresse": None,
             "direction": settings.DEFAULT_ACTION_DIRECTION,
-            "overwritten_direction": settings.DEFAULT_ACTION_DIRECTION,
             "action_list": None,
             "latitude": None,
             "longitude": None,

--- a/jinja2/layout/base.html
+++ b/jinja2/layout/base.html
@@ -29,16 +29,14 @@
 
     </head>
 
-    <body class="h-full m-0 font-default ">
+    <body class="qfdmo-flex qfdmo-flex-col">
         {% if not is_iframe(request) %}
             {% block header %}
                 {% include "layout/header.html" %}
             {% endblock %}
         {% endif %}
-        <main role="main" class="bg-white shadow">
-            <div class="fr-container">
-                {% block content %}{% endblock %}
-            </div>
+        <main role="main" id="solutions">
+            {% block content %}{% endblock %}
         </main>
         {% if not is_iframe(request) %}
             {% block footer %}

--- a/jinja2/qfdmo/analyse.html
+++ b/jinja2/qfdmo/analyse.html
@@ -1,31 +1,34 @@
 {% extends 'layout/base.html' %}
 
 {% block content %}
-    <div class="qfdmo-content-center">
-        <h1>Analyse de la base de données LVAO</h1>
-        <p>
-            Nb d'acteurs avec plusieurs revisions pour les mêmes actions: {{lvao_bases.count()}}
-        </p>
-        <div class="fr-table">
-            <table>
-                <caption>Acteur du réemploi ayant plusieurs occurences</caption>
-                <thead>
-                    <tr>
-                        <th scope="col">Acteur du Réemploi</th>
-                        <th scope="col">Nb Révisions</th>
-                        <th scope="col">Nb Actions</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for lvao_base in lvao_bases %}
+    <div class="fr-container">
+
+        <div class="qfdmo-content-center">
+            <h1>Analyse de la base de données LVAO</h1>
+            <p>
+                Nb d'acteurs avec plusieurs revisions pour les mêmes actions: {{lvao_bases.count()}}
+            </p>
+            <div class="fr-table">
+                <table>
+                    <caption>Acteur du réemploi ayant plusieurs occurences</caption>
+                    <thead>
                         <tr>
-                            <td><a href="{{ reverse('qfdmo:analyse_lvao_base', args=[lvao_base.id]) }}">{{ lvao_base.nom }}</a></td>
-                            <td>{{ lvao_base.lvao_base_revision_count }}</td>
-                            <td>{{ lvao_base.action_count }}</td>
+                            <th scope="col">Acteur du Réemploi</th>
+                            <th scope="col">Nb Révisions</th>
+                            <th scope="col">Nb Actions</th>
                         </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+                    </thead>
+                    <tbody>
+                        {% for lvao_base in lvao_bases %}
+                            <tr>
+                                <td><a href="{{ reverse('qfdmo:analyse_lvao_base', args=[lvao_base.id]) }}">{{ lvao_base.nom }}</a></td>
+                                <td>{{ lvao_base.lvao_base_revision_count }}</td>
+                                <td>{{ lvao_base.action_count }}</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/jinja2/qfdmo/analyse_lvao_base.html
+++ b/jinja2/qfdmo/analyse_lvao_base.html
@@ -1,163 +1,165 @@
 {% extends 'layout/base.html' %}
 
 {% block content %}
-    <div class="qfdmo-content-center">
-        <h1>Analyse de la base de données LVAO</h1>
-        <a href="{{ reverse('qfdmo:analyse') }}">retour à la page d'analyse</a>
+    <div class="fr-container">
+        <div class="qfdmo-content-center">
+            <h1>Analyse de la base de données LVAO</h1>
+            <a href="{{ reverse('qfdmo:analyse') }}">retour à la page d'analyse</a>
 
-        <h2>{{ lvao_base.nom }} ({{ lvao_base.identifiant_unique }})</h2>
-        <p>Nb occurences : {{ lvao_base_revisions.count() }}</p>
+            <h2>{{ lvao_base.nom }} ({{ lvao_base.identifiant_unique }})</h2>
+            <p>Nb occurences : {{ lvao_base_revisions.count() }}</p>
 
 
-        <div class="fr-table">
-            <table>
-                <caption>Diff de révision</caption>
-                <thead>
-                    <tr>
-                        <th scope="col"></th>
-                        {% for lvao_base_revision in lvao_base_revisions %}
-                            <th scope="col">{{ lvao_base_revision.lvao_revision_id }}</th>
-                        {% endfor %}
-                        <th scope="col">Acteur du réemploi</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>
-                            Nom<br>
-                            siret<br>
-                            Nom commercial<br>
-                            Raison social
-                        </td>
-                        {% for lvao_base_revision in lvao_base_revisions %}
-                            <td scope="col">
-                                {{ lvao_base_revision.nom }}<br>
-                                {{ lvao_base_revision.siret }}<br>
-                                {{ lvao_base_revision.nom_commercial }}<br>
-                                {{ lvao_base_revision.nom_officiel }}
+            <div class="fr-table">
+                <table>
+                    <caption>Diff de révision</caption>
+                    <thead>
+                        <tr>
+                            <th scope="col"></th>
+                            {% for lvao_base_revision in lvao_base_revisions %}
+                                <th scope="col">{{ lvao_base_revision.lvao_revision_id }}</th>
+                            {% endfor %}
+                            <th scope="col">Acteur du réemploi</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>
+                                Nom<br>
+                                siret<br>
+                                Nom commercial<br>
+                                Raison social
                             </td>
-                        {% endfor %}
-                        <td scope="col">
-                            {% if acteur %}
-                                {{ acteur.nom }}<br>
-                                {{ acteur.siret }}<br>
-                                {{ acteur.nom_commercial }}<br>
-                                {{ acteur.nom_officiel }}
-                            {% endif %}
-                        </td>
+                            {% for lvao_base_revision in lvao_base_revisions %}
+                                <td scope="col">
+                                    {{ lvao_base_revision.nom }}<br>
+                                    {{ lvao_base_revision.siret }}<br>
+                                    {{ lvao_base_revision.nom_commercial }}<br>
+                                    {{ lvao_base_revision.nom_officiel }}
+                                </td>
+                            {% endfor %}
+                            <td scope="col">
+                                {% if acteur %}
+                                    {{ acteur.nom }}<br>
+                                    {{ acteur.siret }}<br>
+                                    {{ acteur.nom_commercial }}<br>
+                                    {{ acteur.nom_officiel }}
+                                {% endif %}
+                            </td>
 
-                    </tr>
-                    <tr>
-                        <td>Adresse</td>
-                        {% for lvao_base_revision in lvao_base_revisions %}
+                        </tr>
+                        <tr>
+                            <td>Adresse</td>
+                            {% for lvao_base_revision in lvao_base_revisions %}
+                                <td scope="col">
+                                    {{ lvao_base_revision.adresse }}<br>
+                                    {{ lvao_base_revision.adresse_complement }}<br>
+                                    {{ lvao_base_revision.code_postal }} {{ lvao_base_revision.ville }}
+                                </td>
+                            {% endfor %}
                             <td scope="col">
-                                {{ lvao_base_revision.adresse }}<br>
-                                {{ lvao_base_revision.adresse_complement }}<br>
-                                {{ lvao_base_revision.code_postal }} {{ lvao_base_revision.ville }}
+                                {% if acteur %}
+                                    {{ acteur.adresse }}<br>
+                                    {{ acteur.adresse_complement }}<br>
+                                    {{ acteur.code_postal }} {{ acteur.ville }}
+                                {% endif %}
                             </td>
-                        {% endfor %}
-                        <td scope="col">
-                            {% if acteur %}
-                                {{ acteur.adresse }}<br>
-                                {{ acteur.adresse_complement }}<br>
-                                {{ acteur.code_postal }} {{ acteur.ville }}
-                            {% endif %}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>latitude / longitude</td>
-                        {% for lvao_base_revision in lvao_base_revisions %}
+                        </tr>
+                        <tr>
+                            <td>latitude / longitude</td>
+                            {% for lvao_base_revision in lvao_base_revisions %}
+                                <td scope="col">
+                                    lat {{ lvao_base_revision.latitude }}<br>
+                                    long {{ lvao_base_revision.longitude }}<br>
+                                    <a href="https://maps.google.com/maps?z=12&t=m&q=loc:{{ lvao_base_revision.latitude }}+{{ lvao_base_revision.longitude }}" target='blank'>GMap</a>
+                                </td>
+                            {% endfor %}
                             <td scope="col">
-                                lat {{ lvao_base_revision.latitude }}<br>
-                                long {{ lvao_base_revision.longitude }}<br>
-                                <a href="https://maps.google.com/maps?z=12&t=m&q=loc:{{ lvao_base_revision.latitude }}+{{ lvao_base_revision.longitude }}" target='blank'>GMap</a>
+                                {% if acteur %}
+                                    lat {{ acteur.latitude }}<br>
+                                    long {{ acteur.longitude }}<br>
+                                    <a href="https://maps.google.com/maps?z=12&t=m&q=loc:{{ acteur.latitude }}+{{ acteur.longitude }}" target='blank'>GMap</a>
+                                {% endif %}
                             </td>
-                        {% endfor %}
-                        <td scope="col">
-                            {% if acteur %}
-                                lat {{ acteur.latitude }}<br>
-                                long {{ acteur.longitude }}<br>
-                                <a href="https://maps.google.com/maps?z=12&t=m&q=loc:{{ acteur.latitude }}+{{ acteur.longitude }}" target='blank'>GMap</a>
-                            {% endif %}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>Action</td>
-                        {% for lvao_base_revision in lvao_base_revisions %}
+                        </tr>
+                        <tr>
+                            <td>Action</td>
+                            {% for lvao_base_revision in lvao_base_revisions %}
+                                <td scope="col">
+                                    {% for action in lvao_base_revision.actions.all() %}
+                                        {{ action }}<br>
+                                    {% endfor %}
+                                </td>
+                            {% endfor %}
                             <td scope="col">
-                                {% for action in lvao_base_revision.actions.all() %}
-                                    {{ action }}<br>
-                                {% endfor %}
+                                …
                             </td>
-                        {% endfor %}
-                        <td scope="col">
-                            …
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>Categories / Sous-categories</td>
-                        {% for lvao_base_revision in lvao_base_revisions %}
+                        </tr>
+                        <tr>
+                            <td>Categories / Sous-categories</td>
+                            {% for lvao_base_revision in lvao_base_revisions %}
+                                <td scope="col">
+                                    {% for sous_categories in lvao_base_revision.sous_categories.all() %}
+                                        {{ sous_categories.categorie }} / {{ sous_categories }}<br>
+                                    {% endfor %}
+                                </td>
+                            {% endfor %}
                             <td scope="col">
-                                {% for sous_categories in lvao_base_revision.sous_categories.all() %}
-                                    {{ sous_categories.categorie }} / {{ sous_categories }}<br>
-                                {% endfor %}
+                                …
                             </td>
-                        {% endfor %}
-                        <td scope="col">
-                            …
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>Services</td>
-                        {% for lvao_base_revision in lvao_base_revisions %}
+                        </tr>
+                        <tr>
+                            <td>Services</td>
+                            {% for lvao_base_revision in lvao_base_revisions %}
+                                <td scope="col">
+                                    {% for service in lvao_base_revision.acteur_services.all() %}
+                                        {{ service }}<br>
+                                    {% endfor %}
+                                </td>
+                            {% endfor %}
                             <td scope="col">
-                                {% for service in lvao_base_revision.acteur_services.all() %}
-                                    {{ service }}<br>
-                                {% endfor %}
+                                …
                             </td>
-                        {% endfor %}
-                        <td scope="col">
-                            …
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>Type d'entité</td>
-                        {% for lvao_base_revision in lvao_base_revisions %}
-                            <td scope="col">{{ lvao_base_revision.acteur_type }}</td>
-                        {% endfor %}
-                        <td scope="col">
-                            {% if acteur %}
-                                {{ acteur.acteur_type }}
-                            {% endif %}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>Source des donnée (BDD)</td>
-                        {% for lvao_base_revision in lvao_base_revisions %}
-                            <td scope="col">{{ lvao_base_revision.source_donnee }} </td>
-                        {% endfor %}
-                        <td scope="col">
-                            {% if acteur %}
-                                {{ acteur.source_donnee }}
-                            {% endif %}
-                        </td>
-                    </tr>
+                        </tr>
+                        <tr>
+                            <td>Type d'entité</td>
+                            {% for lvao_base_revision in lvao_base_revisions %}
+                                <td scope="col">{{ lvao_base_revision.acteur_type }}</td>
+                            {% endfor %}
+                            <td scope="col">
+                                {% if acteur %}
+                                    {{ acteur.acteur_type }}
+                                {% endif %}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Source des donnée (BDD)</td>
+                            {% for lvao_base_revision in lvao_base_revisions %}
+                                <td scope="col">{{ lvao_base_revision.source_donnee }} </td>
+                            {% endfor %}
+                            <td scope="col">
+                                {% if acteur %}
+                                    {{ acteur.source_donnee }}
+                                {% endif %}
+                            </td>
+                        </tr>
 
-                    <tr>
-                        <td>identifiant externe</td>
-                        {% for lvao_base_revision in lvao_base_revisions %}
+                        <tr>
+                            <td>identifiant externe</td>
+                            {% for lvao_base_revision in lvao_base_revisions %}
+                                <td scope="col">
+                                    {{ lvao_base_revision.identifiant_externe }}<br>
+                                </td>
+                            {% endfor %}
                             <td scope="col">
-                                {{ lvao_base_revision.identifiant_externe }}<br>
+                                {% if acteur %}
+                                    {{ acteur.identifiant_externe }}
+                                {% endif %}
                             </td>
-                        {% endfor %}
-                        <td scope="col">
-                            {% if acteur %}
-                                {{ acteur.identifiant_externe }}
-                            {% endif %}
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/jinja2/qfdmo/partials/action_list_by_direction.html
+++ b/jinja2/qfdmo/partials/action_list_by_direction.html
@@ -1,0 +1,14 @@
+
+<div id="{{action_direction}}" data-choose-action-target='{{action_direction}}'>
+    {% for action in action_by_direction(request, action_direction) %}
+        <button
+            type="button"
+            class="fr-tag fr-m-1v"
+            name="{{action.nom}}"
+            data-action="click->choose-action#apply"
+            {% if action.description %} title="{{ action.description }}"{% endif %}
+            aria-pressed="{{ 'true' if action.active else 'false' }}">
+            {{ action.nom_affiche }}
+        </button>
+    {% endfor %}
+</div>

--- a/jinja2/qfdmo/reemploi_solution.html
+++ b/jinja2/qfdmo/reemploi_solution.html
@@ -1,90 +1,54 @@
 {% extends 'layout/base.html' %}
 
 {% block content %}
-    <div data-controller="choose-action">
-        <form class="fr-my-3w" id='search_form'>
-            {% include "qfdmo/partials/iframe_input.html" %}
-            <div class="fr-grid-row fr-grid-row--gutters">
-                <div class="fr-col-12">
-                    <div class="qfdmo-flex qfdmo-justify-between qfdmo-items-center fr-mb-1v">
-                        <div>
-                            {{ form.direction }}
-                            {{ form.action_list }}
-                        </div>
-                        <div>
-                            <button type="button" class="fr-btn fr-btn__secondary" data-fr-opened="false" aria-controls="fr-modal-actions">
-                                <span class="fr-icon-equalizer-line" aria-hidden="true"></span>
-                                Affiner
-                            </button>
-                        </div>
+    <div class="fr-container qfdmo-min-h-screen md:qfdmo-min-h-fit md:qfdmo-flex-auto qfdmo-flex qfdmo-flex-col" >
+        <div data-controller="choose-action">
+            <form class="fr-my-3w" id='search_form' action='#solutions'>
+                {% include "qfdmo/partials/iframe_input.html" %}
+                {{ form.direction }}
+                {{ form.action_list }}
+                <div data-controller='autocomplete' data-autocomplete-max-option-displayed-value=5>
+                    {{ form.sous_categorie_objet.label }}
+                    {{ form.sous_categorie_objet }}
+                </div>
+                <div data-controller='address-autocomplete'
+                    data-address-autocomplete-max-option-displayed-value=5
+                    data-address-autocomplete-is-ban-address-value='true'
+                >
+                    {{ form.adresse.label }}
+                    {{ form.adresse }}
+                    {{ form.longitude }}
+                    {{ form.latitude }}
+                </div>
+                <div class="fr-grid-row fr-grid-row--bottom">
+                    <div class="fr-col-12 fr-col-md-9">
+                        <label>Je souhaite</label>
+                        {% with action_direction='jai' %}
+                            {% include "qfdmo/partials/action_list_by_direction.html"  %}
+                        {% endwith %}
+                        {% with action_direction='jecherche' %}
+                            {% include "qfdmo/partials/action_list_by_direction.html"  %}
+                        {% endwith %}
                     </div>
-                    <div class="qfdmo-text-xs qfdmo-flex qfdmo-justify-start fr-mb-2w">
-                        <div class="qfdmo-whitespace-nowrap">Je peux :&nbsp;</div>
-                        <div class="qfdmo-truncate">
-                            {{ ", ".join(action_list_display(request)) }}
-                        </div>
+                    <div class="fr-col-12 fr-col-md-3">
+                        <button class="fr-btn fr-icon-search-line fr-btn--icon-left qfdmo-float-right">Rechercher</button>
                     </div>
                 </div>
-            </div>
-
-            {{ form.sous_categorie_objet }}
-            {{ form.adresse }}
-            {{ form.latitude }}
-            {{ form.longitude }}
-
-            <dialog aria-labelledby="action_modal" id="fr-modal-actions" class="fr-modal" role="dialog" >
-                <div class="fr-container fr-container--fluid fr-container-md qfdmo-h-full">
-                    <div class="fr-grid-row fr-grid-row--center qfdmo-h-full">
-                        <div class="fr-col-12 fr-col-md-8">
-                            <div class="fr-modal__body qfdmo-h-full">
-                                <div class="qfdmo-h-full qfdmo-flex qfdmo-flex-col qfdmo-justify-between">
-                                    <div class="fr-modal__header">
-                                        <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-actions">Fermer</button>
-                                    </div>
-                                    <div class="fr-modal__content">
-                                        <h1 id="fr-modal-2-title" class="fr-modal__title">
-                                            <span class="fr-icon-arrow-right-line fr-icon--lg"></span>
-                                            Que souhaitez-vous faire ?
-                                        </h1>
-                                        <div class="fr-mb-3w">
-                                            {{ form.overwritten_direction }}
-                                        </div>
-                                        <div id="jai" data-choose-action-target='jai'>
-                                            {% for action in action_by_direction(request, 'jai') %}
-                                                <button type="button" class="fr-tag fr-m-1v" name="{{action.nom}}"{% if action.description %} title="{{ action.description }}"{% endif %} aria-pressed="{{ 'true' if action.active else 'false' }}">{{ action.nom_affiche }}</button>
-                                            {% endfor %}
-                                        </div>
-                                        <div id="jecherche" data-choose-action-target="jecherche">
-                                            {% for action in action_by_direction(request, 'jecherche') %}
-                                                <button type="button" class="fr-tag fr-m-1v" name="{{action.nom}}"{% if action.description %} title="{{ action.description }}"{% endif %} aria-pressed="{{ 'true' if action.active else 'false' }}">{{ action.nom_affiche }}</button>
-                                            {% endfor %}
-                                        </div>
-
-                                    </div>
-                                    <div class="fr-modal__footer">
-                                        <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
-                                            <li>
-                                                <button type="button" class="fr-btn fr-icon-checkbox-line" data-action="click->choose-action#apply">
-                                                    Appliquer ces gestes
-                                                </button>
-                                            </li>
-                                        </ul>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </dialog>
-        </form>
-
+            </form>
+        </div>
         <div
-            class="fr-mb-3w"
+            class="fr-mb-3w qfdmo-flex-auto qfdmo-relative qfdmo-min-h-[50vh]"
             data-controller="map"
             data-map-location-value="{{ location }}"
-            data-map-acteurs-value="{{ acteurs }}"
+            id="map" data-map-target="map"
         >
-            <div id="map" data-map-target="map"></div>
+            {% if not form.initial.adresse %}
+                <div class="qfdmo-absolute qfdmo-inset-0 qfdmo-bg-black qfdmo-opacity-70 qfdmo-font-black" style="z-index:10000;background-color:gray">
+                    <div class="qfdmo-flex qfdmo-h-full qfdmo-w-full qfdmo-items-center qfdmo-justify-center qfdmo-text-2xl md:qfdmo-text-4xl qfdmo-text-center">
+                        Préciser une adresse pour afficher la carte
+                    </div>
+                </div>
+            {% endif %}
             {% for acteur in acteurs %}
                 <script type="application/json" data-map-target="acteur">
                     {{ acteur.serialize(format='json') | safe }}

--- a/jinja2/qfdmo/reemploi_solution.html
+++ b/jinja2/qfdmo/reemploi_solution.html
@@ -7,7 +7,9 @@
                 {% include "qfdmo/partials/iframe_input.html" %}
                 {{ form.direction }}
                 {{ form.action_list }}
-                <div data-controller='autocomplete' data-autocomplete-max-option-displayed-value=5>
+                <div data-controller='autocomplete'
+                    data-autocomplete-max-option-displayed-value=5
+                >
                     {{ form.sous_categorie_objet.label }}
                     {{ form.sous_categorie_objet }}
                 </div>
@@ -43,7 +45,7 @@
             id="map" data-map-target="map"
         >
             {% if not form.initial.adresse %}
-                <div class="qfdmo-absolute qfdmo-inset-0 qfdmo-bg-black qfdmo-opacity-70 qfdmo-font-black" style="z-index:10000;background-color:gray">
+                <div class="qfdmo-absolute qfdmo-inset-0 qfdmo-bg-black qfdmo-opacity-70 qfdmo-font-black qfdmo-z-[1000]" style="background-color:gray">
                     <div class="qfdmo-flex qfdmo-h-full qfdmo-w-full qfdmo-items-center qfdmo-justify-center qfdmo-text-2xl md:qfdmo-text-4xl qfdmo-text-center">
                         Préciser une adresse pour afficher la carte
                     </div>

--- a/qfdmo/forms.py
+++ b/qfdmo/forms.py
@@ -6,25 +6,13 @@ from qfdmo.models import ActionDirection, SousCategorieObjet
 class AutoCompleteInput(forms.Select):
     template_name = "django/forms/widgets/autocomplete.html"
 
-    def __init__(
-        self,
-        attrs=None,
-        max_options_displayed=10,
-        is_ban_address=False,
-        data_controller="autocomplete",
-        **kwargs
-    ):
+    def __init__(self, attrs=None, data_controller="autocomplete", **kwargs):
         self.data_controller = data_controller
-        self.max_options_displayed = max_options_displayed
-        self.is_ban_address = is_ban_address
         super().__init__(attrs=attrs, **kwargs)
 
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
         context["widget"]["data_controller"] = self.data_controller
-        context["widget"]["max_options_displayed"] = self.max_options_displayed
-        if self.is_ban_address:
-            context["widget"]["is_ban_address"] = "true"
         return context
 
 
@@ -62,8 +50,6 @@ class GetReemploiSolutionForm(forms.Form):
                 "placeholder": "ex : 20 Av. du Grésillé, 49000 Angers",
             },
             data_controller="address-autocomplete",
-            is_ban_address=True,
-            max_options_displayed=5,
         ),
         label="Autour de l'adresse suivante",
         required=False,

--- a/qfdmo/forms.py
+++ b/qfdmo/forms.py
@@ -47,11 +47,11 @@ class GetReemploiSolutionForm(forms.Form):
         queryset=SousCategorieObjet.objects.all(),
         widget=AutoCompleteInput(
             attrs={
-                "class": "fr-input",
-                "placeholder": "Vêtement, Meuble, Smartphone, etc.",
+                "class": "fr-input fr-icon-search-line",
+                "placeholder": "ex : Vêtement, Meuble, Smartphone, etc.",
             }
         ),
-        label="",
+        label="Indiquer une famille d'objet",
         empty_label="",
         required=False,
     )
@@ -59,13 +59,13 @@ class GetReemploiSolutionForm(forms.Form):
         widget=AutoCompleteInput(
             attrs={
                 "class": "fr-input",
-                "placeholder": "Quelle est votre adresse ?",
+                "placeholder": "ex : 20 Av. du Grésillé, 49000 Angers",
             },
             data_controller="address-autocomplete",
             is_ban_address=True,
             max_options_displayed=5,
         ),
-        label="",
+        label="Autour de l'adresse suivante",
         required=False,
     )
     latitude = forms.FloatField(
@@ -88,25 +88,8 @@ class GetReemploiSolutionForm(forms.Form):
                 "data-action": "click -> choose-action#changeDirection",
             },
             fieldset_attrs={
-                "class": "fr-fieldset fr-mb-0",
+                "class": "fr-fieldset fr-mb-1w",
                 "data-choose-action-target": "direction",
-            },
-        ),
-        queryset=ActionDirection.objects.all().order_by("order"),
-        to_field_name="nom",
-        label="",
-        required=False,
-    )
-
-    overwritten_direction = forms.ModelChoiceField(
-        widget=InlineRadioSelect(
-            attrs={
-                "class": "fr-radio",
-                "data-action": "click->choose-action#displayActionList",
-            },
-            fieldset_attrs={
-                "class": "fr-fieldset",
-                "data-choose-action-target": "overwrittenDirection",
             },
         ),
         queryset=ActionDirection.objects.all().order_by("order"),

--- a/qfdmo/views.py
+++ b/qfdmo/views.py
@@ -26,9 +26,6 @@ class ReemploiSolutionView(FormView):
         initial["direction"] = self.request.GET.get(
             "direction", settings.DEFAULT_ACTION_DIRECTION
         )
-        initial["overwritten_direction"] = self.request.GET.get(
-            "direction", settings.DEFAULT_ACTION_DIRECTION
-        )
         initial["action_list"] = self.request.GET.get("action_list")
         initial["latitude"] = self.request.GET.get("latitude")
         initial["longitude"] = self.request.GET.get("longitude")

--- a/static/to_compile/entrypoints/qfdmo.css
+++ b/static/to_compile/entrypoints/qfdmo.css
@@ -29,7 +29,6 @@ Style the autocomplete container:
     border: 1px solid #d4d4d4;
     border-bottom: none;
     border-top: none;
-    z-index: 99;
     /*position the autocomplete items to be the same width as the container:*/
     top: 100%;
     left: 0;

--- a/static/to_compile/entrypoints/qfdmo.css
+++ b/static/to_compile/entrypoints/qfdmo.css
@@ -7,10 +7,6 @@
 @tailwind components;
 @tailwind utilities;
 
-#map {
-    height: 500px;
-}
-
 .leaflet-control-zoom a {
     background-image: none;
 }

--- a/static/to_compile/src/address_autocomplete_controller.ts
+++ b/static/to_compile/src/address_autocomplete_controller.ts
@@ -23,7 +23,6 @@ export default class extends AutocompleteController {
 
         if (!val) {
             this.closeAllLists()
-            return false
         }
 
         let countResult = 0
@@ -50,23 +49,62 @@ export default class extends AutocompleteController {
             .getElementsByTagName("input")[0]
             .value.split(SEPARATOR)
         this.inputTarget.value = label
-        if (longitude) this.longitudeTarget.value = longitude
-        if (latitude) this.latitudeTarget.value = latitude
+        if (longitude == "9999" && latitude == "9999") {
+            if ("geolocation" in navigator) {
+                navigator.geolocation.getCurrentPosition(
+                    (position) => {
+                        fetch(
+                            `https://api-adresse.data.gouv.fr/reverse/?lon=${position.coords.longitude}&lat=${position.coords.latitude}`,
+                        )
+                            .then((response) => response.json())
+                            .then((data) => {
+                                this.inputTarget.value =
+                                    data.features[0].properties.label
+                                this.latitudeTarget.value =
+                                    data.features[0].geometry.coordinates[1]
+                                this.longitudeTarget.value =
+                                    data.features[0].geometry.coordinates[0]
+                                /* FIXME : Check if we can partially refresh the page using Turbo */
+                                this.inputTarget.form.submit()
+                            })
+                            .catch((error) => {
+                                console.error("error catched : ", error)
+                            })
+                    },
+                    () => this.geolocatisationRefused(),
+                )
+            } else {
+                console.error("geolocation is not available")
+            }
+        } else {
+            if (longitude) this.longitudeTarget.value = longitude
+            if (latitude) this.latitudeTarget.value = latitude
+        }
         this.closeAllLists()
     }
 
+    geolocatisationRefused() {
+        console.error("geolocation is refused")
+        this.inputTarget.value = ""
+        this.longitudeTarget.value = ""
+        this.latitudeTarget.value = ""
+    }
+
     async #searchAddressCallback(value: string): Promise<string[]> {
-        if (value.trim().length < 3) return []
+        if (value.trim().length < 3)
+            return [["Autour de moi", 9999, 9999].join(SEPARATOR)]
         return await fetch(`https://api-adresse.data.gouv.fr/search/?q=${value}`)
             .then((response) => response.json())
             .then((data) => {
-                let labels = data.features.map((feature: any) => {
-                    return [
-                        feature.properties.label,
-                        feature.geometry.coordinates[1],
-                        feature.geometry.coordinates[0],
-                    ].join(SEPARATOR)
-                })
+                let labels = [["Autour de moi", 9999, 9999].join(SEPARATOR)].concat(
+                    data.features.map((feature: any) => {
+                        return [
+                            feature.properties.label,
+                            feature.geometry.coordinates[1],
+                            feature.geometry.coordinates[0],
+                        ].join(SEPARATOR)
+                    }),
+                )
                 return labels
             })
             .catch((error) => {

--- a/static/to_compile/src/address_autocomplete_controller.ts
+++ b/static/to_compile/src/address_autocomplete_controller.ts
@@ -1,5 +1,6 @@
 import AutocompleteController from "../src/autocomplete_controller"
 
+const SEPARATOR = "||"
 export default class extends AutocompleteController {
     controllerName: string = "address-autocomplete"
 
@@ -12,26 +13,6 @@ export default class extends AutocompleteController {
             this.allAvailableOptions = JSON.parse(
                 this.allAvailableOptionsTarget.textContent,
             )
-        }
-
-        if ("geolocation" in navigator && this.inputTarget.value == "") {
-            if (this.inputTarget.value == "") {
-                navigator.geolocation.getCurrentPosition((position) => {
-                    fetch(
-                        `https://api-adresse.data.gouv.fr/reverse/?lon=${position.coords.longitude}&lat=${position.coords.latitude}`,
-                    )
-                        .then((response) => response.json())
-                        .then((data) => {
-                            this.inputTarget.value = data.features[0].properties.label
-                            this.latitudeTarget.value =
-                                data.features[0].geometry.coordinates[1]
-                            this.longitudeTarget.value =
-                                data.features[0].geometry.coordinates[0]
-                            /* FIXME : Check if we can partially refresh the page using Turbo */
-                            this.inputTarget.form.submit()
-                        })
-                })
-            }
         }
     }
 
@@ -67,11 +48,10 @@ export default class extends AutocompleteController {
         let target = event.target as HTMLElement
         const [label, latitude, longitude] = target
             .getElementsByTagName("input")[0]
-            .value.split("||")
+            .value.split(SEPARATOR)
         this.inputTarget.value = label
         if (longitude) this.longitudeTarget.value = longitude
         if (latitude) this.latitudeTarget.value = latitude
-        this.inputTarget.form.submit()
         this.closeAllLists()
     }
 
@@ -85,7 +65,7 @@ export default class extends AutocompleteController {
                         feature.properties.label,
                         feature.geometry.coordinates[1],
                         feature.geometry.coordinates[0],
-                    ].join("||")
+                    ].join(SEPARATOR)
                 })
                 return labels
             })

--- a/static/to_compile/src/autocomplete_controller.ts
+++ b/static/to_compile/src/autocomplete_controller.ts
@@ -57,7 +57,6 @@ export default class extends Controller<HTMLElement> {
         let target = event.target as HTMLElement
         const label = target.getElementsByTagName("input")[0].value
         this.inputTarget.value = label
-        this.inputTarget.form.submit()
         this.closeAllLists()
     }
 

--- a/static/to_compile/src/choose_action_controller.ts
+++ b/static/to_compile/src/choose_action_controller.ts
@@ -1,17 +1,10 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller<HTMLElement> {
-    static targets = [
-        "jai",
-        "jecherche",
-        "overwrittenDirection",
-        "direction",
-        "apply",
-        "actionList",
-    ]
+    #selectedOption: string = "jecherche"
+    static targets = ["jai", "jecherche", "direction", "apply", "actionList"]
     declare readonly jaiTarget: HTMLElement
     declare readonly jechercheTarget: HTMLElement
-    declare readonly overwrittenDirectionTarget: HTMLElement
     declare readonly directionTarget: HTMLElement
     declare readonly applyTarget: HTMLElement
     declare readonly actionListTarget: HTMLInputElement
@@ -21,14 +14,16 @@ export default class extends Controller<HTMLElement> {
     }
 
     displayActionList() {
-        const overwrittenDirection = this.overwrittenDirectionTarget
-        const options = overwrittenDirection.getElementsByTagName("input")
+        const direction = this.directionTarget
+        const options = direction.getElementsByTagName("input")
         for (let i = 0; i < options.length; i++) {
             if (options[i].checked && options[i].value == "jai") {
+                this.#selectedOption = "jai"
                 this.jechercheTarget.hidden = true
                 this.jaiTarget.hidden = false
             }
             if (options[i].checked && options[i].value == "jecherche") {
+                this.#selectedOption = "jecherche"
                 this.jechercheTarget.hidden = false
                 this.jaiTarget.hidden = true
             }
@@ -36,30 +31,22 @@ export default class extends Controller<HTMLElement> {
     }
 
     apply() {
-        const overwrittenDirection = this.overwrittenDirectionTarget
-        const overwrittenOptions = overwrittenDirection.getElementsByTagName("input")
-        let checkedValue = "jai"
-        for (let i = 0; i < overwrittenOptions.length; i++) {
-            if (overwrittenOptions[i].checked)
-                checkedValue = overwrittenOptions[i].value
-        }
-
         const direction = this.directionTarget
         const options = direction.getElementsByTagName("input")
         for (let i = 0; i < options.length; i++) {
-            if (options[i].value == checkedValue) options[i].checked = true
+            if (options[i].value == this.#selectedOption) options[i].checked = true
             else options[i].checked = false
         }
 
         let actionList = []
-        if (checkedValue == "jai") {
+        if (this.#selectedOption == "jai") {
             const actionButtons = this.jaiTarget.getElementsByTagName("button")
             for (let i = 0; i < actionButtons.length; i++) {
                 if (actionButtons[i].getAttribute("aria-pressed") == "true")
                     actionList.push(actionButtons[i].getAttribute("name"))
             }
         }
-        if (checkedValue == "jecherche") {
+        if (this.#selectedOption == "jecherche") {
             const actionButtons = this.jechercheTarget.getElementsByTagName("button")
             for (let i = 0; i < actionButtons.length; i++) {
                 if (actionButtons[i].getAttribute("aria-pressed") == "true")
@@ -67,12 +54,11 @@ export default class extends Controller<HTMLElement> {
             }
         }
         this.actionListTarget.value = actionList.join("|")
-
-        overwrittenOptions[0].form.submit()
     }
 
     changeDirection() {
         this.actionListTarget.value = ""
-        this.actionListTarget.form.submit()
+        this.displayActionList()
+        this.apply()
     }
 }

--- a/static/to_compile/src/types.ts
+++ b/static/to_compile/src/types.ts
@@ -74,7 +74,6 @@ export class Actor {
     popupContent(): string {
         let popup = document.createElement("div")
         let popupContent = ""
-        console.log(this.proposition_services)
         if (this.proposition_services !== undefined) {
             let services = Array.from(
                 new Set(

--- a/static/to_compile/tests/choose_action_controller.test.ts
+++ b/static/to_compile/tests/choose_action_controller.test.ts
@@ -13,10 +13,6 @@ describe("ChooseActionController", () => {
                     <input type="radio" name="direction" value="jai" data-action="click->choose-action#changeDirection" id="id_direction_0" checked="">
                     <input type="radio" name="direction" value="jecherche" data-action="click->choose-action#changeDirection" id="id_direction_1">
                 </fieldset>
-                <fieldset data-choose-action-target="overwrittenDirection">
-                    <input type="radio" name="direction" value="jai" data-action="click->choose-action#changeDirection" id="id_direction_2" checked="">
-                    <input type="radio" name="direction" value="jecherche" data-action="click->choose-action#changeDirection" id="id_direction_3">
-                </fieldset>
                 <div data-choose-action-target="jai"></div>
                 <div data-choose-action-target="jecherche"></div>
                 <div data-choose-action-target="apply"></div>

--- a/templates/django/forms/widgets/autocomplete.html
+++ b/templates/django/forms/widgets/autocomplete.html
@@ -1,7 +1,6 @@
 {% load custom_filters %}
 <p
-    class="autocomplete"
-    data-controller="{{ widget.data_controller }}"
+    class="autocomplete fr-mb-1w"
     data-{{ widget.data_controller }}-max-option-displayed-value={{ widget.max_options_displayed }}
     data-{{ widget.data_controller }}-is-ban-address-value={{ widget.is_ban_address|default_if_none:"" }}
 >
@@ -23,4 +22,9 @@
     <script type="application/json" data-{{ widget.data_controller }}-target="allAvailableOptions">
         {{ widget.optgroups|options_in_json }}
     </script>
-</ps>
+    {% if widget.data_controller == 'address-autocomplete'%}
+        {{ form.longitude }}
+        {{ form.latitude }}
+    {% endif %}
+
+</p>

--- a/templates/django/forms/widgets/autocomplete.html
+++ b/templates/django/forms/widgets/autocomplete.html
@@ -1,12 +1,11 @@
 {% load custom_filters %}
 <p
     class="autocomplete fr-mb-1w"
-    data-{{ widget.data_controller }}-max-option-displayed-value={{ widget.max_options_displayed }}
-    data-{{ widget.data_controller }}-is-ban-address-value={{ widget.is_ban_address|default_if_none:"" }}
 >
     <input
         data-action="
         input->{{ widget.data_controller }}#complete
+    focus->{{ widget.data_controller }}#complete
     keydown.down->{{ widget.data_controller }}#keydownDown
     keydown.up->{{ widget.data_controller }}#keydownUp
     keydown.enter->{{ widget.data_controller }}#keydownEnter
@@ -22,9 +21,5 @@
     <script type="application/json" data-{{ widget.data_controller }}-target="allAvailableOptions">
         {{ widget.optgroups|options_in_json }}
     </script>
-    {% if widget.data_controller == 'address-autocomplete'%}
-        {{ form.longitude }}
-        {{ form.latitude }}
-    {% endif %}
 
 </p>


### PR DESCRIPTION
- [x]  “Je recherche” avant “j’ai” et coché par défaut
- [x]  Ordonnancer les champs cf maquette Laura
- [x]  Sortir les gestes et tous les afficher (sur 2 lignes si pas assez de place)
- [x]  Mettre un exemple dans le placeholder adresse (20 Av. du Grésillé, 49000 Angers)
- [x]  Libellés :
    - “Indiquer une catégorie d’objet”
    - “Autour de l’adresse”
- [x]  Le choix du radio button par défaut reste configurable en paramètres de l’iFrame
- [x] affichage du contenu sur la taille complete de l'écran en mode mobile
- [x] affichage du footer en bas et du header en haut, la carte prend le reste de place mais fait toujours au moins 50 % de la taille de l'écran
- [x] focus sur le contenu (pas header et footer) quand on fait une recherche
- [x] overlay opaque quand pas d'adresse saisie
- [x] bouton localisez-moi