### PR TITLE
Add missing classes to tailwind safelist

### DIFF
--- a/qfdmo/views/adresses.py
+++ b/qfdmo/views/adresses.py
@@ -438,6 +438,8 @@ class AddressesView(FormView):
         for [groupe, groupe_displayed_actions] in groupe_with_displayed_actions:
             libelle = ""
             if groupe.icon:
+                # Les classes qfdmo- ci-dessous doivent être ajoutées à la safelist
+                # Tailwind dans tailwind.config.js
                 libelle = (
                     f'<span class="fr-px-1v qfdmo-text-white {groupe.icon}'
                     f' fr-icon--sm qfdmo-rounded-full qfdmo-bg-{groupe.couleur}"'

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -61,6 +61,8 @@ module.exports = {
         "qfdmo-justify-between",
         "qfdmo-m-1w",
         "qfdmo-w-full",
+        "qfdmo-text-white",
+        "qfdmo-rounded-full",
     ],
     theme: {
         colors: {


### PR DESCRIPTION
Il manque des classes CSS à la safelist tailwind, je les ai ajoutées ainsi qu'un commentaire pour l'éviter plus tard. 