### PR TITLE
hide object filter when sous categorie id is set

### DIFF
--- a/core/jinja2_handler.py
+++ b/core/jinja2_handler.py
@@ -58,6 +58,10 @@ def display_sources_panel(adresse: DisplayedActeur) -> bool:
     return bool(adresse.source and adresse.source.afficher)
 
 
+def display_object_filter(request) -> bool:
+    return not bool(request.GET.get("sc_id"))
+
+
 def distance_to_acteur(request, adresse):
     long = request.GET.get("longitude")
     lat = request.GET.get("latitude")
@@ -81,6 +85,7 @@ def environment(**options):
             "display_infos_panel": display_infos_panel,
             "display_sources_panel": display_sources_panel,
             "display_labels_panel": display_labels_panel,
+            "display_object_filter": display_object_filter,
             "distance_to_acteur": distance_to_acteur,
             "is_embedded": is_embedded,
             "is_iframe": is_iframe,

--- a/jinja2/qfdmo/_addresses_partials/filters/carte_filters.html
+++ b/jinja2/qfdmo/_addresses_partials/filters/carte_filters.html
@@ -7,10 +7,10 @@
 {% endblock %}
 
 {% block filters_content %}
-
-    {% include 'qfdmo/_addresses_partials/filters/_object_filter.html' %}
+    {% if display_object_filter(request) %}
+        {% include 'qfdmo/_addresses_partials/filters/_object_filter.html' %}
+    {% endif %}
     {% include 'qfdmo/_addresses_partials/filters/_labels_filters.html' %}
-
 {% endblock %}
 
 {% block filters_footer_links %}


### PR DESCRIPTION
Dans le cas de l'assistant, l'id de sous catégorie est défini dans l'URL. Lorsque c'est le cas, on cache le filtre avancé objet qui n'a pas lieu d'être. 

Ref https://www.notion.so/accelerateur-transition-ecologique-ademe/Supprimer-le-filtre-objet-dans-les-filtres-pour-l-assistant-40d4925314374da69523a237758c9056?pvs=4 