### PR TITLE
Manage deprecation for schedule_interval and provide_context

### DIFF
--- a/dags/annuaire_entreprise_checks.py
+++ b/dags/annuaire_entreprise_checks.py
@@ -34,7 +34,7 @@ dag = DAG(
         "A pipeline to apply checks using annuaire entreprise "
         "API and output data to validation tool"
     ),
-    schedule_interval="0 0 1 * *",
+    schedule="0 0 1 * *",
 )
 
 

--- a/dags/corepile.py
+++ b/dags/corepile.py
@@ -25,7 +25,7 @@ dag = DAG(
         "A pipeline to fetch, process, and load to validate data into postgresql"
         " for Corepile dataset"
     ),
-    schedule_interval=None,
+    schedule=None,
 )
 
 

--- a/dags/create_final_actors.py
+++ b/dags/create_final_actors.py
@@ -296,7 +296,7 @@ dag = DAG(
     description=(
         "DAG for applying correction on normalized actors and propositionservice"
     ),
-    schedule_interval=None,
+    schedule=None,
 )
 
 read_actors = PythonOperator(
@@ -358,28 +358,24 @@ read_revision_labels = PythonOperator(
 merge_labels = PythonOperator(
     task_id="merge_labels",
     python_callable=merge_actors_labels,
-    provide_context=True,
     dag=dag,
 )
 
 apply_corr = PythonOperator(
     task_id="apply_corrections_actors",
     python_callable=apply_corrections,
-    provide_context=True,
     dag=dag,
 )
 
 apply_corr_ps = PythonOperator(
     task_id="apply_corrections_propositionservice",
     python_callable=apply_corrections_ps,
-    provide_context=True,
     dag=dag,
 )
 
 write_pos = PythonOperator(
     task_id="write_data_to_postgres",
     python_callable=write_data_to_postgres,
-    provide_context=True,
     dag=dag,
 )
 

--- a/dags/ecodds.py
+++ b/dags/ecodds.py
@@ -25,7 +25,7 @@ dag = DAG(
         "A pipeline to fetch, process, and load to validate data into postgresql"
         " for EcoDDS dataset"
     ),
-    schedule_interval=None,
+    schedule=None,
 )
 
 

--- a/dags/ecologic.py
+++ b/dags/ecologic.py
@@ -25,7 +25,7 @@ dag = DAG(
         "A pipeline to fetch, process, and load to validate data into postgresql"
         " for Ecologic dataset"
     ),
-    schedule_interval=None,
+    schedule=None,
 )
 
 

--- a/dags/ecosystem.py
+++ b/dags/ecosystem.py
@@ -25,7 +25,7 @@ dag = DAG(
         "A pipeline to fetch, process, and load to validate data into postgresql"
         " for Ecosystem dataset"
     ),
-    schedule_interval=None,
+    schedule=None,
 )
 
 

--- a/dags/ingest_validated_dataset_to_db.py
+++ b/dags/ingest_validated_dataset_to_db.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pandas as pd
 from airflow.models import DAG
 from airflow.operators.dagrun_operator import TriggerDagRunOperator
-from airflow.operators.python_operator import PythonOperator, BranchPythonOperator
+from airflow.operators.python_operator import BranchPythonOperator, PythonOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.utils.dates import days_ago
 
@@ -25,7 +25,7 @@ dag = DAG(
     utils.get_dag_name(__file__, "validate_and_process_dagruns"),
     default_args=default_args,
     description="Check for VALIDATE in qfdmo_dagrun and process qfdmo_dagrunchange",
-    schedule_interval="*/5 * * * *",
+    schedule="*/5 * * * *",
     catchup=False,
     max_active_runs=1,
 )
@@ -95,7 +95,6 @@ def write_data_to_postgres(**kwargs):
 fetch_parse_task = PythonOperator(
     task_id="fetch_and_parse_data",
     python_callable=fetch_and_parse_data,
-    provide_context=True,
     dag=dag,
 )
 
@@ -107,21 +106,18 @@ def skip_processing(**kwargs):
 skip_processing_task = PythonOperator(
     task_id="skip_processing",
     python_callable=skip_processing,
-    provide_context=True,
     dag=dag,
 )
 
 branch_task = BranchPythonOperator(
     task_id="branch_processing",
     python_callable=check_for_validation,
-    provide_context=True,
     dag=dag,
 )
 
 write_to_postgres_task = PythonOperator(
     task_id="write_to_postgres",
     python_callable=write_data_to_postgres,
-    provide_context=True,
     dag=dag,
 )
 

--- a/dags/ocab.py
+++ b/dags/ocab.py
@@ -25,7 +25,7 @@ dag = DAG(
         "A pipeline to fetch, process, and load to validate data into postgresql"
         " for OCAB dataset"
     ),
-    schedule_interval=None,
+    schedule=None,
 )
 
 

--- a/dags/pyreo.py
+++ b/dags/pyreo.py
@@ -25,7 +25,7 @@ dag = DAG(
         "A pipeline to fetch, process, and load to validate data into postgresql"
         " for Pyreo dataset"
     ),
-    schedule_interval=None,
+    schedule=None,
 )
 
 

--- a/dags/refashion.py
+++ b/dags/refashion.py
@@ -26,7 +26,7 @@ dag = DAG(
         "A pipeline to fetch, process, and load to validate data into postgresql"
         " for Refashion dataset"
     ),
-    schedule_interval=None,
+    schedule=None,
 )
 
 

--- a/dags/soren.py
+++ b/dags/soren.py
@@ -25,7 +25,7 @@ dag = DAG(
         "A pipeline to fetch, process, and load to validate data into postgresql"
         " for Soren dataset"
     ),
-    schedule_interval=None,
+    schedule=None,
 )
 
 

--- a/dags/valdelia.py
+++ b/dags/valdelia.py
@@ -25,7 +25,7 @@ dag = DAG(
         "A pipeline to fetch, process, and load to validate data into postgresql"
         " for Valdelia dataset"
     ),
-    schedule_interval=None,
+    schedule=None,
 )
 
 


### PR DESCRIPTION
Following deprecation documentation :

- for [schedule_interval](https://airflow.apache.org/docs/apache-airflow/2.4.0/release_notes.html#deprecation-of-schedule-interval-and-timetable-arguments-25410) 
- for [provide_context](https://airflow.apache.org/docs/apache-airflow/2.4.0/release_notes.html#airflow-operators-python-pythonoperator)