### PR TITLE
[Accessibilité] Label du bouton rechercer plus explicite quand c'est possible

### DIFF
--- a/jinja2/qfdmo/partials/search_solution.html
+++ b/jinja2/qfdmo/partials/search_solution.html
@@ -86,7 +86,7 @@
                         data-action="click -> search-solution-form#loadingSolutions"
                         data-search-solution-form-target="submitButton"
                         >
-                        Rechercher
+                        Rechercher<span class="qfdmo-hidden md:qfdmo-block">&nbsp;les solutions</span>
                     </button>
                     <div
                         name='digital'


### PR DESCRIPTION
cf. audit RGAA

> [Formulaire Maps - Bouton "Rechercher"]
L'intitulé du bouton n'est pas pertinent.
Le balise button ne dépend pas du contexte. Il doit être explicite à lui seul.
