### PR TITLE
[Proposition] Refactoring of dags

### DIFF
--- a/dags/corepile.py
+++ b/dags/corepile.py
@@ -3,11 +3,10 @@ from importlib import import_module
 from pathlib import Path
 
 from airflow import DAG
-from airflow.operators.python import PythonOperator
 
 env = Path(__file__).parent.name
 utils = import_module(f"{env}.utils.utils")
-dag_eo_utils = import_module(f"{env}.utils.dag_eo_utils")
+eo_operators = import_module(f"{env}.utils.eo_operators")
 
 default_args = {
     "owner": "airflow",
@@ -18,34 +17,18 @@ default_args = {
     "retries": 1,
 }
 
-dag = DAG(
+with DAG(
     utils.get_dag_name(__file__, "corepile"),
     default_args=default_args,
     description=(
         "A pipeline to fetch, process, and load to validate data into postgresql"
         " for Corepile dataset"
     ),
-    schedule=None,
-)
-
-
-fetch_data_task = PythonOperator(
-    task_id="fetch_data_from_api",
-    python_callable=dag_eo_utils.fetch_data_from_api,
-    op_kwargs={"dataset": "donnees-eo-corepile"},
-    dag=dag,
-)
-
-load_data_task = PythonOperator(
-    task_id="load_data_from_postgresql",
-    python_callable=dag_eo_utils.load_data_from_postgresql,
-    dag=dag,
-)
-
-create_actors_task = PythonOperator(
-    task_id="create_actors",
-    python_callable=dag_eo_utils.create_actors,
-    op_kwargs={
+    params={
+        "endpoint": (
+            "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
+            "donnees-eo-corepile/lines?size=10000"
+        ),
         "column_mapping": {
             "id_point_apport_ou_reparation": "identifiant_externe",
             "type_de_point_de_collecte": "acteur_type_id",
@@ -66,46 +49,21 @@ create_actors_task = PythonOperator(
             "perimetre_dintervention": "",
             "longitudewgs84": "location",
             "latitudewgs84": "location",
-        }
+        },
     },
-    dag=dag,
-)
-
-create_proposition_services_task = PythonOperator(
-    task_id="create_proposition_services",
-    python_callable=dag_eo_utils.create_proposition_services,
-    dag=dag,
-)
-
-create_proposition_services_sous_categories_task = PythonOperator(
-    task_id="create_proposition_services_sous_categories",
-    python_callable=dag_eo_utils.create_proposition_services_sous_categories,
-    dag=dag,
-)
-
-write_data_task = PythonOperator(
-    task_id="write_data_to_validate_into_dagruns",
-    python_callable=dag_eo_utils.write_to_dagruns,
-    dag=dag,
-)
-
-serialize_to_json_task = PythonOperator(
-    task_id="serialize_actors_to_records",
-    python_callable=dag_eo_utils.serialize_to_json,
-    dag=dag,
-)
-
-create_labels_task = PythonOperator(
-    task_id="create_labels",
-    python_callable=dag_eo_utils.create_labels,
-    dag=dag,
-)
-
-(
-    [fetch_data_task, load_data_task]
-    >> create_actors_task
-    >> [create_proposition_services_task, create_labels_task]
-    >> create_proposition_services_sous_categories_task
-    >> serialize_to_json_task
-    >> write_data_task
-)
+    schedule=None,
+) as dag:
+    (
+        [
+            eo_operators.fetch_data_task(dag),
+            eo_operators.load_data_task(dag),
+        ]
+        >> eo_operators.create_actors_task(dag)
+        >> [
+            eo_operators.create_proposition_services_task(dag),
+            eo_operators.create_labels_task(dag),
+        ]
+        >> eo_operators.create_proposition_services_sous_categories_task(dag)
+        >> eo_operators.serialize_to_json_task(dag)
+        >> eo_operators.write_data_task(dag)
+    )  # type: ignore

--- a/dags/ecodds.py
+++ b/dags/ecodds.py
@@ -3,11 +3,10 @@ from importlib import import_module
 from pathlib import Path
 
 from airflow import DAG
-from airflow.operators.python import PythonOperator
 
 env = Path(__file__).parent.name
 utils = import_module(f"{env}.utils.utils")
-dag_eo_utils = import_module(f"{env}.utils.dag_eo_utils")
+eo_operators = import_module(f"{env}.utils.eo_operators")
 
 default_args = {
     "owner": "airflow",
@@ -18,34 +17,18 @@ default_args = {
     "retries": 1,
 }
 
-dag = DAG(
+with DAG(
     utils.get_dag_name(__file__, "ecodds"),
     default_args=default_args,
     description=(
         "A pipeline to fetch, process, and load to validate data into postgresql"
         " for EcoDDS dataset"
     ),
-    schedule=None,
-)
-
-
-fetch_data_task = PythonOperator(
-    task_id="fetch_data_from_api",
-    python_callable=dag_eo_utils.fetch_data_from_api,
-    op_kwargs={"dataset": "donnees-eo-ecodds"},
-    dag=dag,
-)
-
-load_data_task = PythonOperator(
-    task_id="load_data_from_postgresql",
-    python_callable=dag_eo_utils.load_data_from_postgresql,
-    dag=dag,
-)
-
-create_actors_task = PythonOperator(
-    task_id="create_actors",
-    python_callable=dag_eo_utils.create_actors,
-    op_kwargs={
+    params={
+        "endpoint": (
+            "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
+            "donnees-eo-ecodds/lines?size=10000"
+        ),
         "column_mapping": {
             "id_point_apport_ou_reparation": "identifiant_externe",
             "type_de_point_de_collecte": "acteur_type_id",
@@ -65,46 +48,21 @@ create_actors_task = PythonOperator(
             "perimetre_dintervention": "",
             "longitudewgs84": "location",
             "latitudewgs84": "location",
-        }
+        },
     },
-    dag=dag,
-)
-
-create_proposition_services_task = PythonOperator(
-    task_id="create_proposition_services",
-    python_callable=dag_eo_utils.create_proposition_services,
-    dag=dag,
-)
-
-create_proposition_services_sous_categories_task = PythonOperator(
-    task_id="create_proposition_services_sous_categories",
-    python_callable=dag_eo_utils.create_proposition_services_sous_categories,
-    dag=dag,
-)
-
-write_data_task = PythonOperator(
-    task_id="write_data_to_validate_into_dagruns",
-    python_callable=dag_eo_utils.write_to_dagruns,
-    dag=dag,
-)
-
-serialize_to_json_task = PythonOperator(
-    task_id="serialize_actors_to_records",
-    python_callable=dag_eo_utils.serialize_to_json,
-    dag=dag,
-)
-
-create_labels_task = PythonOperator(
-    task_id="create_labels",
-    python_callable=dag_eo_utils.create_labels,
-    dag=dag,
-)
-
-(
-    [fetch_data_task, load_data_task]
-    >> create_actors_task
-    >> [create_proposition_services_task, create_labels_task]
-    >> create_proposition_services_sous_categories_task
-    >> serialize_to_json_task
-    >> write_data_task
-)
+    schedule=None,
+) as dag:
+    (
+        [
+            eo_operators.fetch_data_task(dag),
+            eo_operators.load_data_task(dag),
+        ]
+        >> eo_operators.create_actors_task(dag)
+        >> [
+            eo_operators.create_proposition_services_task(dag),
+            eo_operators.create_labels_task(dag),
+        ]
+        >> eo_operators.create_proposition_services_sous_categories_task(dag)
+        >> eo_operators.serialize_to_json_task(dag)
+        >> eo_operators.write_data_task(dag)
+    )  # type: ignore

--- a/dags/ecologic.py
+++ b/dags/ecologic.py
@@ -3,11 +3,10 @@ from importlib import import_module
 from pathlib import Path
 
 from airflow import DAG
-from airflow.operators.python import PythonOperator
 
 env = Path(__file__).parent.name
 utils = import_module(f"{env}.utils.utils")
-dag_eo_utils = import_module(f"{env}.utils.dag_eo_utils")
+eo_operators = import_module(f"{env}.utils.eo_operators")
 
 default_args = {
     "owner": "airflow",
@@ -18,34 +17,18 @@ default_args = {
     "retries": 1,
 }
 
-dag = DAG(
+with DAG(
     utils.get_dag_name(__file__, "ecologic"),
     default_args=default_args,
     description=(
         "A pipeline to fetch, process, and load to validate data into postgresql"
         " for Ecologic dataset"
     ),
-    schedule=None,
-)
-
-
-fetch_data_task = PythonOperator(
-    task_id="fetch_data_from_api",
-    python_callable=dag_eo_utils.fetch_data_from_api,
-    op_kwargs={"dataset": "donnees-eo-ecologic"},
-    dag=dag,
-)
-
-load_data_task = PythonOperator(
-    task_id="load_data_from_postgresql",
-    python_callable=dag_eo_utils.load_data_from_postgresql,
-    dag=dag,
-)
-
-create_actors_task = PythonOperator(
-    task_id="create_actors",
-    python_callable=dag_eo_utils.create_actors,
-    op_kwargs={
+    params={
+        "endpoint": (
+            "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
+            "donnees-eo-ecologic/lines?size=10000"
+        ),
         "column_mapping": {
             "id_point_apport_ou_reparation": "identifiant_externe",
             "type_de_point_de_collecte": "acteur_type_id",
@@ -64,46 +47,21 @@ create_actors_task = PythonOperator(
             "perimetre_dintervention": "",
             "longitudewgs84": "location",
             "latitudewgs84": "location",
-        }
+        },
     },
-    dag=dag,
-)
-
-create_proposition_services_task = PythonOperator(
-    task_id="create_proposition_services",
-    python_callable=dag_eo_utils.create_proposition_services,
-    dag=dag,
-)
-
-create_proposition_services_sous_categories_task = PythonOperator(
-    task_id="create_proposition_services_sous_categories",
-    python_callable=dag_eo_utils.create_proposition_services_sous_categories,
-    dag=dag,
-)
-
-write_data_task = PythonOperator(
-    task_id="write_data_to_validate_into_dagruns",
-    python_callable=dag_eo_utils.write_to_dagruns,
-    dag=dag,
-)
-
-serialize_to_json_task = PythonOperator(
-    task_id="serialize_actors_to_records",
-    python_callable=dag_eo_utils.serialize_to_json,
-    dag=dag,
-)
-
-create_labels_task = PythonOperator(
-    task_id="create_labels",
-    python_callable=dag_eo_utils.create_labels,
-    dag=dag,
-)
-
-(
-    [fetch_data_task, load_data_task]
-    >> create_actors_task
-    >> [create_proposition_services_task, create_labels_task]
-    >> create_proposition_services_sous_categories_task
-    >> serialize_to_json_task
-    >> write_data_task
-)
+    schedule=None,
+) as dag:
+    (
+        [
+            eo_operators.fetch_data_task(dag),
+            eo_operators.load_data_task(dag),
+        ]
+        >> eo_operators.create_actors_task(dag)
+        >> [
+            eo_operators.create_proposition_services_task(dag),
+            eo_operators.create_labels_task(dag),
+        ]
+        >> eo_operators.create_proposition_services_sous_categories_task(dag)
+        >> eo_operators.serialize_to_json_task(dag)
+        >> eo_operators.write_data_task(dag)
+    )  # type: ignore

--- a/dags/ecosystem.py
+++ b/dags/ecosystem.py
@@ -3,11 +3,10 @@ from importlib import import_module
 from pathlib import Path
 
 from airflow import DAG
-from airflow.operators.python import PythonOperator
 
 env = Path(__file__).parent.name
 utils = import_module(f"{env}.utils.utils")
-dag_eo_utils = import_module(f"{env}.utils.dag_eo_utils")
+eo_operators = import_module(f"{env}.utils.eo_operators")
 
 default_args = {
     "owner": "airflow",
@@ -18,34 +17,18 @@ default_args = {
     "retries": 1,
 }
 
-dag = DAG(
+with DAG(
     utils.get_dag_name(__file__, "ecosystem"),
     default_args=default_args,
     description=(
         "A pipeline to fetch, process, and load to validate data into postgresql"
         " for Ecosystem dataset"
     ),
-    schedule=None,
-)
-
-
-fetch_data_task = PythonOperator(
-    task_id="fetch_data_from_api",
-    python_callable=dag_eo_utils.fetch_data_from_api,
-    op_kwargs={"dataset": "donnees-eo-ecosystem"},
-    dag=dag,
-)
-
-load_data_task = PythonOperator(
-    task_id="load_data_from_postgresql",
-    python_callable=dag_eo_utils.load_data_from_postgresql,
-    dag=dag,
-)
-
-create_actors_task = PythonOperator(
-    task_id="create_actors",
-    python_callable=dag_eo_utils.create_actors,
-    op_kwargs={
+    params={
+        "endpoint": (
+            "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
+            "donnees-eo-ecosystem/lines?size=10000"
+        ),
         "column_mapping": {
             "id_point_apport_ou_reparation": "identifiant_externe",
             "type_de_point_de_collecte": "acteur_type_id",
@@ -65,46 +48,23 @@ create_actors_task = PythonOperator(
             "longitudewgs84": "location",
             "latitudewgs84": "location",
         },
-        "column_to_drop": ["siret"],
+        "column_to_drop": [
+            "siret",
+        ],
     },
-    dag=dag,
-)
-
-create_proposition_services_task = PythonOperator(
-    task_id="create_proposition_services",
-    python_callable=dag_eo_utils.create_proposition_services,
-    dag=dag,
-)
-
-create_proposition_services_sous_categories_task = PythonOperator(
-    task_id="create_proposition_services_sous_categories",
-    python_callable=dag_eo_utils.create_proposition_services_sous_categories,
-    dag=dag,
-)
-
-write_data_task = PythonOperator(
-    task_id="write_data_to_validate_into_dagruns",
-    python_callable=dag_eo_utils.write_to_dagruns,
-    dag=dag,
-)
-
-serialize_to_json_task = PythonOperator(
-    task_id="serialize_actors_to_records",
-    python_callable=dag_eo_utils.serialize_to_json,
-    dag=dag,
-)
-
-create_labels_task = PythonOperator(
-    task_id="create_labels",
-    python_callable=dag_eo_utils.create_labels,
-    dag=dag,
-)
-
-(
-    [fetch_data_task, load_data_task]
-    >> create_actors_task
-    >> [create_proposition_services_task, create_labels_task]
-    >> create_proposition_services_sous_categories_task
-    >> serialize_to_json_task
-    >> write_data_task
-)
+    schedule=None,
+) as dag:
+    (
+        [
+            eo_operators.fetch_data_task(dag),
+            eo_operators.load_data_task(dag),
+        ]
+        >> eo_operators.create_actors_task(dag)
+        >> [
+            eo_operators.create_proposition_services_task(dag),
+            eo_operators.create_labels_task(dag),
+        ]
+        >> eo_operators.create_proposition_services_sous_categories_task(dag)
+        >> eo_operators.serialize_to_json_task(dag)
+        >> eo_operators.write_data_task(dag)
+    )  # type: ignore

--- a/dags/ocab.py
+++ b/dags/ocab.py
@@ -3,11 +3,10 @@ from importlib import import_module
 from pathlib import Path
 
 from airflow import DAG
-from airflow.operators.python import PythonOperator
 
 env = Path(__file__).parent.name
 utils = import_module(f"{env}.utils.utils")
-dag_eo_utils = import_module(f"{env}.utils.dag_eo_utils")
+eo_operators = import_module(f"{env}.utils.eo_operators")
 
 default_args = {
     "owner": "airflow",
@@ -18,34 +17,18 @@ default_args = {
     "retries": 1,
 }
 
-dag = DAG(
+with DAG(
     utils.get_dag_name(__file__, "ocab"),
     default_args=default_args,
     description=(
         "A pipeline to fetch, process, and load to validate data into postgresql"
         " for OCAB dataset"
     ),
-    schedule=None,
-)
-
-
-fetch_data_task = PythonOperator(
-    task_id="fetch_data_from_api",
-    python_callable=dag_eo_utils.fetch_data_from_api,
-    op_kwargs={"dataset": "donnees-eo-ocab"},
-    dag=dag,
-)
-
-load_data_task = PythonOperator(
-    task_id="load_data_from_postgresql",
-    python_callable=dag_eo_utils.load_data_from_postgresql,
-    dag=dag,
-)
-
-create_actors_task = PythonOperator(
-    task_id="create_actors",
-    python_callable=dag_eo_utils.create_actors,
-    op_kwargs={
+    params={
+        "endpoint": (
+            "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
+            "donnees-eo-ocab/lines?size=10000"
+        ),
         "column_mapping": {
             "id_point_apport_ou_reparation": "identifiant_externe",
             "type_de_point_de_collecte": "acteur_type_id",
@@ -65,46 +48,21 @@ create_actors_task = PythonOperator(
             "perimetre_dintervention": "",
             "longitudewgs84": "location",
             "latitudewgs84": "location",
-        }
+        },
     },
-    dag=dag,
-)
-
-create_proposition_services_task = PythonOperator(
-    task_id="create_proposition_services",
-    python_callable=dag_eo_utils.create_proposition_services,
-    dag=dag,
-)
-
-create_proposition_services_sous_categories_task = PythonOperator(
-    task_id="create_proposition_services_sous_categories",
-    python_callable=dag_eo_utils.create_proposition_services_sous_categories,
-    dag=dag,
-)
-
-write_data_task = PythonOperator(
-    task_id="write_data_to_validate_into_dagruns",
-    python_callable=dag_eo_utils.write_to_dagruns,
-    dag=dag,
-)
-
-serialize_to_json_task = PythonOperator(
-    task_id="serialize_actors_to_records",
-    python_callable=dag_eo_utils.serialize_to_json,
-    dag=dag,
-)
-
-create_labels_task = PythonOperator(
-    task_id="create_labels",
-    python_callable=dag_eo_utils.create_labels,
-    dag=dag,
-)
-
-(
-    [fetch_data_task, load_data_task]
-    >> create_actors_task
-    >> [create_proposition_services_task, create_labels_task]
-    >> create_proposition_services_sous_categories_task
-    >> serialize_to_json_task
-    >> write_data_task
-)
+    schedule=None,
+) as dag:
+    (
+        [
+            eo_operators.fetch_data_task(dag),
+            eo_operators.load_data_task(dag),
+        ]
+        >> eo_operators.create_actors_task(dag)
+        >> [
+            eo_operators.create_proposition_services_task(dag),
+            eo_operators.create_labels_task(dag),
+        ]
+        >> eo_operators.create_proposition_services_sous_categories_task(dag)
+        >> eo_operators.serialize_to_json_task(dag)
+        >> eo_operators.write_data_task(dag)
+    )  # type: ignore

--- a/dags/pyreo.py
+++ b/dags/pyreo.py
@@ -3,11 +3,10 @@ from importlib import import_module
 from pathlib import Path
 
 from airflow import DAG
-from airflow.operators.python import PythonOperator
 
 env = Path(__file__).parent.name
 utils = import_module(f"{env}.utils.utils")
-dag_eo_utils = import_module(f"{env}.utils.dag_eo_utils")
+eo_operators = import_module(f"{env}.utils.eo_operators")
 
 default_args = {
     "owner": "airflow",
@@ -18,34 +17,18 @@ default_args = {
     "retries": 1,
 }
 
-dag = DAG(
+with DAG(
     utils.get_dag_name(__file__, "pyreo"),
     default_args=default_args,
     description=(
         "A pipeline to fetch, process, and load to validate data into postgresql"
         " for Pyreo dataset"
     ),
-    schedule=None,
-)
-
-
-fetch_data_task = PythonOperator(
-    task_id="fetch_data_from_api",
-    python_callable=dag_eo_utils.fetch_data_from_api,
-    op_kwargs={"dataset": "donnees-eo-pyreo"},
-    dag=dag,
-)
-
-load_data_task = PythonOperator(
-    task_id="load_data_from_postgresql",
-    python_callable=dag_eo_utils.load_data_from_postgresql,
-    dag=dag,
-)
-
-create_actors_task = PythonOperator(
-    task_id="create_actors",
-    python_callable=dag_eo_utils.create_actors,
-    op_kwargs={
+    params={
+        "endpoint": (
+            "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
+            "donnees-eo-pyreo/lines?size=10000"
+        ),
         "column_mapping": {
             "id_point_apport_ou_reparation": "identifiant_externe",
             "type_de_point_de_collecte": "acteur_type_id",
@@ -70,44 +53,19 @@ create_actors_task = PythonOperator(
             " enseigne commerciale / distributeur / point de vente"
         },
     },
-    dag=dag,
-)
-
-create_proposition_services_task = PythonOperator(
-    task_id="create_proposition_services",
-    python_callable=dag_eo_utils.create_proposition_services,
-    dag=dag,
-)
-
-create_proposition_services_sous_categories_task = PythonOperator(
-    task_id="create_proposition_services_sous_categories",
-    python_callable=dag_eo_utils.create_proposition_services_sous_categories,
-    dag=dag,
-)
-
-write_data_task = PythonOperator(
-    task_id="write_data_to_validate_into_dagruns",
-    python_callable=dag_eo_utils.write_to_dagruns,
-    dag=dag,
-)
-
-serialize_to_json_task = PythonOperator(
-    task_id="serialize_actors_to_records",
-    python_callable=dag_eo_utils.serialize_to_json,
-    dag=dag,
-)
-
-create_labels_task = PythonOperator(
-    task_id="create_labels",
-    python_callable=dag_eo_utils.create_labels,
-    dag=dag,
-)
-
-(
-    [fetch_data_task, load_data_task]
-    >> create_actors_task
-    >> [create_proposition_services_task, create_labels_task]
-    >> create_proposition_services_sous_categories_task
-    >> serialize_to_json_task
-    >> write_data_task
-)
+    schedule=None,
+) as dag:
+    (
+        [
+            eo_operators.fetch_data_task(dag),
+            eo_operators.load_data_task(dag),
+        ]
+        >> eo_operators.create_actors_task(dag)
+        >> [
+            eo_operators.create_proposition_services_task(dag),
+            eo_operators.create_labels_task(dag),
+        ]
+        >> eo_operators.create_proposition_services_sous_categories_task(dag)
+        >> eo_operators.serialize_to_json_task(dag)
+        >> eo_operators.write_data_task(dag)
+    )  # type: ignore

--- a/dags/refashion.py
+++ b/dags/refashion.py
@@ -3,13 +3,11 @@ from importlib import import_module
 from pathlib import Path
 
 from airflow import DAG
-from airflow.operators.python import PythonOperator
 
 env = Path(__file__).parent.name
 utils = import_module(f"{env}.utils.utils")
-api_utils = import_module(f"{env}.utils.api_utils")
-mapping_utils = import_module(f"{env}.utils.mapping_utils")
-dag_eo_utils = import_module(f"{env}.utils.dag_eo_utils")
+eo_operators = import_module(f"{env}.utils.eo_operators")
+
 default_args = {
     "owner": "airflow",
     "depends_on_past": False,
@@ -19,34 +17,18 @@ default_args = {
     "retries": 1,
 }
 
-dag = DAG(
+with DAG(
     utils.get_dag_name(__file__, "refashion"),
     default_args=default_args,
     description=(
         "A pipeline to fetch, process, and load to validate data into postgresql"
         " for Refashion dataset"
     ),
-    schedule=None,
-)
-
-
-fetch_data_task = PythonOperator(
-    task_id="fetch_data_from_api",
-    python_callable=dag_eo_utils.fetch_data_from_api,
-    op_kwargs={"dataset": "donnees-eo-refashion"},
-    dag=dag,
-)
-
-load_data_task = PythonOperator(
-    task_id="load_data_from_postgresql",
-    python_callable=dag_eo_utils.load_data_from_postgresql,
-    dag=dag,
-)
-
-create_actors_task = PythonOperator(
-    task_id="create_actors",
-    python_callable=dag_eo_utils.create_actors,
-    op_kwargs={
+    params={
+        "endpoint": (
+            "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
+            "donnees-eo-refashion/lines?size=10000"
+        ),
         "column_mapping": {
             "id_point_apport_ou_reparation": "identifiant_externe",
             "adresse_complement": "adresse_complement",
@@ -73,47 +55,21 @@ create_actors_task = PythonOperator(
             "latitudewgs84": "location",
             "horaires_douverture": "horaires_description",
             "consignes_dacces": "commentaires",
-        }
+        },
     },
-    dag=dag,
-)
-
-
-create_labels_task = PythonOperator(
-    task_id="create_labels",
-    python_callable=dag_eo_utils.create_labels,
-    dag=dag,
-)
-
-create_proposition_services_task = PythonOperator(
-    task_id="create_proposition_services",
-    python_callable=dag_eo_utils.create_proposition_services,
-    dag=dag,
-)
-
-create_proposition_services_sous_categories_task = PythonOperator(
-    task_id="create_proposition_services_sous_categories",
-    python_callable=dag_eo_utils.create_proposition_services_sous_categories,
-    dag=dag,
-)
-
-write_data_task = PythonOperator(
-    task_id="write_data_to_validate_into_dagruns",
-    python_callable=dag_eo_utils.write_to_dagruns,
-    dag=dag,
-)
-
-serialize_to_json_task = PythonOperator(
-    task_id="serialize_actors_to_records",
-    python_callable=dag_eo_utils.serialize_to_json,
-    dag=dag,
-)
-
-(
-    [fetch_data_task, load_data_task]
-    >> create_actors_task
-    >> [create_proposition_services_task, create_labels_task]
-    >> create_proposition_services_sous_categories_task
-    >> serialize_to_json_task
-    >> write_data_task
-)
+    schedule=None,
+) as dag:
+    (
+        [
+            eo_operators.fetch_data_task(dag),
+            eo_operators.load_data_task(dag),
+        ]
+        >> eo_operators.create_actors_task(dag)
+        >> [
+            eo_operators.create_proposition_services_task(dag),
+            eo_operators.create_labels_task(dag),
+        ]
+        >> eo_operators.create_proposition_services_sous_categories_task(dag)
+        >> eo_operators.serialize_to_json_task(dag)
+        >> eo_operators.write_data_task(dag)
+    )  # type: ignore

--- a/dags/soren.py
+++ b/dags/soren.py
@@ -3,11 +3,10 @@ from importlib import import_module
 from pathlib import Path
 
 from airflow import DAG
-from airflow.operators.python import PythonOperator
 
 env = Path(__file__).parent.name
 utils = import_module(f"{env}.utils.utils")
-dag_eo_utils = import_module(f"{env}.utils.dag_eo_utils")
+eo_operators = import_module(f"{env}.utils.eo_operators")
 
 default_args = {
     "owner": "airflow",
@@ -18,34 +17,18 @@ default_args = {
     "retries": 1,
 }
 
-dag = DAG(
+with DAG(
     utils.get_dag_name(__file__, "soren"),
     default_args=default_args,
     description=(
         "A pipeline to fetch, process, and load to validate data into postgresql"
         " for Soren dataset"
     ),
-    schedule=None,
-)
-
-
-fetch_data_task = PythonOperator(
-    task_id="fetch_data_from_api",
-    python_callable=dag_eo_utils.fetch_data_from_api,
-    op_kwargs={"dataset": "donnees-eo-soren"},
-    dag=dag,
-)
-
-load_data_task = PythonOperator(
-    task_id="load_data_from_postgresql",
-    python_callable=dag_eo_utils.load_data_from_postgresql,
-    dag=dag,
-)
-
-create_actors_task = PythonOperator(
-    task_id="create_actors",
-    python_callable=dag_eo_utils.create_actors,
-    op_kwargs={
+    params={
+        "endpoint": (
+            "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
+            "donnees-eo-soren/lines?size=10000"
+        ),
         "column_mapping": {
             "id_point_apport_ou_reparation": "identifiant_externe",
             "type_de_point_de_collecte": "acteur_type_id",
@@ -64,46 +47,21 @@ create_actors_task = PythonOperator(
             "perimetre_dintervention": "",
             "longitudewgs84": "location",
             "latitudewgs84": "location",
-        }
+        },
     },
-    dag=dag,
-)
-
-create_proposition_services_task = PythonOperator(
-    task_id="create_proposition_services",
-    python_callable=dag_eo_utils.create_proposition_services,
-    dag=dag,
-)
-
-create_proposition_services_sous_categories_task = PythonOperator(
-    task_id="create_proposition_services_sous_categories",
-    python_callable=dag_eo_utils.create_proposition_services_sous_categories,
-    dag=dag,
-)
-
-write_data_task = PythonOperator(
-    task_id="write_data_to_validate_into_dagruns",
-    python_callable=dag_eo_utils.write_to_dagruns,
-    dag=dag,
-)
-
-serialize_to_json_task = PythonOperator(
-    task_id="serialize_actors_to_records",
-    python_callable=dag_eo_utils.serialize_to_json,
-    dag=dag,
-)
-
-create_labels_task = PythonOperator(
-    task_id="create_labels",
-    python_callable=dag_eo_utils.create_labels,
-    dag=dag,
-)
-
-(
-    [fetch_data_task, load_data_task]
-    >> create_actors_task
-    >> [create_proposition_services_task, create_labels_task]
-    >> create_proposition_services_sous_categories_task
-    >> serialize_to_json_task
-    >> write_data_task
-)
+    schedule=None,
+) as dag:
+    (
+        [
+            eo_operators.fetch_data_task(dag),
+            eo_operators.load_data_task(dag),
+        ]
+        >> eo_operators.create_actors_task(dag)
+        >> [
+            eo_operators.create_proposition_services_task(dag),
+            eo_operators.create_labels_task(dag),
+        ]
+        >> eo_operators.create_proposition_services_sous_categories_task(dag)
+        >> eo_operators.serialize_to_json_task(dag)
+        >> eo_operators.write_data_task(dag)
+    )  # type: ignore

--- a/dags/utils/eo_operators.py
+++ b/dags/utils/eo_operators.py
@@ -1,0 +1,73 @@
+from importlib import import_module
+from pathlib import Path
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+
+env = Path(__file__).parent.parent.name
+
+dag_eo_utils = import_module(f"{env}.utils.dag_eo_utils")
+
+
+def fetch_data_task(dag: DAG) -> PythonOperator:
+    return PythonOperator(
+        task_id="fetch_data_from_api",
+        python_callable=dag_eo_utils.fetch_data_from_api,
+        dag=dag,
+    )
+
+
+def load_data_task(dag: DAG) -> PythonOperator:
+    return PythonOperator(
+        task_id="load_data_from_postgresql",
+        python_callable=dag_eo_utils.load_data_from_postgresql,
+        dag=dag,
+    )
+
+
+def create_actors_task(dag: DAG) -> PythonOperator:
+    return PythonOperator(
+        task_id="create_actors",
+        python_callable=dag_eo_utils.create_actors,
+        dag=dag,
+    )
+
+
+def create_proposition_services_task(dag: DAG) -> PythonOperator:
+    return PythonOperator(
+        task_id="create_proposition_services",
+        python_callable=dag_eo_utils.create_proposition_services,
+        dag=dag,
+    )
+
+
+def create_proposition_services_sous_categories_task(dag: DAG) -> PythonOperator:
+    return PythonOperator(
+        task_id="create_proposition_services_sous_categories",
+        python_callable=dag_eo_utils.create_proposition_services_sous_categories,
+        dag=dag,
+    )
+
+
+def write_data_task(dag: DAG) -> PythonOperator:
+    return PythonOperator(
+        task_id="write_data_to_validate_into_dagruns",
+        python_callable=dag_eo_utils.write_to_dagruns,
+        dag=dag,
+    )
+
+
+def serialize_to_json_task(dag: DAG) -> PythonOperator:
+    return PythonOperator(
+        task_id="serialize_actors_to_records",
+        python_callable=dag_eo_utils.serialize_to_json,
+        dag=dag,
+    )
+
+
+def create_labels_task(dag: DAG) -> PythonOperator:
+    return PythonOperator(
+        task_id="create_labels",
+        python_callable=dag_eo_utils.create_labels,
+        dag=dag,
+    )

--- a/dags/valdelia.py
+++ b/dags/valdelia.py
@@ -3,11 +3,10 @@ from importlib import import_module
 from pathlib import Path
 
 from airflow import DAG
-from airflow.operators.python import PythonOperator
 
 env = Path(__file__).parent.name
 utils = import_module(f"{env}.utils.utils")
-dag_eo_utils = import_module(f"{env}.utils.dag_eo_utils")
+eo_operators = import_module(f"{env}.utils.eo_operators")
 
 default_args = {
     "owner": "airflow",
@@ -18,34 +17,18 @@ default_args = {
     "retries": 1,
 }
 
-dag = DAG(
+with DAG(
     utils.get_dag_name(__file__, "valdelia"),
     default_args=default_args,
     description=(
         "A pipeline to fetch, process, and load to validate data into postgresql"
         " for Valdelia dataset"
     ),
-    schedule=None,
-)
-
-
-fetch_data_task = PythonOperator(
-    task_id="fetch_data_from_api",
-    python_callable=dag_eo_utils.fetch_data_from_api,
-    op_kwargs={"dataset": "donnees-eo-valdelia"},
-    dag=dag,
-)
-
-load_data_task = PythonOperator(
-    task_id="load_data_from_postgresql",
-    python_callable=dag_eo_utils.load_data_from_postgresql,
-    dag=dag,
-)
-
-create_actors_task = PythonOperator(
-    task_id="create_actors",
-    python_callable=dag_eo_utils.create_actors,
-    op_kwargs={
+    params={
+        "endpoint": (
+            "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
+            "donnees-eo-valdelia/lines?size=10000"
+        ),
         "column_mapping": {
             "id_point_apport_ou_reparation": "identifiant_externe",
             "type_de_point_de_collecte": "acteur_type_id",
@@ -66,46 +49,21 @@ create_actors_task = PythonOperator(
             "perimetre_dintervention": "",
             "longitudewgs84": "location",
             "latitudewgs84": "location",
-        }
+        },
     },
-    dag=dag,
-)
-
-create_proposition_services_task = PythonOperator(
-    task_id="create_proposition_services",
-    python_callable=dag_eo_utils.create_proposition_services,
-    dag=dag,
-)
-
-create_proposition_services_sous_categories_task = PythonOperator(
-    task_id="create_proposition_services_sous_categories",
-    python_callable=dag_eo_utils.create_proposition_services_sous_categories,
-    dag=dag,
-)
-
-write_data_task = PythonOperator(
-    task_id="write_data_to_validate_into_dagruns",
-    python_callable=dag_eo_utils.write_to_dagruns,
-    dag=dag,
-)
-
-serialize_to_json_task = PythonOperator(
-    task_id="serialize_actors_to_records",
-    python_callable=dag_eo_utils.serialize_to_json,
-    dag=dag,
-)
-
-create_labels_task = PythonOperator(
-    task_id="create_labels",
-    python_callable=dag_eo_utils.create_labels,
-    dag=dag,
-)
-
-(
-    [fetch_data_task, load_data_task]
-    >> create_actors_task
-    >> [create_proposition_services_task, create_labels_task]
-    >> create_proposition_services_sous_categories_task
-    >> serialize_to_json_task
-    >> write_data_task
-)
+    schedule=None,
+) as dag:
+    (
+        [
+            eo_operators.fetch_data_task(dag),
+            eo_operators.load_data_task(dag),
+        ]
+        >> eo_operators.create_actors_task(dag)
+        >> [
+            eo_operators.create_proposition_services_task(dag),
+            eo_operators.create_labels_task(dag),
+        ]
+        >> eo_operators.create_proposition_services_sous_categories_task(dag)
+        >> eo_operators.serialize_to_json_task(dag)
+        >> eo_operators.write_data_task(dag)
+    )  # type: ignore

--- a/unit_tests/dags/utils/dag_eo_utils_test.py
+++ b/unit_tests/dags/utils/dag_eo_utils_test.py
@@ -1,14 +1,13 @@
 from unittest.mock import MagicMock
 
 import pandas as pd
-
 import pytest
 
 from dags.utils.dag_eo_utils import (
-    create_proposition_services,
-    create_proposition_services_sous_categories,
     create_actors,
     create_labels,
+    create_proposition_services,
+    create_proposition_services_sous_categories,
 )
 
 
@@ -623,7 +622,7 @@ def test_create_proposition_services_sous_categories(mock_ti):
 
 
 def test_create_actors(mock_ti, mock_config):
-    kwargs = {"ti": mock_ti, **mock_config}
+    kwargs = {"ti": mock_ti, "params": mock_config}
     result = create_actors(**kwargs)
     df_result = result["df"]
     metadata = result["metadata"]


### PR DESCRIPTION
Hello @Hazelmat 

Voici une proposition de refactorisation des dags et de leurs opérateurs

Mettre la configuration dans les parametres du DAG (à terme ou pourrait déplacer cette configuration dans des fichiers si nécessaire)

```
    params={
        "endpoint": (
            "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
            "donnees-eo-corepile/lines?size=10000"
        )
    },
 ```
 
 Accès à ces paramètres dans les opérateurs : 
 
```
def fetch_data_from_api(**kwargs):
    params = kwargs["params"]
    api_url = params["endpoint"]
```

déclarer les opérateurs dans un fichier dédié `dags/utils/eo_operators.py` et appeler ces opérateurs dans le fichier du dag :

```
(
    [eo_operators.fetch_data_task(dag), …]
    >> …
```

Ainsi, il ne resterait dans les fichiers de DAG que la configuration du DAG via les paramètres et le graph du DAG

Qu'en pense-tu ?