### PR TITLE
add script to hide logo when origin is ademe.fr

### DIFF
--- a/jinja2/qfdmo/_addresses_partials/carte_header.html
+++ b/jinja2/qfdmo/_addresses_partials/carte_header.html
@@ -1,5 +1,5 @@
 <div class="fr-container qfdmo-flex qfdmo-flex-row sm:qfdmo-items-center">
-    <div class="qfdmo-items-center qfdmo-hidden md:qfdmo-flex qfdmo-flex-row">
+    <div class="qfdmo-items-center qfdmo-hidden md:qfdmo-flex qfdmo-flex-row" id="logo">
         {% include 'layout/_partials/header_logos.html' %}
     </div>
 

--- a/static/to_compile/entrypoints/qfdmo.ts
+++ b/static/to_compile/entrypoints/qfdmo.ts
@@ -8,6 +8,7 @@ import SearchSolutionFormController from "../src/search_solution_form_controller
 import SsCatObjectAutocompleteController from "../src/ss_cat_object_autocomplete_controller"
 
 import "../src/browser_check"
+import "../src/iframe"
 
 window.stimulus = Application.start()
 stimulus.register("map", MapController)

--- a/static/to_compile/src/iframe.ts
+++ b/static/to_compile/src/iframe.ts
@@ -1,6 +1,6 @@
 window.addEventListener("message", (event) => {
   const domain = new URL(event.origin).hostname
-  if (event.data === "ademe" && (domain === 'localhost' || domain.endsWith("ademe.fr"))) {
+  if (event.data === "ademe" && (domain === 'localhost' || domain.endsWith(".ademe.fr"))) {
     document.querySelector("#logo")?.remove()
   }
 });

--- a/static/to_compile/src/iframe.ts
+++ b/static/to_compile/src/iframe.ts
@@ -1,0 +1,6 @@
+window.addEventListener("message", (event) => {
+  const domain = new URL(event.origin).hostname
+  if (event.data === "ademe" && (domain === 'localhost' || domain.endsWith("ademe.fr"))) {
+    document.querySelector("#logo")?.remove()
+  }
+});


### PR DESCRIPTION
Ajout d'un script qui permet de communiquer depuis l'iframe parent 
- Si le parent qui inclut l'iframe envoie un [message](https://developer.mozilla.org/fr/docs/Web/API/Window/postMessage) d'un domaine ademe.fr, alors on cache le logo 

cf https://github.com/incubateur-ademe/quefairedemesdechets/pull/93
cf https://www.notion.so/accelerateur-transition-ecologique-ademe/Ne-pas-mettre-de-logo-au-niveau-de-la-barre-de-recherche-sinon-on-doublonne-les-logos-5843aa673270465a89bca50c85be0d0a?pvs=4