### PR TITLE
Fix typo in placeholder rechercher adresse

### DIFF
--- a/qfdmo/forms.py
+++ b/qfdmo/forms.py
@@ -276,7 +276,7 @@ class CarteAddressesForm(AddressesForm):
         widget=AutoCompleteAndSearchInput(
             attrs={
                 "class": "fr-input",
-                "placeholder": "Recherche autour d'une adresse",
+                "placeholder": "Rechercher autour d'une adresse",
                 "autocomplete": "off",
                 "aria-label": "Saisir une adresse - obligatoire",
             },
@@ -335,7 +335,6 @@ class DagsForm(forms.Form):
 
 
 class ConfiguratorForm(forms.Form):
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.load_choices()


### PR DESCRIPTION
Cf https://www.notion.so/accelerateur-transition-ecologique-ademe/Rechercher-autour-d-une-adresse-manque-le-r-69faa190b6f24ca4a67843317f8ad29b?pvs=4