### PR TITLE
remove obsolete version in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   postgres:
     image: postgis/postgis:15-3.3-alpine


### PR DESCRIPTION
La version dans le `docker-compose` n'est plus requise depuis quelques temps. 

Ça évitera le warning au lancement de la stack `version is obsolete"  Container quefairedemesobjets-postgres-1  Created`