### PR TITLE
Fix issue related to share link from an iframe

### DIFF
--- a/e2e_tests/iframe.spec.ts
+++ b/e2e_tests/iframe.spec.ts
@@ -2,50 +2,50 @@ import { expect, test } from "@playwright/test"
 import exp = require("constants")
 
 test("iframe is loaded with correct parameter", async ({ page }) => {
-  await page.goto(`http://localhost:8000/test_iframe`, { waitUntil: "networkidle" })
+    await page.goto(`http://localhost:8000/test_iframe`, { waitUntil: "networkidle" })
 
-  const titlePage = await page.title()
-  expect(titlePage).toBe("IFrame test : QFDMO")
+    const titlePage = await page.title()
+    expect(titlePage).toBe("IFrame test : QFDMO")
 
-  // Check if the iframe is loaded
-  const iframeElement = await page.$("iframe")
+    // Check if the iframe is loaded
+    const iframeElement = await page.$("iframe")
 
-  // test attribute allow="geolocation" is present
-  const iframeAllowAttribute = await iframeElement?.getAttribute("allow")
-  expect(iframeAllowAttribute).toBe("geolocation")
+    // test attribute allow="geolocation" is present
+    const iframeAllowAttribute = await iframeElement?.getAttribute("allow")
+    expect(iframeAllowAttribute).toBe("geolocation; clipboard-write")
 
-  // <iframe  ></iframe>
-  const iframeSrcAttribute = await iframeElement?.getAttribute("src")
-  expect(iframeSrcAttribute).toBe(
-    "http://localhost:8000?iframe=1&direction=jai&first_dir=jai&action_list=reparer%7Cechanger%7Cmettreenlocation%7Crevendre",
-  )
+    // <iframe  ></iframe>
+    const iframeSrcAttribute = await iframeElement?.getAttribute("src")
+    expect(iframeSrcAttribute).toBe(
+        "http://localhost:8000?iframe=1&direction=jai&first_dir=jai&action_list=reparer%7Cechanger%7Cmettreenlocation%7Crevendre",
+    )
 
-  const iframeFrameborderAttribute = await iframeElement?.getAttribute("frameborder")
-  expect(iframeFrameborderAttribute).toBe("0")
-  const iframeScrollingAttribute = await iframeElement?.getAttribute("scrolling")
-  expect(iframeScrollingAttribute).toBe("no")
-  const iframeAllowfullscreenAttribute =
-    await iframeElement?.getAttribute("allowfullscreen")
-  expect(iframeAllowfullscreenAttribute).toBe("true")
-  const iframeStyleAttribute = await iframeElement?.getAttribute("style")
-  expect(iframeStyleAttribute).toContain("width: 100%;")
-  expect(iframeStyleAttribute).toContain("height: 100vh;")
-  expect(iframeStyleAttribute).toContain("max-width: 800px;")
-  const iframeTitleAttribute = await iframeElement?.getAttribute("title")
-  expect(iframeTitleAttribute).toBe("Longue vie aux objets")
+    const iframeFrameborderAttribute = await iframeElement?.getAttribute("frameborder")
+    expect(iframeFrameborderAttribute).toBe("0")
+    const iframeScrollingAttribute = await iframeElement?.getAttribute("scrolling")
+    expect(iframeScrollingAttribute).toBe("no")
+    const iframeAllowfullscreenAttribute =
+        await iframeElement?.getAttribute("allowfullscreen")
+    expect(iframeAllowfullscreenAttribute).toBe("true")
+    const iframeStyleAttribute = await iframeElement?.getAttribute("style")
+    expect(iframeStyleAttribute).toContain("width: 100%;")
+    expect(iframeStyleAttribute).toContain("height: 100vh;")
+    expect(iframeStyleAttribute).toContain("max-width: 800px;")
+    const iframeTitleAttribute = await iframeElement?.getAttribute("title")
+    expect(iframeTitleAttribute).toBe("Longue vie aux objets")
 })
 
 test("the form is visible in the iframe", async ({ page }) => {
-  await page.goto(`http://localhost:8000/test_iframe`, { waitUntil: "networkidle" })
+    await page.goto(`http://localhost:8000/test_iframe`, { waitUntil: "networkidle" })
 
-  const iframeElement = await page.$("iframe")
-  const iframe = await iframeElement?.contentFrame()
-  const form = await iframe?.$("#search_form")
-  expect(form).not.toBeNull()
+    const iframeElement = await page.$("iframe")
+    const iframe = await iframeElement?.contentFrame()
+    const form = await iframe?.$("#search_form")
+    expect(form).not.toBeNull()
 
-  const height = await iframe?.$eval(
-    "[data-test-id='form-content']",
-    (el) => (el as HTMLElement).offsetHeight,
-  )
-  expect(height).toBeGreaterThan(600)
+    const height = await iframe?.$eval(
+        "[data-test-id='form-content']",
+        (el) => (el as HTMLElement).offsetHeight,
+    )
+    expect(height).toBeGreaterThan(600)
 })

--- a/iframe_without_js.html
+++ b/iframe_without_js.html
@@ -24,7 +24,7 @@
             id="myiframe"
             frameborder="0"
             scrolling="no"
-            allow="geolocation"
+            allow="geolocation; clipboard-write"
             style="width: 100%; overflow: hidden; max-width: 800px; height: 579px;"
             allowfullscreen="true"
             webkitallowfullscreen="true"

--- a/static/to_compile/entrypoints/iframe_functions.ts
+++ b/static/to_compile/entrypoints/iframe_functions.ts
@@ -9,7 +9,7 @@ function compileIframeAttributes(
         id: "lvao_iframe",
         frameBorder: "0",
         scrolling: "no",
-        allow: "geolocation",
+        allow: "geolocation; clipboard-write",
         allowFullscreen: true,
         title: "Longue vie aux objets",
         style: `overflow: hidden; max-width: ${maxWidth}; width: 100%; height: ${height};`,


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [En mode iFrame, l’hyperlien derrière le bouton Partager ne fonctionne plus (depuis la nouvelle carte)](https://www.notion.so/accelerateur-transition-ecologique-ademe/En-mode-iFrame-l-hyperlien-derri-re-le-bouton-Partager-ne-fonctionne-plus-depuis-la-nouvelle-carte-bb97f81d482749f982e6168ebcf85b1d?pvs=4)

Manque une permission lors de l'appel de l'iframe pour permettre d'utiliser le clipboard

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :
- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :
- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [x] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- Afficher le configurateur dans Chrome
- Afficher le détail d'une adresse
- Cliquer sur `partager` par `lien`
- Le lien doit être copié dans le clipboard

## Développement local

N/A

## Déploiement

N/A
