### PR TITLE
build exclusivite reparation filter when reparer is checked

### DIFF
--- a/qfdmo/views/adresses.py
+++ b/qfdmo/views/adresses.py
@@ -373,7 +373,10 @@ class AddressesView(FormView):
         reparer_action_id = CachedDirectionAction.get_reparer_action_id()
         reparer_is_checked = reparer_action_id in selected_actions_ids
 
-        if self.cleaned_data["pas_exclusivite_reparation"]:
+        if (
+            self.cleaned_data["pas_exclusivite_reparation"] is not False
+            or reparer_is_checked
+        ):
             excludes |= Q(exclusivite_de_reprisereparation=True)
 
         if self.cleaned_data["label_reparacteur"] and reparer_is_checked:

--- a/qfdmo/views/adresses.py
+++ b/qfdmo/views/adresses.py
@@ -299,7 +299,14 @@ class AddressesView(FormView):
         return []
 
     def _get_selected_action_ids(self):
-        return [a.id for a in self._get_selected_action()]
+        if self.request.GET.get("carte") is not None:
+            return [a.id for a in self._get_selected_action()]
+
+        return [a["id"] for a in self.get_action_list()]
+
+    def _get_reparer_action_id(self):
+        """Sert essentiellement à faciliter le teste de AddressesView"""
+        return CachedDirectionAction.get_reparer_action_id()
 
     def _get_selected_action(self) -> List[Action]:
         """
@@ -365,17 +372,13 @@ class AddressesView(FormView):
         filters = Q()
         excludes = Q()
 
-        selected_actions_ids = (
-            self._get_selected_action_ids()
-            if self.request.GET.get("carte") is not None
-            else [a["id"] for a in self.get_action_list()]
-        )
-        reparer_action_id = CachedDirectionAction.get_reparer_action_id()
+        selected_actions_ids = self._get_selected_action_ids()
+        reparer_action_id = self._get_reparer_action_id()
         reparer_is_checked = reparer_action_id in selected_actions_ids
 
         if (
             self.cleaned_data["pas_exclusivite_reparation"] is not False
-            or reparer_is_checked
+            or not reparer_is_checked
         ):
             excludes |= Q(exclusivite_de_reprisereparation=True)
 

--- a/qfdmo/views/adresses.py
+++ b/qfdmo/views/adresses.py
@@ -122,13 +122,6 @@ class AddressesView(FormView):
 
         # Manage the selection of sous_categorie_objet and actions
         acteurs = self._manage_sous_categorie_objet_and_actions()
-        acteurs = acteurs.exclude(exclusivite_de_reprisereparation=True)
-
-        if self.cleaned_data["ess"]:
-            acteurs = acteurs.filter(labels__code="ess")
-
-        if self.cleaned_data["bonus"]:
-            acteurs = acteurs.filter(labels__bonus=True)
 
         # Case of digital acteurs
         if self.request.GET.get("digital") and self.request.GET.get("digital") == "1":
@@ -140,6 +133,8 @@ class AddressesView(FormView):
             return super().get_context_data(**kwargs)
 
         # Case of physical acteurs
+        # TODO : refactoriser ci-dessous pour passer dans
+        # _manage_sous_categorie_objet_and_actions ou autre
         else:
             # Exclude digital acteurs
             acteurs = acteurs.exclude(
@@ -385,6 +380,12 @@ class AddressesView(FormView):
             selected_actions_ids = [
                 a for a in selected_actions_ids if a != reparer_action_id
             ]
+
+        if self.cleaned_data["ess"]:
+            filters |= Q(labels__code="ess")
+
+        if self.cleaned_data["bonus"]:
+            filters |= Q(labels__bonus=True)
 
         if self.cleaned_data.get("sous_categorie_objet") and self.cleaned_data.get(
             "sc_id"

--- a/unit_tests/qfdmo/acteur_factory.py
+++ b/unit_tests/qfdmo/acteur_factory.py
@@ -1,6 +1,6 @@
 import factory.fuzzy
 from django.contrib.gis.geos import Point
-from factory import SubFactory
+from factory import SubFactory, Faker
 from factory.django import DjangoModelFactory as Factory
 
 from qfdmo.models import (
@@ -20,6 +20,8 @@ class SourceFactory(Factory):
     class Meta:
         model = Source
 
+    libelle = Faker("word")
+    code = Faker("word")
     afficher = True
 
 

--- a/unit_tests/qfdmo/test_addresses_view.py
+++ b/unit_tests/qfdmo/test_addresses_view.py
@@ -1,9 +1,7 @@
 from django.contrib.gis.geos import Point
 import pytest
-from unittest.mock import MagicMock
 from django.http import HttpRequest
 
-from qfdmo.models.acteur import DisplayedActeur
 from qfdmo.views.adresses import AddressesView
 from unit_tests.core.test_utils import query_dict_from
 from unit_tests.qfdmo.acteur_factory import DisplayedActeurFactory
@@ -74,9 +72,6 @@ def adresses_view():
         location=Point(1, 1),
     )
     adresses_view = AddressesView()
-    adresses_view._manage_sous_categorie_objet_and_actions = MagicMock(
-        return_value=DisplayedActeur.objects.all()
-    )
     return adresses_view
 
 
@@ -89,7 +84,7 @@ class TestExclusiviteReparation:
                 "action_list": ["preter"],
                 "latitude": [1],
                 "longitude": [1],
-                "pas_exclusivite_reparation": ["on"],
+                "pas_exclusivite_reparation": ["true"],
             }
         )
         adresses_view.request = request
@@ -104,9 +99,9 @@ class TestExclusiviteReparation:
         request.GET = query_dict_from(
             {
                 "action_list": ["preter|reparer"],
-                "pas_exclusivite_reparation": ["on"],
                 "latitude": [1],
                 "longitude": [1],
+                "pas_exclusivite_reparation": ["true"],
             }
         )
         adresses_view.request = request
@@ -123,9 +118,12 @@ class TestExclusiviteReparation:
                 "action_list": ["preter|reparer"],
                 "latitude": [1],
                 "longitude": [1],
+                "pas_exclusivite_reparation": ["false"],
             }
         )
         adresses_view.request = request
         context = adresses_view.get_context_data()
 
+        # TODO: comprendre pourquoi c'est pas bon ici...
+        # je pense que ca vient du else ligne 413 de views/adresses.py
         assert context["acteurs"].count() == 1

--- a/unit_tests/qfdmo/test_addresses_view.py
+++ b/unit_tests/qfdmo/test_addresses_view.py
@@ -1,10 +1,17 @@
 from django.contrib.gis.geos import Point
+from unittest.mock import MagicMock
 import pytest
 from django.http import HttpRequest
 
+from qfdmo.models.acteur import ActeurStatus
 from qfdmo.views.adresses import AddressesView
 from unit_tests.core.test_utils import query_dict_from
-from unit_tests.qfdmo.acteur_factory import DisplayedActeurFactory
+from unit_tests.qfdmo.acteur_factory import (
+    DisplayedActeurFactory,
+    LabelQualiteFactory,
+    PropositionServiceFactory,
+)
+from unit_tests.qfdmo.action_factory import ActionFactory
 
 
 class TestAdessesViewGetActionList:
@@ -67,11 +74,20 @@ class TestAdessesViewGetActionList:
 
 @pytest.fixture
 def adresses_view():
-    DisplayedActeurFactory(
+    reparacteur = LabelQualiteFactory(code="reparacteur")
+    action = ActionFactory()
+    proposition_service = PropositionServiceFactory(action=action)
+
+    acteur = DisplayedActeurFactory(
         exclusivite_de_reprisereparation=True,
         location=Point(1, 1),
+        statut=ActeurStatus.ACTIF,
     )
+    acteur.labels.add(reparacteur)
+    acteur.proposition_service.add(proposition_service)
     adresses_view = AddressesView()
+    adresses_view._get_reparer_action_id = MagicMock(return_value=action.id)
+    # adresses_view._get_selected_action_ids = MagicMock(return_value=["reparer"])
     return adresses_view
 
 

--- a/unit_tests/qfdmo/test_addresses_view.py
+++ b/unit_tests/qfdmo/test_addresses_view.py
@@ -8,8 +8,8 @@ from qfdmo.views.adresses import AddressesView
 from unit_tests.core.test_utils import query_dict_from
 from unit_tests.qfdmo.acteur_factory import (
     DisplayedActeurFactory,
+    DisplayedPropositionServiceFactory,
     LabelQualiteFactory,
-    PropositionServiceFactory,
 )
 from unit_tests.qfdmo.action_factory import ActionFactory
 
@@ -76,18 +76,19 @@ class TestAdessesViewGetActionList:
 def adresses_view():
     reparacteur = LabelQualiteFactory(code="reparacteur")
     action = ActionFactory()
-    proposition_service = PropositionServiceFactory(action=action)
 
-    acteur = DisplayedActeurFactory(
+    displayed_acteur = DisplayedActeurFactory(
         exclusivite_de_reprisereparation=True,
         location=Point(1, 1),
         statut=ActeurStatus.ACTIF,
     )
-    acteur.labels.add(reparacteur)
-    acteur.proposition_service.add(proposition_service)
+    display_proposition_service = DisplayedPropositionServiceFactory(action=action)
+    displayed_acteur.labels.add(reparacteur)
+    displayed_acteur.proposition_services.add(display_proposition_service)
+
     adresses_view = AddressesView()
     adresses_view._get_reparer_action_id = MagicMock(return_value=action.id)
-    # adresses_view._get_selected_action_ids = MagicMock(return_value=["reparer"])
+    adresses_view._get_selected_action_ids = MagicMock(return_value=[action.id])
     return adresses_view
 
 
@@ -140,6 +141,4 @@ class TestExclusiviteReparation:
         adresses_view.request = request
         context = adresses_view.get_context_data()
 
-        # TODO: comprendre pourquoi c'est pas bon ici...
-        # je pense que ca vient du else ligne 413 de views/adresses.py
         assert context["acteurs"].count() == 1


### PR DESCRIPTION
Ref https://www.notion.so/accelerateur-transition-ecologique-ademe/Acteur-avec-exclu-de-R-paration-n-appara-t-pas-sur-la-carte-m-me-quand-on-d-coche-le-filtre-be5dd348c83b48f3a76ac60e894d0e1d?pvs=4 

Le filtrage de l'exclusivité de réparation exclut des acteurs qui devraient s'afficher, notamment car on récupère mal l'action réparer choisie par l'utilisateur.   

⚠️ J'ai réalisé que cette partie du code était pas mal *emmêlée*, je propose dans cette PR une légère réorganisation. 
Notamment : 
- Utilisation de **formulaire django plutôt que d'accéder directement aux paramètres de la requête** : c'est plus stable, les données ont déjà été validées par Django. Ça évite notamment des `int(request.GET.get("an_int_parameter", "0"))`
- J'ai **refactorisé ces méthodes** pour mieux visualiser où est-ce qu'on faisait le filtrage sur les acteurs 
- J'ai revu le **nommage** pour m'y retrouver un peu, je suis ouvert sur le sujet 
- J'ai ajouté deux `# TODO` dans le code pour pas oublier de finaliser la refacto 

### TODO 
- [x] Vérifier les tests qui plantent

--- 
J'ai pas mal galéré sur l'écriture des tests, il y a des conditions un petit peu cachée pour faire marcher la vue avec l'action `reparer`, en l'occurence j'ai du :
- définir un label qualité `réparateur`
- créer une `action` que je passe à une `displayed proposition service` que j'ajoute à mon `displayed acteur`
- mocker `_get_reparer_action_id` et `_get_selected_action_ids` pour retourner cette `action`

Ça me semble un peu tordu, je me demande si j'ai bien compris le sujet ou pas. 
En tout cas la _bonne_ nouvelle, c'est que mes tests échouaient avec un périmètre fonctionnel mal respecté, donc j'imagine qu'ils étaient pas si mal écrits 😅 

--- 

# Tests fonctionnels 

Pour tester : je conseille de passer la limite de résultats affichés à 100 ou plus dans l'environnement du projet. 
Les tests sont réalisés en cherchant Atelier tuffery Floirac, à Floirac Trois Rivières (acteur proposé par Christian qui a bien une exclusivité de réparation). 

## [En mode formulaire](http://localhost:8000/?r=512&pas_exclusivite_reparation=on&direction=jai&action_displayed=preter%7Cemprunter%7Clouer%7Cmettreenlocation%7Creparer%7Cdonner%7Cechanger%7Cacheter%7Crevendre&action_list=preter%7Cemprunter%7Clouer%7Cmettreenlocation%7Creparer%7Cdonner%7Cechanger%7Cacheter%7Crevendre&sous_categorie_objet=Vêtement&sc_id=107&adresse=Florac+Trois+Rivières&longitude=3.596087&latitude=44.326946&preter=on&mettreenlocation=on&reparer=on&donner=on&echanger=on&revendre=on&emprunter=on&louer=on&echanger=on&acheter=on&digital=0&bounding_box=)

### 1. Par défaut : pas exclu coché, réparer coché

<img width="715" alt="image" src="https://github.com/user-attachments/assets/5a04511b-ddc4-42d3-a1be-e8091cd04098">

Il n'y a rien ici 
<img width="1242" alt="image" src="https://github.com/user-attachments/assets/e6e548fd-1dd4-46e4-9b8f-fafe84ab627f">

### 2. Pas exclu décoché, réparer coché 
<img width="919" alt="image" src="https://github.com/user-attachments/assets/af3aafc3-e103-4319-828c-eab6065c62ea">

Atelier tuffery Floirac s'affiche bien
<img width="1265" alt="image" src="https://github.com/user-attachments/assets/e16f3206-1a27-4052-809f-d63449827771">

### 3. Pas exclu décoché, réparer décoché 
<img width="506" alt="image" src="https://github.com/user-attachments/assets/2df819eb-ee10-4db5-bfa5-369ce52b2f4d">

Il n'y a rien ici 🎉 
<img width="1236" alt="image" src="https://github.com/user-attachments/assets/5b94066d-31c3-45f3-9d67-31a511770dd6">

## [En mode carte](http://localhost:8000/?carte&r=512&pas_exclusivite_reparation=on&direction=jai&action_displayed=preter%7Cemprunter%7Clouer%7Cmettreenlocation%7Creparer%7Cdonner%7Cechanger%7Cacheter%7Crevendre&action_list=preter%7Cemprunter%7Clouer%7Cmettreenlocation%7Creparer%7Cdonner%7Cechanger%7Cacheter%7Crevendre&sous_categorie_objet=Vêtement&sc_id=107&adresse=Florac+Trois+Rivières&longitude=3.596087&latitude=44.326946&preter=on&mettreenlocation=on&reparer=on&donner=on&echanger=on&revendre=on&emprunter=on&louer=on&echanger=on&acheter=on&digital=0&bounding_box=)

### 1. Par défaut : pas exclu coché, réparer coché
<img width="1250" alt="image" src="https://github.com/user-attachments/assets/936d408f-9e8d-43dd-ab51-1dbe66479130">

Il n'apparaît pas, comportement attendu ✔️ 

### 2. Pas exclu décoché, réparer coché 
<img width="1236" alt="image" src="https://github.com/user-attachments/assets/fd893686-4199-42ef-aa90-b114de4c11f8">

Il apparaît, comportement attendu ✔️

### 3. Pas exclu décoché, réparer décoché 
Il n'apparaît pas, comportement attendu ✔️
<img width="1266" alt="image" src="https://github.com/user-attachments/assets/31bac9a4-4e8b-4f47-a805-c349214c4280">
