### PR TITLE
rollback pip-compile engine because it is automatically detect

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip-compile"
+  - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
no need pip-compile enngine declaration