### PR TITLE
Correctifs pour l'API LVAO 

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,5 @@
 ALLOWED_HOSTS=localhost,127.0.0.1
+BASE_URL=http://localhost:8000
 DATABASE_URL=postgis://qfdmo:qfdmo@localhost:6543/qfdmo
 DB_READONLY=postgis://qfdmo:qfdmo@localhost:6543/qfdmo
 DEBUG=True
@@ -17,3 +18,4 @@ AWS_S3_REGION_NAME='fr-par'
 AWS_S3_ENDPOINT_URL='https://s3.fr-par.scw.cloud'
 AWS_STORAGE_BUCKET_NAME='qfdmo-interface'
 AIRFLOW_WEBSERVER_REFRESHACTEUR_URL=http://localhost:8080
+

--- a/core/jinja2_handler.py
+++ b/core/jinja2_handler.py
@@ -62,8 +62,8 @@ def display_sources_panel(adresse: DisplayedActeur) -> bool:
     return bool(adresse.source and adresse.source.afficher)
 
 
-def display_object_filter(request) -> bool:
-    return not bool(request.GET.get("sc_id"))
+def hide_object_filter(request) -> bool:
+    return bool(request.GET.get("sc_id"))
 
 
 def distance_to_acteur(request, adresse):
@@ -89,7 +89,7 @@ def environment(**options):
             "display_infos_panel": display_infos_panel,
             "display_sources_panel": display_sources_panel,
             "display_labels_panel": display_labels_panel,
-            "display_object_filter": display_object_filter,
+            "hide_object_filter": hide_object_filter,
             "distance_to_acteur": distance_to_acteur,
             "display_exclusivite_reparation": display_exclusivite_reparation,
             "is_embedded": is_embedded,

--- a/jinja2/qfdmo/_addresses_partials/filters/_object_filter.html
+++ b/jinja2/qfdmo/_addresses_partials/filters/_object_filter.html
@@ -1,4 +1,4 @@
-<div data-search-solution-form-target="sousCategoryObjetGroup" class="fr-mt-3w fr-px-1v fr-input-group">
+<div data-search-solution-form-target="sousCategoryObjetGroup" class="fr-mt-3w fr-px-1v fr-input-group {% if hidden %}hidden{% endif %}">
     <div data-controller='ss-cat-object-autocomplete'
         data-ss-cat-object-autocomplete-max-option-displayed-value=5
         data-ss-cat-object-autocomplete-nb-char-to-search-value=2

--- a/jinja2/qfdmo/_addresses_partials/filters/_object_filter.html
+++ b/jinja2/qfdmo/_addresses_partials/filters/_object_filter.html
@@ -1,4 +1,4 @@
-<div data-search-solution-form-target="sousCategoryObjetGroup" class="fr-mt-3w fr-px-1v fr-input-group {% if hidden %}hidden{% endif %}">
+<div data-search-solution-form-target="sousCategoryObjetGroup" class="fr-mt-3w fr-px-1v fr-input-group {% if hidden %}qfdmo-hidden{% endif %}">
     <div data-controller='ss-cat-object-autocomplete'
         data-ss-cat-object-autocomplete-max-option-displayed-value=5
         data-ss-cat-object-autocomplete-nb-char-to-search-value=2

--- a/jinja2/qfdmo/_addresses_partials/filters/carte_filters.html
+++ b/jinja2/qfdmo/_addresses_partials/filters/carte_filters.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block filters_content %}
-    {% with hidden=display_object_filter(request) %}
+    {% with hidden=hide_object_filter(request) %}
         {% include 'qfdmo/_addresses_partials/filters/_object_filter.html' %}
     {% endwith %}
     {% include 'qfdmo/_addresses_partials/filters/_labels_filters.html' %}

--- a/jinja2/qfdmo/_addresses_partials/filters/carte_filters.html
+++ b/jinja2/qfdmo/_addresses_partials/filters/carte_filters.html
@@ -7,9 +7,9 @@
 {% endblock %}
 
 {% block filters_content %}
-    {% if display_object_filter(request) %}
+    {% with hidden=display_object_filter(request) %}
         {% include 'qfdmo/_addresses_partials/filters/_object_filter.html' %}
-    {% endif %}
+    {% endwith %}
     {% include 'qfdmo/_addresses_partials/filters/_labels_filters.html' %}
 {% endblock %}
 


### PR DESCRIPTION
- ajout de la variable d'environnement utile à l'API LVAO au fichier .env.template
- masquage CSS dans le DOM du champ de filtrage des objets plutôt que de l'en supprimer pour corriger une régression depuis https://github.com/incubateur-ademe/quefairedemesobjets/commit/5e87ed0b0d05763712c807ba9baad96053038bf8