### PR TITLE
Track product interactions in posthog

### DIFF
--- a/jinja2/layout/base.html
+++ b/jinja2/layout/base.html
@@ -31,7 +31,10 @@
         {% endif %}
     </head>
 
-    <body class="qfdmo-flex qfdmo-flex-col" data-controller="analytics">
+    <body
+        class="qfdmo-flex qfdmo-flex-col"
+        data-controller="analytics"
+    >
         {% if not is_embedded(request) %}
             {% block header %}
                 {% include "layout/header.html" %}

--- a/jinja2/layout/base.html
+++ b/jinja2/layout/base.html
@@ -31,7 +31,7 @@
         {% endif %}
     </head>
 
-    <body class="qfdmo-flex qfdmo-flex-col">
+    <body class="qfdmo-flex qfdmo-flex-col" data-controller="analytics">
         {% if not is_embedded(request) %}
             {% block header %}
                 {% include "layout/header.html" %}

--- a/jinja2/qfdmo/_addresses_partials/map_and_detail.html
+++ b/jinja2/qfdmo/_addresses_partials/map_and_detail.html
@@ -163,7 +163,7 @@
                 <button class="fr-btn fr-btn--sm fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-arrow-up-s-line sm:qfdmo-hidden"
                     type='button'
                     data-action="click -> search-solution-form#displayFullDetails
-                    click -> analytics#captureInteractionWithASolution"
+                    click -> analytics#captureInteractionWithSolutionDetails"
                     data-search-solution-form-target="expandDetailsButton"
                     >
                     Ouvrir

--- a/jinja2/qfdmo/_addresses_partials/map_and_detail.html
+++ b/jinja2/qfdmo/_addresses_partials/map_and_detail.html
@@ -38,8 +38,9 @@
                 <div
                     class="qfdmo-flex-grow qfdmo-relative qfdmo-shadow"
                     data-controller="map"
+                    data-action="map:captureInteraction->analytics#captureInteractionWithMap"
                     data-map-location-value="{{ location }}"
-                >
+                    >
                     {{ form.bounding_box }}
                     <div id="map" class="qfdmo-absolute qfdmo-inset-0">
                     </div>
@@ -161,7 +162,8 @@
                 </button>
                 <button class="fr-btn fr-btn--sm fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-arrow-up-s-line sm:qfdmo-hidden"
                     type='button'
-                    data-action="click -> search-solution-form#displayFullDetails"
+                    data-action="click -> search-solution-form#displayFullDetails
+                    click -> analytics#captureInteractionWithASolution"
                     data-search-solution-form-target="expandDetailsButton"
                     >
                     Ouvrir

--- a/jinja2/qfdmo/adresse/detail.html
+++ b/jinja2/qfdmo/adresse/detail.html
@@ -54,7 +54,7 @@
             target="_blank"
             title="itinéraire"
             rel='noopener'
-            data-action="click -> analytics#captureInteractionWithASolution"
+            data-action="click -> analytics#captureInteractionWithSolutionDetails"
             >
             <span  class="fr-btn fr-icon-send-plane-line qfdmo-rounded-full"
             ></span>
@@ -64,7 +64,7 @@
     {% if adresse.url %}
         <a class="qfdmo-flex qfdmo-flex-col qfdmo-items-center qfdmo-no-underline qfdmo-bg-none qfdmo-no-external-link-icon"
             href="{{ adresse.url }}" target="_blank" title="Site Internet" rel='noopener'
-            data-action="click -> analytics#captureInteractionWithASolution"
+            data-action="click -> analytics#captureInteractionWithSolutionDetails"
             >
             <span class="fr-btn fr-btn--secondary-light fr-icon-global-line qfdmo-rounded-full">
             </span>
@@ -83,7 +83,7 @@
     {% if adresse.telephone %}
         <a class="qfdmo-flex qfdmo-flex-col qfdmo-items-center qfdmo-bg-none qfdmo-no-external-link-icon"
             href="tel:{{ adresse.telephone }}" title="Téléphone" rel='noopener'
-            data-action="click -> analytics#captureInteractionWithASolution"
+            data-action="click -> analytics#captureInteractionWithSolutionDetails"
             >
             <span class="fr-btn fr-btn--secondary-light fr-icon-phone-line qfdmo-rounded-full"
             ></span>
@@ -97,7 +97,7 @@
             type="button"
             aria-describedby="shareTooltip"
             aria-labelledby="detail-share-tooltip-label"
-            data-action="click -> analytics#captureInteractionWithASolution"
+            data-action="click -> analytics#captureInteractionWithSolutionDetails"
             >
         </button>
         <span class="fr-tooltip fr-placement" id="shareTooltip" role="tooltip" aria-hidden="true">
@@ -186,7 +186,7 @@
                     aria-selected="false"
                     aria-controls="infosPanel"
                     type="button"
-                    data-action="click -> analytics#captureInteractionWithASolution"
+                    data-action="click -> analytics#captureInteractionWithSolutionDetails"
                     >
                     Adresse
                 </button>
@@ -200,7 +200,7 @@
                     aria-selected="false"
                     aria-controls="labelsPanel"
                     type="button"
-                    data-action="click -> analytics#captureInteractionWithASolution"
+                    data-action="click -> analytics#captureInteractionWithSolutionDetails"
                     >
                     Labels
                 </button>
@@ -214,7 +214,7 @@
                     aria-selected="false"
                     aria-controls="sourcesPanel"
                     type="button"
-                    data-action="click -> analytics#captureInteractionWithASolution"
+                    data-action="click -> analytics#captureInteractionWithSolutionDetails"
                     >
                     Sources
                 </button>
@@ -366,7 +366,7 @@
     target="_blank"
     rel="noopener"
     title="Proposer une modification - Nouvelle fenêtre"
-    data-action="click -> analytics#captureInteractionWithASolution"
+    data-action="click -> analytics#captureInteractionWithSolutionDetails"
     >
     Proposer une modification
 </a>

--- a/jinja2/qfdmo/adresse/detail.html
+++ b/jinja2/qfdmo/adresse/detail.html
@@ -54,7 +54,8 @@
             target="_blank"
             title="itinéraire"
             rel='noopener'
-        >
+            data-action="click -> analytics#captureInteractionWithASolution"
+            >
             <span  class="fr-btn fr-icon-send-plane-line qfdmo-rounded-full"
             ></span>
             <span class="fr-text--xs fr-mb-0">Itinéraire</span>
@@ -63,7 +64,8 @@
     {% if adresse.url %}
         <a class="qfdmo-flex qfdmo-flex-col qfdmo-items-center qfdmo-no-underline qfdmo-bg-none qfdmo-no-external-link-icon"
             href="{{ adresse.url }}" target="_blank" title="Site Internet" rel='noopener'
-        >
+            data-action="click -> analytics#captureInteractionWithASolution"
+            >
             <span class="fr-btn fr-btn--secondary-light fr-icon-global-line qfdmo-rounded-full">
             </span>
             <span class="fr-text--xs fr-mb-0">Site web</span>
@@ -81,7 +83,8 @@
     {% if adresse.telephone %}
         <a class="qfdmo-flex qfdmo-flex-col qfdmo-items-center qfdmo-bg-none qfdmo-no-external-link-icon"
             href="tel:{{ adresse.telephone }}" title="Téléphone" rel='noopener'
-        >
+            data-action="click -> analytics#captureInteractionWithASolution"
+            >
             <span class="fr-btn fr-btn--secondary-light fr-icon-phone-line qfdmo-rounded-full"
             ></span>
             <span class="fr-text--xs fr-mb-0">Téléphone</span>
@@ -89,7 +92,13 @@
     {% endif %}
 
     <div class="qfdmo-flex qfdmo-flex-col qfdmo-items-center">
-        <button class="fr-btn fr-btn--secondary-light fr-icon-share-line qfdmo-rounded-full" type="button" aria-describedby="shareTooltip" aria-labelledby="detail-share-tooltip-label">
+        <button
+            class="fr-btn fr-btn--secondary-light fr-icon-share-line qfdmo-rounded-full"
+            type="button"
+            aria-describedby="shareTooltip"
+            aria-labelledby="detail-share-tooltip-label"
+            data-action="click -> analytics#captureInteractionWithASolution"
+            >
         </button>
         <span class="fr-tooltip fr-placement" id="shareTooltip" role="tooltip" aria-hidden="true">
             <span class="fr-share">
@@ -177,7 +186,8 @@
                     aria-selected="false"
                     aria-controls="infosPanel"
                     type="button"
-                >
+                    data-action="click -> analytics#captureInteractionWithASolution"
+                    >
                     Adresse
                 </button>
             </li>
@@ -190,7 +200,8 @@
                     aria-selected="false"
                     aria-controls="labelsPanel"
                     type="button"
-                >
+                    data-action="click -> analytics#captureInteractionWithASolution"
+                    >
                     Labels
                 </button>
             </li>
@@ -203,7 +214,8 @@
                     aria-selected="false"
                     aria-controls="sourcesPanel"
                     type="button"
-                >
+                    data-action="click -> analytics#captureInteractionWithASolution"
+                    >
                     Sources
                 </button>
             </li>
@@ -351,7 +363,10 @@
 
 <a class="fr-my-1w fr-btn fr-btn--tertiary qfdmo-whitespace-nowrap qfdmo-w-full qfdmo-justify-center"
     href="https://tally.so/r/3xMqd9?Nom={{adresse.nom}}&Ville={{adresse.ville}}&Adresse={{adresse.adresse}}"
-    target="_blank" rel="noopener" title="Proposer une modification - Nouvelle fenêtre"
->
+    target="_blank"
+    rel="noopener"
+    title="Proposer une modification - Nouvelle fenêtre"
+    data-action="click -> analytics#captureInteractionWithASolution"
+    >
     Proposer une modification
 </a>

--- a/static/to_compile/entrypoints/qfdmo.ts
+++ b/static/to_compile/entrypoints/qfdmo.ts
@@ -4,6 +4,7 @@ import * as Turbo from "@hotwired/turbo"
 
 import AddressAutocompleteController from "../src/address_autocomplete_controller"
 import MapController from "../src/map_controller"
+import AnalyticsController from "../src/analytics_controller"
 import SearchSolutionFormController from "../src/search_solution_form_controller"
 import SsCatObjectAutocompleteController from "../src/ss_cat_object_autocomplete_controller"
 
@@ -15,5 +16,6 @@ stimulus.register("map", MapController)
 stimulus.register("ss-cat-object-autocomplete", SsCatObjectAutocompleteController)
 stimulus.register("address-autocomplete", AddressAutocompleteController)
 stimulus.register("search-solution-form", SearchSolutionFormController)
+stimulus.register("analytics", AnalyticsController)
 
 Turbo.session.drive = false

--- a/static/to_compile/src/analytics.ts
+++ b/static/to_compile/src/analytics.ts
@@ -1,5 +1,4 @@
 import posthog from "posthog-js"
-import { InteractionType } from "./types"
 
 const posthogConfig = {
   api_host: "https://eu.posthog.com",
@@ -38,23 +37,5 @@ window.addEventListener("DOMContentLoaded", () => {
     }
   })
 })
-
-// Ci-dessous sont définis les événements utilisés côté métier
-// pour tracker l'activié des utilisteurs dans PostHog.
-//
-// Cette abstraction a été définie pour faciliter un éventuel changement d'outil futur.
-// Elle consiste simplement en :
-// - Une fonction nommée (en camelCase)
-// - Un appel à la méthode posthog.capture reprenant le nom de cette fonction dans la convention de nommage (snake_case)
-//
-// Il est important de ne pas intégrer trop de logique dans celle-ci, et de la conserver
-// dans les contrôleurs Stimulus.
-export function captureInteractionWithASolution(
-    specificInteractionType?: InteractionType,
-) {
-    posthog.capture("interaction_with_a_solution", {
-        specific_interaction_type: specificInteractionType,
-    })
-}
 
 export default posthog

--- a/static/to_compile/src/analytics.ts
+++ b/static/to_compile/src/analytics.ts
@@ -7,6 +7,7 @@ const posthogConfig = {
 
 if (process.env.NODE_ENV !== "development") {
   posthog.init("phc_SGbYOrenShCMKJOQYyl62se9ZqCHntjTlzgKNhrKnzm", posthogConfig)
+  posthog.debug()
 } else {
   // TODO : ce serait bien qu'on définisse ces variables dans l'environnement de build,
   // pour qu'elles soient écrites durant cette phase et

--- a/static/to_compile/src/analytics.ts
+++ b/static/to_compile/src/analytics.ts
@@ -9,6 +9,9 @@ const posthogConfig = {
 if (process.env.NODE_ENV !== "development") {
   posthog.init("phc_SGbYOrenShCMKJOQYyl62se9ZqCHntjTlzgKNhrKnzm", posthogConfig)
 } else {
+  // TODO : ce serait bien qu'on définisse ces variables dans l'environnement de build,
+  // pour qu'elles soient écrites durant cette phase et
+  // avoir un environnement PostHog dédié en staging
   posthog.init("phc_SwcKewoXg9MZyAIdl8qsyvwz3Vij8Vlrbr2SjEeN3u9", posthogConfig)
 }
 

--- a/static/to_compile/src/analytics.ts
+++ b/static/to_compile/src/analytics.ts
@@ -1,4 +1,5 @@
 import posthog from "posthog-js"
+import { InteractionType } from "./types"
 
 const posthogConfig = {
   api_host: "https://eu.posthog.com",
@@ -34,5 +35,13 @@ window.addEventListener("DOMContentLoaded", () => {
     }
   })
 })
+
+export function captureInteractionWithASolution(
+    specificInteractionType?: InteractionType,
+) {
+    posthog.capture("interaction_with_a_solution", {
+        specific_interaction_type: specificInteractionType,
+    })
+}
 
 export default posthog

--- a/static/to_compile/src/analytics.ts
+++ b/static/to_compile/src/analytics.ts
@@ -36,6 +36,16 @@ window.addEventListener("DOMContentLoaded", () => {
   })
 })
 
+// Ci-dessous sont définis les événements utilisés côté métier
+// pour tracker l'activié des utilisteurs dans PostHog.
+//
+// Cette abstraction a été définie pour faciliter un éventuel changement d'outil futur.
+// Elle consiste simplement en :
+// - Une fonction nommée (en camelCase)
+// - Un appel à la méthode posthog.capture reprenant le nom de cette fonction dans la convention de nommage (snake_case)
+//
+// Il est important de ne pas intégrer trop de logique dans celle-ci, et de la conserver
+// dans les contrôleurs Stimulus.
 export function captureInteractionWithASolution(
     specificInteractionType?: InteractionType,
 ) {

--- a/static/to_compile/src/analytics_controller.ts
+++ b/static/to_compile/src/analytics_controller.ts
@@ -1,23 +1,23 @@
 import { Controller } from "@hotwired/stimulus"
-import { InteractionDetails, InteractionType } from "./types"
+import { InteractionType, PosthogEventType } from "./types"
 import posthog from "posthog-js"
 
 export default class extends Controller<HTMLElement> {
-    // Ci-dessous sont définis les événements utilisés côté métier
-    // pour tracker l'activié des utilisteurs dans PostHog.
-    //
-    // Cette abstraction a été définie pour faciliter un éventuel changement d'outil futur.
-    // Elle consiste simplement en :
-    // - Une fonction nommée (en camelCase)
-    // - Un appel à la méthode posthog.capture reprenant le nom de cette fonction dans la convention de nommage (snake_case)
-    //
-    // Il est important de ne pas intégrer trop de logique dans celle-ci, et de la conserver
-    // dans les contrôleurs Stimulus.
-    captureInteractionWithASolution(
+    posthogWrapper(
+        posthogEvent: PosthogEventType,
         specificInteractionType?: InteractionType,
     ) {
-        posthog.capture("interaction_with_a_solution", {
+        console.debug("posthogWrapper", { posthogEvent, specificInteractionType })
+        posthog.capture(posthogEvent, {
             specific_interaction_type: specificInteractionType,
         })
+    }
+
+    captureInteractionWithASolution() {
+        this.posthogWrapper("interaction_with_a_solution")
+    }
+
+    captureInteractionWithMap() {
+        this.posthogWrapper("interaction_with_a_solution", "with_map")
     }
 }

--- a/static/to_compile/src/analytics_controller.ts
+++ b/static/to_compile/src/analytics_controller.ts
@@ -3,7 +3,7 @@ import { InteractionType as PosthogUIInteractionType, PosthogEventType } from ".
 import posthog from "posthog-js"
 
 export default class extends Controller<HTMLElement> {
-    // Sert principalement à type les appels à la   this.capturede Posthog.
+    // Sert principalement à type les appels à la méthode capture de Posthog.
     // Ça évite d'appeler un événement indéfini, ce qui peut rapidement polluer
     // les données stockées côtés PostHog.
     capture(posthogEvent: PosthogEventType, details: object) {

--- a/static/to_compile/src/analytics_controller.ts
+++ b/static/to_compile/src/analytics_controller.ts
@@ -1,23 +1,23 @@
 import { Controller } from "@hotwired/stimulus"
-import { InteractionType, PosthogEventType } from "./types"
+import { InteractionType as PosthogUIInteractionType, PosthogEventType } from "./types"
 import posthog from "posthog-js"
 
 export default class extends Controller<HTMLElement> {
-    posthogWrapper(
+    posthogCapture(
         posthogEvent: PosthogEventType,
-        specificInteractionType?: InteractionType,
+        uiInteractionType?: PosthogUIInteractionType,
     ) {
-        console.debug("posthogWrapper", { posthogEvent, specificInteractionType })
+        console.debug("posthogWrapper", { posthogEvent, specificInteractionType: uiInteractionType })
         posthog.capture(posthogEvent, {
-            specific_interaction_type: specificInteractionType,
+            ui_interaction_type: uiInteractionType,
         })
     }
 
-    captureInteractionWithASolution() {
-        this.posthogWrapper("interaction_with_a_solution")
+    captureInteractioncaptureInteractionWithSolutionDetailsDetails() {
+        this.posthogCapture("ui_interaction", "solution_details")
     }
 
     captureInteractionWithMap() {
-        this.posthogWrapper("interaction_with_a_solution", "with_map")
+        this.posthogCapture("ui_interaction", "map")
     }
 }

--- a/static/to_compile/src/analytics_controller.ts
+++ b/static/to_compile/src/analytics_controller.ts
@@ -3,20 +3,24 @@ import { InteractionType as PosthogUIInteractionType, PosthogEventType } from ".
 import posthog from "posthog-js"
 
 export default class extends Controller<HTMLElement> {
-    posthogCapture(
-        posthogEvent: PosthogEventType,
-        uiInteractionType?: PosthogUIInteractionType,
-    ) {
-        posthog.capture(posthogEvent, {
-            ui_interaction_type: uiInteractionType,
+    // Sert principalement à type les appels à la   this.capturede Posthog.
+    // Ça évite d'appeler un événement indéfini, ce qui peut rapidement polluer
+    // les données stockées côtés PostHog.
+    capture(posthogEvent: PosthogEventType, details: object) {
+        posthog.capture(posthogEvent, details)
+    }
+
+    captureUIInteraction(UIInteractionType: PosthogUIInteractionType) {
+        this.capture("ui_interaction", {
+            ui_interaction_type: UIInteractionType,
         })
     }
 
-    captureInteractioncaptureInteractionWithSolutionDetailsDetails() {
-        this.posthogCapture("ui_interaction", "solution_details")
+    captureInteractionWithSolutionDetails() {
+        this.captureUIInteraction("solution_details")
     }
 
     captureInteractionWithMap() {
-        this.posthogCapture("ui_interaction", "map")
+        this.captureUIInteraction("map")
     }
 }

--- a/static/to_compile/src/analytics_controller.ts
+++ b/static/to_compile/src/analytics_controller.ts
@@ -1,0 +1,23 @@
+import { Controller } from "@hotwired/stimulus"
+import { InteractionDetails, InteractionType } from "./types"
+import posthog from "posthog-js"
+
+export default class extends Controller<HTMLElement> {
+    // Ci-dessous sont définis les événements utilisés côté métier
+    // pour tracker l'activié des utilisteurs dans PostHog.
+    //
+    // Cette abstraction a été définie pour faciliter un éventuel changement d'outil futur.
+    // Elle consiste simplement en :
+    // - Une fonction nommée (en camelCase)
+    // - Un appel à la méthode posthog.capture reprenant le nom de cette fonction dans la convention de nommage (snake_case)
+    //
+    // Il est important de ne pas intégrer trop de logique dans celle-ci, et de la conserver
+    // dans les contrôleurs Stimulus.
+    captureInteractionWithASolution(
+        specificInteractionType?: InteractionType,
+    ) {
+        posthog.capture("interaction_with_a_solution", {
+            specific_interaction_type: specificInteractionType,
+        })
+    }
+}

--- a/static/to_compile/src/analytics_controller.ts
+++ b/static/to_compile/src/analytics_controller.ts
@@ -7,7 +7,6 @@ export default class extends Controller<HTMLElement> {
         posthogEvent: PosthogEventType,
         uiInteractionType?: PosthogUIInteractionType,
     ) {
-        console.debug("posthogWrapper", { posthogEvent, specificInteractionType: uiInteractionType })
         posthog.capture(posthogEvent, {
             ui_interaction_type: uiInteractionType,
         })

--- a/static/to_compile/src/map_controller.ts
+++ b/static/to_compile/src/map_controller.ts
@@ -2,8 +2,6 @@ import { Controller } from "@hotwired/stimulus"
 import debounce from "lodash/debounce"
 import { SolutionMap } from "./solution_map"
 import { Actor } from "./types"
-import { captureRejections } from "stream"
-import { captureInteractionWithASolution } from "./analytics"
 
 export default class extends Controller<HTMLElement> {
     static targets = ["acteur", "searchInZoneButton", "bbox"]
@@ -61,6 +59,6 @@ export default class extends Controller<HTMLElement> {
         this.dispatch("setSrcDetailsAddress", {
             detail: { identifiantUnique: identifiantUnique },
         })
-        captureInteractionWithASolution("with_map", "clic sur un pin point sur la carte / ouverture aperçu de la fiche")
+        this.dispatch("captureInteraction")
     }
 }

--- a/static/to_compile/src/map_controller.ts
+++ b/static/to_compile/src/map_controller.ts
@@ -2,6 +2,8 @@ import { Controller } from "@hotwired/stimulus"
 import debounce from "lodash/debounce"
 import { SolutionMap } from "./solution_map"
 import { Actor } from "./types"
+import { captureRejections } from "stream"
+import { captureInteractionWithASolution } from "./analytics"
 
 export default class extends Controller<HTMLElement> {
     static targets = ["acteur", "searchInZoneButton", "bbox"]
@@ -59,5 +61,6 @@ export default class extends Controller<HTMLElement> {
         this.dispatch("setSrcDetailsAddress", {
             detail: { identifiantUnique: identifiantUnique },
         })
+        captureInteractionWithASolution("with_map", "clic sur un pin point sur la carte / ouverture aperçu de la fiche")
     }
 }

--- a/static/to_compile/src/search_solution_form_controller.ts
+++ b/static/to_compile/src/search_solution_form_controller.ts
@@ -1,5 +1,4 @@
 import { Controller } from "@hotwired/stimulus"
-import { captureInteractioncaptureInteractionWithSolutionDetails } from "./analytics"
 
 export default class extends Controller<HTMLElement> {
     #selectedOption: string = ""

--- a/static/to_compile/src/search_solution_form_controller.ts
+++ b/static/to_compile/src/search_solution_form_controller.ts
@@ -1,5 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
-import { captureInteractionWithASolution } from "./analytics"
+import { captureInteractioncaptureInteractionWithSolutionDetails } from "./analytics"
 
 export default class extends Controller<HTMLElement> {
     #selectedOption: string = ""

--- a/static/to_compile/src/search_solution_form_controller.ts
+++ b/static/to_compile/src/search_solution_form_controller.ts
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { captureInteractionWithASolution } from "./analytics"
 
 export default class extends Controller<HTMLElement> {
     #selectedOption: string = ""
@@ -209,6 +210,7 @@ export default class extends Controller<HTMLElement> {
         this.detailsAddressPanelTarget.classList.add("sm:qfdmo-w-full")
         this.detailsAddressPanelTarget.classList.remove("sm:qfdmo-w-0")
         this.detailsAddressPanelTarget.classList.remove("sm:qfdmo-w-[480]")
+        captureInteractionWithASolution("with_details","ouverture de la fiche détaillée en grand “ouvrir” (sur mobile)")
     }
 
     displayActeurDetails(event) {

--- a/static/to_compile/src/search_solution_form_controller.ts
+++ b/static/to_compile/src/search_solution_form_controller.ts
@@ -210,7 +210,6 @@ export default class extends Controller<HTMLElement> {
         this.detailsAddressPanelTarget.classList.add("sm:qfdmo-w-full")
         this.detailsAddressPanelTarget.classList.remove("sm:qfdmo-w-0")
         this.detailsAddressPanelTarget.classList.remove("sm:qfdmo-w-[480]")
-        captureInteractionWithASolution("with_details","ouverture de la fiche détaillée en grand “ouvrir” (sur mobile)")
     }
 
     displayActeurDetails(event) {

--- a/static/to_compile/src/types.ts
+++ b/static/to_compile/src/types.ts
@@ -26,3 +26,5 @@ export class SSCatObject {
     sub_label: string
     identifier: int
 }
+
+export type InteractionType = "with_map"

--- a/static/to_compile/src/types.ts
+++ b/static/to_compile/src/types.ts
@@ -28,3 +28,4 @@ export class SSCatObject {
 }
 
 export type InteractionType = "with_map"
+export type PosthogEventType = "interaction_with_a_solution"

--- a/static/to_compile/src/types.ts
+++ b/static/to_compile/src/types.ts
@@ -28,4 +28,4 @@ export class SSCatObject {
 }
 
 export type InteractionType = "map" | "solution_details"
-export type PosthogEventType = "interaction_with_a_solution"
+export type PosthogEventType = "ui_interaction"

--- a/static/to_compile/src/types.ts
+++ b/static/to_compile/src/types.ts
@@ -27,5 +27,5 @@ export class SSCatObject {
     identifier: int
 }
 
-export type InteractionType = "with_map"
+export type InteractionType = "map" | "solution_details"
 export type PosthogEventType = "interaction_with_a_solution"


### PR DESCRIPTION
[Lien Notion](https://www.notion.so/accelerateur-transition-ecologique-ademe/Cr-ation-d-v-nement-pour-suivi-dans-Posthog-du-nombre-d-interactions-avec-une-solution-68e0ac7fdecd4943b3fe2fc055fa3857?pvs=4)

**Ajout d'appels à PostHog pour tracter les interactions utilisateurs avec l'interface.** 

- Création d'un controller stimulus agissant comme une couche d'abstraction entre la solution d'analytics et les appels : ça simplifiera le changement d'outil d'analytics dans le futur 

## Comment tester 
**En local :** 
- Aller sur http://localhost:8000/?carte
- Faire une recherche

**Les interactions ci-dessous peuvent être réalisées :**
-  un clic sur un pin point sur la carte / ouverture aperçu de la fiche
-  une ouverture de la fiche détaillée en grand “ouvrir” (sur mobile)
- un clic sur le bouton “Itinéraire”
- un clic sur le bouton “Téléphone”
- un clic sur bouton “site web”
- un clic sur le bouton “partager”
- un clic sur les onglets “Adresse”, “Sources”, “Labels”
- un clic sur le bouton “Proposer une modification”

Chacune de ces interactions va générer un événement dans le [PostHog de développement](https://eu.posthog.com/project/29745/activity/explore#q=%7B%22kind%22%3A%22DataTableNode%22%2C%22full%22%3Atrue%2C%22source%22%3A%7B%22kind%22%3A%22EventsQuery%22%2C%22select%22%3A%5B%22*%22%2C%22event%22%2C%22person%22%2C%22coalesce(properties.%24current_url%2C%20properties.%24screen_name)%20--%20Url%20%2F%20Screen%22%2C%22properties.%24lib%22%2C%22timestamp%22%2C%22properties.type%22%5D%2C%22orderBy%22%3A%5B%22timestamp%20DESC%22%5D%2C%22after%22%3A%22-24h%22%2C%22event%22%3A%22ui_interaction%22%2C%22properties%22%3A%5B%7B%22key%22%3A%22type%22%2C%22value%22%3A%5B%22solution_details%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D%7D%2C%22propertiesViaUrl%22%3Atrue%2C%22showSavedQueries%22%3Atrue%2C%22showPersistentColumnConfigurator%22%3Atrue%7D)
