### PR TITLE
Update the breakingpoint to display legend in slide panel or on top of the map

### DIFF
--- a/jinja2/qfdmo/_addresses_partials/carte_header.html
+++ b/jinja2/qfdmo/_addresses_partials/carte_header.html
@@ -7,7 +7,7 @@
     <div class="fr-my-1w qfdmo-flex-grow qfdmo-flex qfdmo-flex-col md:qfdmo-mr-2w">
         {% include 'qfdmo/_addresses_partials/adresse_input_form.html' %}
 
-        <div class="md:qfdmo-hidden fr-mt-1w qfdmo-flex qfdmo-justify-between">
+        <div class="lg:qfdmo-hidden fr-mt-1w qfdmo-flex qfdmo-justify-between">
             <button
                 class="fr-btn fr-btn--sm fr-btn--tertiary"
                 type="button"

--- a/jinja2/qfdmo/_addresses_partials/carte_header.html
+++ b/jinja2/qfdmo/_addresses_partials/carte_header.html
@@ -7,7 +7,7 @@
     <div class="fr-my-1w qfdmo-flex-grow qfdmo-flex qfdmo-flex-col md:qfdmo-mr-2w">
         {% include 'qfdmo/_addresses_partials/adresse_input_form.html' %}
 
-        <div class="sm:qfdmo-hidden fr-mt-1w qfdmo-flex qfdmo-justify-between">
+        <div class="md:qfdmo-hidden fr-mt-1w qfdmo-flex qfdmo-justify-between">
             <button
                 class="fr-btn fr-btn--sm fr-btn--tertiary"
                 type="button"

--- a/jinja2/qfdmo/_addresses_partials/map_and_detail.html
+++ b/jinja2/qfdmo/_addresses_partials/map_and_detail.html
@@ -55,7 +55,7 @@
                         Rechercher dans cette zone
                     </button>
                     {% if is_carte(request) %}
-                        <div class="fr-px-3w qfdmo-hidden sm:qfdmo-block qfdmo-absolute qfdmo-bottom-0 qfdmo-left-0 qfdmo-bg-white qfdmo-z-[2000] qfdmo-max-w-[21rem]">
+                        <div class="fr-px-3w qfdmo-hidden md:qfdmo-block qfdmo-absolute qfdmo-bottom-0 qfdmo-left-0 qfdmo-bg-white qfdmo-z-[2000] qfdmo-max-w-[21rem]">
                             <h2 class="fr-h4 fr-mt-3w">
                                 Actions possibles
                             </h2>

--- a/jinja2/qfdmo/_addresses_partials/map_and_detail.html
+++ b/jinja2/qfdmo/_addresses_partials/map_and_detail.html
@@ -55,7 +55,7 @@
                         Rechercher dans cette zone
                     </button>
                     {% if is_carte(request) %}
-                        <div class="fr-px-3w qfdmo-hidden md:qfdmo-block qfdmo-absolute qfdmo-bottom-0 qfdmo-left-0 qfdmo-bg-white qfdmo-z-[2000] qfdmo-max-w-[21rem]">
+                        <div class="fr-px-3w qfdmo-hidden lg:qfdmo-block qfdmo-absolute qfdmo-bottom-0 qfdmo-left-0 qfdmo-bg-white qfdmo-z-[2000] qfdmo-max-w-[21rem]">
                             <h2 class="fr-h4 fr-mt-3w">
                                 Actions possibles
                             </h2>


### PR DESCRIPTION
dans cette PR on modifie le point de rupture pour l'affichage de la légende comme un paneau apparaissan lors de l'appuie sur le bouton legends ou comme un ecart toujours visible : 

![CleanShot 2024-06-28 at 11 05 09](https://github.com/incubateur-ademe/quefairedemesobjets/assets/454431/f1651d18-bad5-4732-a977-bf9a2b14852b)

vs

![CleanShot 2024-06-28 at 11 05 51](https://github.com/incubateur-ademe/quefairedemesobjets/assets/454431/b80117e3-5f0e-4589-bbb6-f42433974088)


Reste à choisir avec @LuluFreeDesign quel est le point de rupture pour ce changement de comportement :  `md` ou `lg`. Si `lg` est choisit il faudra modifier cette PR en conséquence.
