### PR TITLE
add login form

### DIFF
--- a/core/jinja2_handler.py
+++ b/core/jinja2_handler.py
@@ -85,7 +85,6 @@ def environment(**options):
             "is_embedded": is_embedded,
             "is_iframe": is_iframe,
             "is_carte": is_carte,
-            "reverse": reverse,
             "url": reverse,
             "static": static,
             "quote_plus": lambda u: quote_plus(u),

--- a/core/jinja2_handler.py
+++ b/core/jinja2_handler.py
@@ -86,6 +86,7 @@ def environment(**options):
             "is_iframe": is_iframe,
             "is_carte": is_carte,
             "reverse": reverse,
+            "url": reverse,
             "static": static,
             "quote_plus": lambda u: quote_plus(u),
             "ENVIRONMENT": settings.ENVIRONMENT,

--- a/core/settings.py
+++ b/core/settings.py
@@ -192,8 +192,8 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 # Redirect to home URL after login
-LOGIN_REDIRECT_URL = "home:index"
-LOGOUT_REDIRECT_URL = "home:reemploi_solution"
+LOGIN_REDIRECT_URL = "qfdmo:reemploi_solution"
+LOGOUT_REDIRECT_URL = "qfdmo:reemploi_solution"
 
 # Internationalization
 # https://docs.djangoproject.com/en/4.2/topics/i18n/
@@ -251,7 +251,7 @@ INSEE_KEY = decouple.config("INSEE_KEY", cast=str, default="")
 INSEE_SECRET = decouple.config("INSEE_SECRET", cast=str, default="")
 
 LOGOUT_REDIRECT_URL = "qfdmo:reemploi_solution"
-LOGIN_URL = "admin:login"
+LOGIN_URL = "qfdmo:login"
 
 DEFAULT_MAX_SOLUTION_DISPLAYED = decouple.config(
     "DEFAULT_MAX_SOLUTION_DISPLAYED", cast=int, default=10

--- a/jinja2/editorial/sitemap.html
+++ b/jinja2/editorial/sitemap.html
@@ -14,11 +14,11 @@
                 <li>
                     <a href="https://tally.so/r/3xMqd9">Proposer une modification</a>
                 </li>
-                <li><a href="{{ reverse('qfdmo:legal_notices') }}">Mentions légales</a></li>
-                <li><a href="{{ reverse('qfdmo:cgu') }}">Conditions générales d'utilisation</a></li>
-                <li><a href="{{ reverse('qfdmo:cookies') }}">Politiques des cookies</a></li>
-                <li><a href="{{ reverse('qfdmo:personal_data') }}">Données personnelles</a></li>
-                <li><a href="{{ reverse('qfdmo:accessibility') }}">Accessibilité : non conforme</a></li>
+                <li><a href="{{ url('qfdmo:legal_notices') }}">Mentions légales</a></li>
+                <li><a href="{{ url('qfdmo:cgu') }}">Conditions générales d'utilisation</a></li>
+                <li><a href="{{ url('qfdmo:cookies') }}">Politiques des cookies</a></li>
+                <li><a href="{{ url('qfdmo:personal_data') }}">Données personnelles</a></li>
+                <li><a href="{{ url('qfdmo:accessibility') }}">Accessibilité : non conforme</a></li>
                 <li><a href="https://tally.so/r/wzME61">Nous contacter</a></li>
             </ul>
         </div>

--- a/jinja2/layout/footer.html
+++ b/jinja2/layout/footer.html
@@ -27,22 +27,22 @@
         <div class="fr-footer__bottom">
             <ul class="fr-footer__bottom-list">
                 <li class="fr-footer__bottom-item">
-                    <a class="fr-footer__bottom-link" href="{{ reverse('qfdmo:sitemap') }}">Plan du site</a>
+                    <a class="fr-footer__bottom-link" href="{{ url('qfdmo:sitemap') }}">Plan du site</a>
                 </li>
                 <li class="fr-footer__bottom-item">
-                    <a class="fr-footer__bottom-link" href="{{ reverse('qfdmo:legal_notices') }}">Mentions légales</a>
+                    <a class="fr-footer__bottom-link" href="{{ url('qfdmo:legal_notices') }}">Mentions légales</a>
                 </li>
                 <li class="fr-footer__bottom-item">
-                    <a class="fr-footer__bottom-link" href="{{ reverse('qfdmo:cgu') }}">Conditions générales d'utilisation</a>
+                    <a class="fr-footer__bottom-link" href="{{ url('qfdmo:cgu') }}">Conditions générales d'utilisation</a>
                 </li>
                 <li class="fr-footer__bottom-item">
-                    <a class="fr-footer__bottom-link" href="{{ reverse('qfdmo:cookies') }}">Politique des cookies</a>
+                    <a class="fr-footer__bottom-link" href="{{ url('qfdmo:cookies') }}">Politique des cookies</a>
                 </li>
                 <li class="fr-footer__bottom-item">
-                    <a class="fr-footer__bottom-link" href="{{ reverse('qfdmo:personal_data') }}">Données personnelles</a>
+                    <a class="fr-footer__bottom-link" href="{{ url('qfdmo:personal_data') }}">Données personnelles</a>
                 </li>
                 <li class="fr-footer__bottom-item">
-                    <a class="fr-footer__bottom-link" href="{{ reverse('qfdmo:accessibility') }}">Accessibilité : non conforme</a>
+                    <a class="fr-footer__bottom-link" href="{{ url('qfdmo:accessibility') }}">Accessibilité : non conforme</a>
                 </li>
                 <li class="fr-footer__bottom-item">
                     <a class="fr-footer__bottom-link" href="https://tally.so/r/wzME61" target="_blank">Nous contacter</a>

--- a/jinja2/qfdmo/_addresses_partials/map_and_detail.html
+++ b/jinja2/qfdmo/_addresses_partials/map_and_detail.html
@@ -139,7 +139,7 @@
                         <turbo-frame id="adr_detail"
                             data-search-solution-form-target="srcDetailsAddress"
                             {% if request.GET.get('detail') %}
-                                src="{{ reverse('qfdmo:adresse_detail', args=[request.GET.get('detail')])}}?{% if is_carte(request) %}carte=1&{% endif %}direction={{ direction }}&latitude={{ latitude }}&longitude={{ longitude }}"
+                                src="{{ url('qfdmo:adresse_detail', args=[request.GET.get('detail')])}}?{% if is_carte(request) %}carte=1&{% endif %}direction={{ direction }}&latitude={{ latitude }}&longitude={{ longitude }}"
                             {% endif %}
                         >
                         </turbo-frame>

--- a/jinja2/registration/login.html
+++ b/jinja2/registration/login.html
@@ -1,22 +1,31 @@
 {% extends 'layout/base.html' %}
 
 {% block content %}
-    <div class="fr-container fr-container--fluid fr-mb-md-14v fr-pt-4w">
+    <div class="fr-container fr-mb-md-14v fr-pt-4w">
         <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--center">
             <h1>Connexion à Que Faire de mes objets</h1>
-            {% if form.errors %}
-                <p>Votre nom d'utilisateur et mot de passe ne correspondent pas. Merci de réessayer.</p>
-            {% endif %}
 
-            {% if next %}
-                {% if user.is_authenticated %}
-                    <p>Votre compte utilisateur n'a pas accès à cette page. Pour continuer, merci de vous identifier avec un compte ayant les droits suffisants.</p>
-                {% else %}
-                    <p>Merci de vous connecter pour voir cette page.</p>
-                {% endif %}
-            {% endif %}
 
             <form method="post" action="{{ url('qfdmo:login') }}">
+                {% if next %}
+                    <div class="fr-alert fr-alert--warning fr-my-2w">
+                        <p class="fr-alert__title">
+                            {% if request.user.is_authenticated %}
+                                Votre compte utilisateur n'a pas accès à cette page. Pour continuer, merci de vous identifier avec un compte ayant les droits suffisants.
+                            {% else %}
+                                Merci de vous connecter pour voir cette page.
+                            {% endif %}
+                        </p>
+                    </div>
+                {% endif %}
+
+                {% if form.errors %}
+                    <div class="fr-alert fr-alert--error fr-my-2w">
+                        <p class="fr-alert__title">
+                            Votre nom d'utilisateur et mot de passe ne correspondent pas. Merci de réessayer.</p>
+                    </div>
+                {% endif %}
+
                 {{ csrf_input }}
                 <input type="hidden" name="next" value="{{ next }}">
                 <fieldset class="fr-fieldset">
@@ -46,13 +55,9 @@
                         </fieldset>
                     </div>
                     <div class="fr-fieldset__element">
-                        <ul class="fr-btns-group">
-                            <li>
-                                <button class="fr-mt-2v fr-btn">
-                                    Se connecter
-                                </button>
-                            </li>
-                        </ul>
+                        <button class="fr-btn">
+                            Se connecter
+                        </button>
                     </div>
                 </fieldset>
             </form>

--- a/jinja2/registration/login.html
+++ b/jinja2/registration/login.html
@@ -1,0 +1,63 @@
+{% extends 'layout/base.html' %}
+
+{% block content %}
+    <div class="fr-container fr-container--fluid fr-mb-md-14v fr-pt-4w">
+        <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--center">
+            <h1>Connexion à Que Faire de mes objets</h1>
+            {% if form.errors %}
+                <p>Votre nom d'utilisateur et mot de passe ne correspondent pas. Merci de réessayer.</p>
+            {% endif %}
+
+            {% if next %}
+                {% if user.is_authenticated %}
+                    <p>Votre compte utilisateur n'a pas accès à cette page. Pour continuer, merci de vous identifier avec un compte ayant les droits suffisants.</p>
+                {% else %}
+                    <p>Merci de vous connecter pour voir cette page.</p>
+                {% endif %}
+            {% endif %}
+
+            <form method="post" action="{{ url('qfdmo:login') }}">
+                {{ csrf_input }}
+                <input type="hidden" name="next" value="{{ next }}">
+                <fieldset class="fr-fieldset">
+                    <legend class="fr-fieldset__legend" id="login-1760-fieldset-legend">
+                        <h2>Se connecter avec son compte</h2>
+                    </legend>
+                    <div class="fr-fieldset__element">
+                        <fieldset class="fr-fieldset">
+                            <div class="fr-fieldset__element">
+                                <div class="fr-input-group">
+                                    <label class="fr-label" for="{{ form.username.id_for_label }}">
+                                        Identifiant
+                                    </label>
+                                    <input class="fr-input" autocomplete="username" aria-required="true" name="username" id="{{ form.username.id_for_label }}" type="text">
+                                </div>
+                            </div>
+                            <div class="fr-fieldset__element">
+                                <div class="fr-password" id="{{ form.password.id_for_label }}">
+                                    <label class="fr-label" for="{{ form.password.id_for_label }}">
+                                        Mot de passe
+                                    </label>
+                                    <div class="fr-input-wrap">
+                                        <input class="fr-password__input fr-input" aria-required="true" name="password" autocomplete="current-password" id="{{ form.password.id_for_label }}" type="password">
+                                    </div>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+                    <div class="fr-fieldset__element">
+                        <ul class="fr-btns-group">
+                            <li>
+                                <button class="fr-mt-2v fr-btn">
+                                    Se connecter
+                                </button>
+                            </li>
+                        </ul>
+                    </div>
+                </fieldset>
+            </form>
+        </div>
+    </div>
+
+{% endblock content %}
+

--- a/jinja2/registration/login.html
+++ b/jinja2/registration/login.html
@@ -39,7 +39,7 @@
                                     <label class="fr-label" for="{{ form.username.id_for_label }}">
                                         Identifiant
                                     </label>
-                                    <input class="fr-input" autocomplete="username" aria-required="true" name="username" id="{{ form.username.id_for_label }}" type="text">
+                                    <input class="fr-input" autocomplete="username" aria-required="true" name="username" id="{{ form.username.id_for_label }}" type="text" value="{{ form.username.value() or "" }}">
                                 </div>
                             </div>
                             <div class="fr-fieldset__element">
@@ -48,7 +48,7 @@
                                         Mot de passe
                                     </label>
                                     <div class="fr-input-wrap">
-                                        <input class="fr-password__input fr-input" aria-required="true" name="password" autocomplete="current-password" id="{{ form.password.id_for_label }}" type="password">
+                                        <input class="fr-password__input fr-input" aria-required="true" name="password" autocomplete="current-password" id="{{ form.password.id_for_label }}" type="password" value="{{ form.password.value() or "" }}">
                                     </div>
                                 </div>
                             </div>

--- a/qfdmo/urls.py
+++ b/qfdmo/urls.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.contrib.auth.views import LoginView
 from django.urls import path
 from django.views.generic import TemplateView
 from django.views.generic.base import RedirectView
@@ -15,6 +16,7 @@ from qfdmo.views.dags import DagsValidation
 
 urlpatterns = [
     path("", AddressesView.as_view(), name="reemploi_solution"),
+    path("connexion", LoginView.as_view(), name="login"),
     path(
         "qfdmo/getorcreate_revisionacteur/<str:acteur_identifiant>",
         getorcreate_revisionacteur,

--- a/unit_tests/qfdmo/test_views.py
+++ b/unit_tests/qfdmo/test_views.py
@@ -4,7 +4,7 @@ class TestConfigurateur:
         assert response.status_code == 302
         assert response.url.startswith("/connexion")
 
-    def test_authenticated_user_can_access_to_configurateur(
+    def test_authenticated_user_can_access_configurateur(
         self, client, django_user_model
     ):
         user = django_user_model.objects.create_user(

--- a/unit_tests/qfdmo/test_views.py
+++ b/unit_tests/qfdmo/test_views.py
@@ -1,0 +1,15 @@
+class TestConfigurateur:
+    def test_anonymous_user_cannot_access_configurateur(self, client):
+        response = client.get("/iframe/configurateur")
+        assert response.status_code == 302
+        assert response.url.startswith("/connexion")
+
+    def test_authenticated_user_can_access_to_configurateur(
+        self, client, django_user_model
+    ):
+        user = django_user_model.objects.create_user(
+            username="Jean-Michel", password="accedeauconfigurateur"
+        )
+        client.force_login(user)
+        response = client.get("/iframe/configurateur")
+        assert response.status_code == 200


### PR DESCRIPTION
Ajout d'un formulaire de connexion pour permettre aux utilisateurs n'ayant pas accès à l'admin django de quand même voir le configurateur.   

Ref : https://www.notion.so/accelerateur-transition-ecologique-ademe/Acc-s-au-configurateur-Atelier-111-da47ccc49b3e42da950c630afa5cd1d3?pvs=4 

## Écrans 

J'ai ajouté une vue : 
1. Tentative d'accès à `/iframe/configurateur`
2. Redirection vers `/connexion`
3. À la connexion : redirection vers `/iframe/configurateur`

<img width="1624" alt="connexion après redirection" src="https://github.com/incubateur-ademe/quefairedemesobjets/assets/1702255/e5c61750-712f-4def-9817-9df06bc2e67f">

<img width="1624" alt="connexion avec login invalide" src="https://github.com/incubateur-ademe/quefairedemesobjets/assets/1702255/7f3e9c9f-646b-4813-b156-f0b768f5785a">



**TODO** 
- [x] Restreindre le configurateur aux users connectés (normalement déjà fait)
- [x] Vérifier qu'un compte non `staff` peut accéder au configurateur 
- [x] unit tests

**QUESTIONS**
- [ ] Quid du bouton de déconnexion ?
- [ ] Voir question Christian dans Notion