### PR TITLE
Make the first direction displayed overridable using a parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Longue vie aux objets propose des solutions pour promouvoir les gestes de consommation responsable:
 
--   Mise à disposition d'une cartographie d'Acteurs du ré-emploi et de la réparation en France (disponible aussi via une iframe)
--   Promotion des gestes de consommation responsable tels que le don, le partage local et la réparation
+- Mise à disposition d'une cartographie d'Acteurs du ré-emploi et de la réparation en France (disponible aussi via une iframe)
+- Promotion des gestes de consommation responsable tels que le don, le partage local et la réparation
 
 ## Afficher l'application dans une Iframe
 
@@ -19,14 +19,15 @@ Dans le cas de l'iframe, l'entête et le pied de page ne sont pas affichés
 
 Les autres paramètres disponibles pour afficher la page principale de l'application et permettant d'interagir avec les champs de recherche sont :
 
--   `sous_categorie_objet`, parmi les sous-catégories disponibles en base de données
--   `adresse`, par exemple : 145+Avenue+Pierre+Brossolette+92120+Montrouge
--   `latitude` et `longitude` récupéré dpuis l'API BAN avec l'adresse ci-dessus
--   `direction`, option `jai` ou `jecherche`, par défaut la direction `jecherche` est appliquée
--   `action_list`, liste des actions possibles selon la direction séparées par le caractère `|` :
-    -   pour la direction `jecherche` les actions possibles sont : `emprunter`, `echanger`, `louer`, `acheter`
-    -   pour la direction `jai` les actions possibles sont : `reparer`, `preter`, `donner`, `echanger`, `mettreenlocation`, `revendre`
-    -   si le paramètre `action_list` n'est pas renseigné ou est vide, toutes les actions éligibles à la direction sont affichées
+- `sous_categorie_objet`, parmi les sous-catégories disponibles en base de données
+- `adresse`, par exemple : 145+Avenue+Pierre+Brossolette+92120+Montrouge
+- `latitude` et `longitude` récupéré dpuis l'API BAN avec l'adresse ci-dessus
+- `direction`, option `jai` ou `jecherche`, par défaut l'option de direction « Je cherche » est active
+- `first_dir`, option `jai` ou `jecherche`, par défaut l'option de direction « Je cherche » est affiché en premier dans la liste des options de direction
+- `action_list`, liste des actions possibles selon la direction séparées par le caractère `|` :
+  - pour la direction `jecherche` les actions possibles sont : `emprunter`, `echanger`, `louer`, `acheter`
+  - pour la direction `jai` les actions possibles sont : `reparer`, `preter`, `donner`, `echanger`, `mettreenlocation`, `revendre`
+  - si le paramètre `action_list` n'est pas renseigné ou est vide, toutes les actions éligibles à la direction sont affichées
 
 Exemple:
 
@@ -143,10 +144,10 @@ Certains objets de la base de données sont des objets d'administration qui n'on
 
 ### Prérequis
 
--   docker-compose
--   python 3.11
--   node 18.17
--   gdal (librairie nécessaire à l'utilisation de GeoDjango)
+- docker-compose
+- python 3.11
+- node 18.17
+- gdal (librairie nécessaire à l'utilisation de GeoDjango)
 
 Conseil: utiliser `asdf` pour la gestion des environnement virtuel `node` et `python`
 
@@ -156,21 +157,21 @@ Conseil: utiliser `asdf` pour la gestion des environnement virtuel `node` et `py
 
 ### Technologies
 
--   Python
--   Django
--   github
--   Licence MIT
--   Node
--   Parcel
--   DSFR
--   honcho
--   Scalingo
--   Sentry
--   Pytest
--   Whitnoise
--   Tailwind
--   Dependabot
--   Django-debug-toolbar
+- Python
+- Django
+- github
+- Licence MIT
+- Node
+- Parcel
+- DSFR
+- honcho
+- Scalingo
+- Sentry
+- Pytest
+- Whitnoise
+- Tailwind
+- Dependabot
+- Django-debug-toolbar
 
 ### installation & exécution
 

--- a/integration_tests/qfdmo/test_reemploi_solution.py
+++ b/integration_tests/qfdmo/test_reemploi_solution.py
@@ -31,7 +31,7 @@ class TestReemploiSolutionView:
         assert response.context_data["acteurs"].count() == 0
         assert response.context_data["form"].initial == {
             "sous_categorie_objet": None,
-            "ss_cat": None,
+            "sc_id": None,
             "adresse": None,
             "direction": settings.DEFAULT_ACTION_DIRECTION,
             "action_list": None,

--- a/integration_tests/qfdmo/test_search_form.py
+++ b/integration_tests/qfdmo/test_search_form.py
@@ -1,0 +1,54 @@
+import pytest
+from django.core.management import call_command
+
+from qfdmo.models import CachedDirectionAction
+
+
+@pytest.fixture(scope="session")
+def populate_admin_object(django_db_blocker):
+    with django_db_blocker.unblock():
+        call_command(
+            "loaddata",
+            "categories",
+            "action_directions",
+            "actions",
+            "acteur_services",
+            "acteur_types",
+        )
+        CachedDirectionAction.reload_cache()
+
+
+@pytest.mark.django_db
+class TestDirectionOrder:
+    def test_default_direction(self, client):
+        url = ""
+
+        response = client.get(url)
+        assert response.status_code == 200
+        assert 'value="jai"' in str(response.content)
+        assert 'value="jecherche"' in str(response.content)
+        assert str(response.content).index('value="jai"') < str(response.content).index(
+            'value="jecherche"'
+        )
+
+    def test_jai_first_direction(self, client):
+        url = "?first_dir=jai"
+
+        response = client.get(url)
+        assert response.status_code == 200
+        assert 'value="jai"' in str(response.content)
+        assert 'value="jecherche"' in str(response.content)
+        assert str(response.content).index('value="jai"') < str(response.content).index(
+            'value="jecherche"'
+        )
+
+    def test_jecherche_first_direction(self, client):
+        url = "?first_dir=jecherche"
+
+        response = client.get(url)
+        assert response.status_code == 200
+        assert 'value="jai"' in str(response.content)
+        assert 'value="jecherche"' in str(response.content)
+        assert str(response.content).index('value="jai"') > str(response.content).index(
+            'value="jecherche"'
+        )

--- a/jinja2/qfdmo/partials/display_solutions.html
+++ b/jinja2/qfdmo/partials/display_solutions.html
@@ -22,6 +22,7 @@
                     data-map-target="map"
                 >
                     <button
+                        name="search_in_zone"
                         data-map-target="searchInZone"
                         data-turbo-frame="solutionFrame"
                         data-action="click -> search-solution-form#loadingSolutions"

--- a/jinja2/qfdmo/partials/featureflip_inputs.html
+++ b/jinja2/qfdmo/partials/featureflip_inputs.html
@@ -1,4 +1,7 @@
 {% if is_iframe(request) %}
-    <input type="hidden" name="iframe" id="iframe">
+    <input type="hidden" name="iframe">
 {% endif %}
-<input type="hidden" name="r" id="r" value="{{ range(100) | random }}">
+<input type="hidden" name="r" value="{{ range(1000) | random }}">
+{% if request.GET.get("fd") %}
+    <input type="hidden" name="fd" value="{{ request.GET.get("fd") }}">
+{% endif %}

--- a/jinja2/qfdmo/partials/featureflip_inputs.html
+++ b/jinja2/qfdmo/partials/featureflip_inputs.html
@@ -2,6 +2,6 @@
     <input type="hidden" name="iframe">
 {% endif %}
 <input type="hidden" name="r" value="{{ range(1000) | random }}">
-{% if request.GET.get("fd") %}
-    <input type="hidden" name="fd" value="{{ request.GET.get("fd") }}">
+{% if request.GET.get("first_dir") %}
+    <input type="hidden" name="first_dir" value="{{ request.GET.get("first_dir") }}">
 {% endif %}

--- a/jinja2/qfdmo/partials/search_solution.html
+++ b/jinja2/qfdmo/partials/search_solution.html
@@ -52,7 +52,7 @@
                         {{ form.sous_categorie_objet }}
                         <span data-ss-cat-object-autocomplete-target="spinner" class="fr-icon-refresh-line qfdmo-absolute qfdmo-right-0 qfdmo-top-0 qfdmo-m-1w qfdmo-animate-spin qfdmo-hidden"></span>
                     </div>
-                    {{ form.ss_cat }}
+                    {{ form.sc_id }}
                 </div>
             </div>
             <div data-controller='address-autocomplete'

--- a/qfdmo/forms.py
+++ b/qfdmo/forms.py
@@ -97,10 +97,12 @@ class GetReemploiSolutionForm(forms.Form):
         required=False,
     )
 
-    def load_choices(self):
+    def load_choices(self, first_direction=None):
         self.fields["direction"].choices = [
             [direction["nom"], direction["nom_affiche"]]
-            for direction in CachedDirectionAction.get_directions()
+            for direction in CachedDirectionAction.get_directions(
+                first_direction=first_direction
+            )
         ]
 
     label_reparacteur = forms.BooleanField(

--- a/qfdmo/forms.py
+++ b/qfdmo/forms.py
@@ -49,7 +49,7 @@ class GetReemploiSolutionForm(forms.Form):
         empty_label="",
         required=False,
     )
-    ss_cat = forms.IntegerField(
+    sc_id = forms.IntegerField(
         widget=forms.HiddenInput(
             attrs={"data-ss-cat-object-autocomplete-target": "ssCat"}
         ),

--- a/qfdmo/models/action.py
+++ b/qfdmo/models/action.py
@@ -39,12 +39,17 @@ class CachedDirectionAction:
         return cls._cached_actions_by_direction
 
     @classmethod
-    def get_directions(cls) -> List[dict]:
+    def get_directions(cls, first_direction=None) -> List[dict]:
         if cls._cached_direction is None:
             directions = ActionDirection.objects.all()
             directions_list = [model_to_dict(d) for d in directions]
             sorted_directions = sorted(directions_list, key=lambda x: x["order"])
             cls._cached_direction = sorted_directions
+        if first_direction is not None:
+            return sorted(
+                cls._cached_direction,
+                key=lambda x: (x["nom"] != first_direction, x["nom"]),
+            )
         return cls._cached_direction
 
     @classmethod

--- a/qfdmo/views/display_solutions.py
+++ b/qfdmo/views/display_solutions.py
@@ -37,10 +37,9 @@ class ReemploiSolutionView(FormView):
     template_name = "qfdmo/reemploi_solution.html"
 
     def _get_search_in_zone_params(self):
-        search_in_zone = self.request.GET.get("search_in_zone", None)
         center = []
         my_bbox_polygon = []
-        if search_in_zone:
+        if search_in_zone := self.request.GET.get("search_in_zone"):
             search_in_zone = json.loads(search_in_zone)
             if (
                 "center" in search_in_zone
@@ -79,8 +78,8 @@ class ReemploiSolutionView(FormView):
         initial["latitude"] = self.request.GET.get("latitude")
         initial["longitude"] = self.request.GET.get("longitude")
         initial["label_reparacteur"] = self.request.GET.get("label_reparacteur")
-        initial["ss_cat"] = (
-            self.request.GET.get("ss_cat") if initial["sous_categorie_objet"] else None
+        initial["sc_id"] = (
+            self.request.GET.get("sc_id") if initial["sous_categorie_objet"] else None
         )
 
         return initial
@@ -89,7 +88,7 @@ class ReemploiSolutionView(FormView):
         my_form = super().get_form(form_class)
         # Here we need to load choices after initialisation because of async management
         # in prod + cache
-        my_form.load_choices(first_direction=self.request.GET.get("fd", None))
+        my_form.load_choices(first_direction=self.request.GET.get("first_dir"))
         return my_form
 
     def get_context_data(self, **kwargs):
@@ -99,9 +98,9 @@ class ReemploiSolutionView(FormView):
         sous_categorie_id = None
         if (
             self.request.GET.get("sous_categorie_objet")
-            and self.request.GET.get("ss_cat", "").isnumeric()
+            and self.request.GET.get("sc_id", "").isnumeric()
         ):
-            sous_categorie_id = int(self.request.GET.get("ss_cat", "0"))
+            sous_categorie_id = int(self.request.GET.get("sc_id", "0"))
 
         action_selection_ids = [a["id"] for a in get_action_list(self.request)]
 

--- a/qfdmo/views/display_solutions.py
+++ b/qfdmo/views/display_solutions.py
@@ -89,7 +89,7 @@ class ReemploiSolutionView(FormView):
         my_form = super().get_form(form_class)
         # Here we need to load choices after initialisation because of async management
         # in prod + cache
-        my_form.load_choices()
+        my_form.load_choices(first_direction=self.request.GET.get("fd", None))
         return my_form
 
     def get_context_data(self, **kwargs):

--- a/static/to_compile/src/map_controller.ts
+++ b/static/to_compile/src/map_controller.ts
@@ -40,7 +40,6 @@ export default class extends Controller<HTMLElement> {
     }
 
     mapChanged(event: CustomEvent) {
-        this.searchInZoneTarget.name = "search_in_zone"
         this.searchInZoneTarget.value = JSON.stringify(event.detail)
         this.displaySearchInZoneButton()
     }

--- a/unit_tests/qfdmo/acteur_factory.py
+++ b/unit_tests/qfdmo/acteur_factory.py
@@ -4,9 +4,7 @@ from factory.django import DjangoModelFactory as Factory
 
 from qfdmo.models import Acteur, ActeurType, Source
 from qfdmo.models.acteur import ActeurService, PropositionService
-from qfdmo.models.action import Action
-
-# from factory import Factory as Factory
+from unit_tests.qfdmo.action_factory import ActionFactory
 
 
 class SourceFactory(Factory):
@@ -34,13 +32,6 @@ class ActeurServiceFactory(Factory):
         model = ActeurService
 
     nom = "service"
-
-
-class ActionFactory(Factory):
-    class Meta:
-        model = Action
-
-    nom = "action"
 
 
 class PropositionServiceFactory(Factory):

--- a/unit_tests/qfdmo/action_factory.py
+++ b/unit_tests/qfdmo/action_factory.py
@@ -1,0 +1,24 @@
+from factory import Sequence
+from factory.django import DjangoModelFactory as Factory
+
+from qfdmo.models.action import Action, ActionDirection
+
+
+class ActionDirectionFactory(Factory):
+    class Meta:
+        model = ActionDirection
+        django_get_or_create = ("nom",)
+
+    nom = Sequence(lambda n: "jai" if n % 2 == 0 else "jecherche")
+    nom_affiche = Sequence(lambda n: "J'ai" if n % 2 == 0 else "Je cherche")
+    order = Sequence(lambda n: n + 1)
+
+
+class ActionFactory(Factory):
+    class Meta:
+        model = Action
+        django_get_or_create = ("nom",)
+
+    nom = "action"
+    nom_affiche = "Action"
+    order = Sequence(lambda n: n + 1)

--- a/unit_tests/qfdmo/test_acteur.py
+++ b/unit_tests/qfdmo/test_acteur.py
@@ -19,9 +19,9 @@ from qfdmo.models import (
 from unit_tests.qfdmo.acteur_factory import (
     ActeurFactory,
     ActeurServiceFactory,
-    ActionFactory,
     PropositionServiceFactory,
 )
+from unit_tests.qfdmo.action_factory import ActionFactory
 
 
 @pytest.fixture(scope="session")

--- a/unit_tests/qfdmo/test_action.py
+++ b/unit_tests/qfdmo/test_action.py
@@ -1,6 +1,8 @@
 import pytest
 
 from qfdmo.models import Action, NomAsNaturalKeyModel
+from qfdmo.models.action import ActionDirection, CachedDirectionAction
+from unit_tests.qfdmo.action_factory import ActionDirectionFactory
 
 
 class TestActionNomAsNaturalKeyHeritage:
@@ -25,3 +27,31 @@ class TestActionNomAsNaturalKeyHeritage:
             "couleur": "yellow-tournesol",
             "icon": None,
         }
+
+
+class TestCachedDirectionActionGetDirections:
+    @pytest.fixture
+    def action_directions(self):
+        ActionDirection.objects.all().delete()
+        ActionDirectionFactory(nom="first", nom_affiche="First")
+        ActionDirectionFactory(nom="second", nom_affiche="Second")
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        "first_direction,expected",
+        [
+            ("first", [{"nom": "first", "order": 1}, {"nom": "second", "order": 2}]),
+            (
+                "second",
+                [{"nom": "second", "order": 2}, {"nom": "first", "order": 1}],
+            ),
+            (None, [{"nom": "first", "order": 1}, {"nom": "second", "order": 2}]),
+        ],
+    )
+    def test_get_directions(self, first_direction, expected, action_directions):
+        assert [
+            {k: v for k, v in direction.items() if k in ["order", "nom"]}
+            for direction in CachedDirectionAction.get_directions(
+                first_direction=first_direction
+            )
+        ] == expected


### PR DESCRIPTION
 add first_dir (aka first_direction) parameter in url to display the mentioned direction first in the option list.

Available options:

* jai
* jecherche

url : http://localhost:8000/?first_dir=jecherche

![CleanShot 2024-01-16 at 18 27 13@2x](https://github.com/incubateur-ademe/quefairedemesobjets/assets/454431/a238433c-2d2c-4e3e-846c-c6dbaa79b56f)


url : http://localhost:8000/?fd=jai

![CleanShot 2024-01-16 at 18 27 39@2x](https://github.com/incubateur-ademe/quefairedemesobjets/assets/454431/088029e9-6079-41a6-b66d-6d2496463058)

Left to do:

- [ ] add a test
- [ ] update the readme with this new parameter