### PR TITLE
Limit export nb of rows without raise

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -257,3 +257,7 @@ MAX_SOLUTION_DISPLAYED_ON_MAP = decouple.config(
     "MAX_SOLUTION_DISPLAYED_ON_MAP", cast=int, default=10
 )
 DISTANCE_MAX = decouple.config("DISTANCE_MAX", cast=int, default=30000)
+
+DJANGO_IMPORT_EXPORT_LIMIT = decouple.config(
+    "DJANGO_IMPORT_EXPORT_LIMIT", cast=int, default=1000
+)

--- a/qfdmo/admin/acteur.py
+++ b/qfdmo/admin/acteur.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.gis import admin
 from django.contrib.gis.geos import Point
 from django.http import HttpRequest
@@ -124,9 +125,14 @@ class ActeurResource(resources.ModelResource):
         else:
             row["location"] = None
 
-    def before_export(self, queryset, *args, **kwargs):
-        if queryset.count() > 1000:
-            raise Exception("Export is limited to 1000 rows")
+    def export(self, *args, queryset=None, **kwargs):
+        if queryset is not None:
+            queryset = queryset[: settings.DJANGO_IMPORT_EXPORT_LIMIT]
+        return super().export(*args, queryset=queryset, **kwargs)
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        return queryset[: settings.DJANGO_IMPORT_EXPORT_LIMIT]
 
     class Meta:
         model = Acteur


### PR DESCRIPTION
to do :
- [ ] don't limit the number of export lines when the export is executed from a django command