### PR TITLE
Update detail.html

### DIFF
--- a/jinja2/qfdmo/adresse/detail.html
+++ b/jinja2/qfdmo/adresse/detail.html
@@ -236,7 +236,7 @@
                                 <span class='fr-icon--sm fr-icon-money-euro-box-line'></span>&nbsp;Éligible au bonus réparation
                             </a>
                         </h3>
-                        <p class="fr-card__desc">Bénéficiez d'une aide pour la réparation de votre objet et faites des économies</p>
+                        <p class="fr-card__desc">Bénéficiez d'une aide pour la réparation de certains objets et faites des économies</p>
 
                     </div>
                 </div>

--- a/jinja2/qfdmo/adresse/detail.html
+++ b/jinja2/qfdmo/adresse/detail.html
@@ -236,7 +236,7 @@
                                 <span class='fr-icon--sm fr-icon-money-euro-box-line'></span>&nbsp;Éligible au bonus réparation
                             </a>
                         </h3>
-                        <p class="fr-card__desc">Bénéficiez d'une aide pour la réparation de certains objets et faites des économies</p>
+                        <p class="fr-card__desc">Découvrez les réparations pour lesquelles vous pouvez bénéficier d'une aide et faites des économies</p>
 
                     </div>
                 </div>


### PR DESCRIPTION
un acteur peut savoir réparer chaussures ET maroquinerie, mais l'aide n'est proposée que pour l'objet chaussures. À long terme, on pourrait envisager de n'afficher cette info (dans la carto) que si l'objet entré dans l'assistant est éligible au bonus, et on pourrait alors revenir au singulier ("Votre objet")