### PR TITLE
add pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,14 @@ Description plus détaillée de l'intention, l'approche ou de l'implémentation 
 - [ ] Les changements nécessitent une mise à jour de documentation
 - [ ] Refactoring de code (explication à retrouver dans la description)
 
+## Auto-review
+
+Les trucs à faire avant de demander une review :
+- [ ] J'ai bien relu mon code
+- [ ] La CI passe bien
+- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
+- [ ] J'ai ajouté des tests qui couvrent le nouveau code
+
 ## Comment tester
 
 En local / staging :
@@ -19,14 +27,6 @@ En local / staging :
 - Aller sur http://localhost:8000
 - Cliquer sur ABC
 - …
-
-## Déploiement
-
-<!-- Dans le cas où il y a des instructions spécifiques de déploiement -->
-
-- Exécuter les migrations
-- Exécuter la commande `rf -rf /`
-- ...
 
 ## Développement local
 
@@ -37,10 +37,10 @@ En local / staging :
 - Rebuild la stack docker avec `docker compose build`
 - ...
 
-## Auto-review
+## Déploiement
 
-Les trucs à faire avant de demander une review :
-- [ ] J'ai bien relu mon code
-- [ ] La CI passe bien
-- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
-- [ ] J'ai ajouté des tests qui couvrent le nouveau code
+<!-- Dans le cas où il y a des instructions spécifiques de déploiement -->
+
+- Exécuter les migrations
+- Exécuter la commande `rf -rf /`
+- ...

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 # Description succincte du problème résolu
 
-Description de l'intention, l'approche ou de l'implémentation (ce qui n’est pas visible directement en lisant le code)
+Description plus détaillée de l'intention, l'approche ou de l'implémentation (ce qui n’est pas visible directement en lisant le code)
 
 <!-- Cocher la/les case.s appropriée.s -->
 **Type de changement** :

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+Description succincte du problème résolu
+
+Explication de l'implémentation (ce qui n’est pas visible directement en lisant le code)
+
+Type de changement :
+- [ ] Bug fix
+- [ ] Nouvelle fonctionnalité
+- [ ] Mise à jour de données / DAG
+- [ ] Les changements nécessitent une mise à jour de documentation
+
+## Comment tester
+En local / staging :
+- Aller sur http://localhost:8000
+- Cliquer sur ABC
+- …
+
+## Déploiement
+- Exécuter les migrations
+- Exécuter la commande `rf -rf /`
+- ...
+
+## Développement local
+
+- Mettre à jour le `.env`
+- Réinstaller les dépendances Python avec `pip install -r requirements.txt -r dev-requirements.txt`
+- Réinstaller les dépendances node avec `npm install`
+- Rebuild la stack docker avec `docker compose build`
+- ...
+
+## Auto-review
+
+Les trucs à faire avant de demander une review :
+
+- [ ] J'ai bien relu mon code
+- [ ] La CI passe bien
+- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
+- [ ] J'ai ajouté des tests qui couvrent le nouveau code

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,26 +1,33 @@
-Description succincte du problème résolu
+# Description succincte du problème résolu
 
-Explication de l'implémentation (ce qui n’est pas visible directement en lisant le code)
+Description de l'intention, l'approche ou de l'implémentation (ce qui n’est pas visible directement en lisant le code)
 
-Type de changement :
+<!-- Cocher la/les case.s appropriée.s -->
+**Type de changement** :
 - [ ] Bug fix
 - [ ] Nouvelle fonctionnalité
 - [ ] Mise à jour de données / DAG
 - [ ] Les changements nécessitent une mise à jour de documentation
 
 ## Comment tester
+
 En local / staging :
+- Récupérer la base de production
 - Aller sur http://localhost:8000
 - Cliquer sur ABC
 - …
 
 ## Déploiement
+
+<!-- Dans le cas où il y a des instructions spécifiques de déploiement -->
+
 - Exécuter les migrations
 - Exécuter la commande `rf -rf /`
 - ...
 
 ## Développement local
 
+<!-- Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe -->
 - Mettre à jour le `.env`
 - Réinstaller les dépendances Python avec `pip install -r requirements.txt -r dev-requirements.txt`
 - Réinstaller les dépendances node avec `npm install`
@@ -30,7 +37,6 @@ En local / staging :
 ## Auto-review
 
 Les trucs à faire avant de demander une review :
-
 - [ ] J'ai bien relu mon code
 - [ ] La CI passe bien
 - [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,7 @@
 # Description succincte du problème résolu
 
+Carte Notion : [Titre de la carte](https://notion.so/...)
+
 Description plus détaillée de l'intention, l'approche ou de l'implémentation (ce qui n’est pas visible directement en lisant le code)
 
 <!-- Cocher la/les case.s appropriée.s -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@ Description plus détaillée de l'intention, l'approche ou de l'implémentation 
 - [ ] Nouvelle fonctionnalité
 - [ ] Mise à jour de données / DAG
 - [ ] Les changements nécessitent une mise à jour de documentation
+- [ ] Refactoring de code (explication à retrouver dans la description)
 
 ## Comment tester
 


### PR DESCRIPTION
# [Version rendue visible ici](https://github.com/incubateur-ademe/quefairedemesobjets/blob/a759b50954c36b3ae997c5ad3555f543c6a6631d/.github/pull_request_template.md)

Cf Mattermost 

> **Suggestion** : est-ce que ça vous dirait qu'on se fasse un template de PR ? 
> 
> Je me retrouve assez souvent à devoir review des PRs sans avoir le contexte ou comprendre l'ampleur de la modification. 
> Et du coup je me retrouve à simplement relire le code, mais j'ai pas de moyen de me projeter plus que ça. 
> 
> Je trouverais ça utile d'avoir a minima : 
> 
> - Lien vers l'issue (si existante)
> - Ce qu'on essaye de résoudre en quelques mots
> - Comment tester - si on veut tester en local
> - Le type de changement : bugfix, nouvelle fonctionnalité
> - Éventuellement les fonctionnalités impactées par la PR
> - Pour les PR complexes, les étapes requises pour le déploiement / dev local : mise à jour du .env, installation de dépendances, etc
> Ça nous permettra de gagner en qualité dans les reviews, et aussi de faciliter la review par quelqu'un qui connaît pas le sujet (quand je review des DAGs, ou que Hamza review du frontend par exemple). 
> 
> J'aime pas trop les usines à gaz, donc je suis pas forcément pour reprendre un template d'un autre repo, mais à titre d'exemple je mets quelques sources ci-dessous qui peuvent donner de l'inspiration. 
> 
> Références : 
> 
> Méthodo https://docs.github.com/fr/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
> Exemples https://mikatuo.com/blog/github-pull-request-template-with-examples/
