### PR TITLE
fix l'ordre des actions dans le mode carte

### DIFF
--- a/qfdmo/models/acteur.py
+++ b/qfdmo/models/acteur.py
@@ -402,6 +402,20 @@ class DisplayedActeur(BaseActeur):
         if action_list:
             actions = [a for a in actions if a.code in action_list.split("|")]
 
+        # sort actions
+        if carte:
+
+            def sort_key(a):
+                return (a.order or 0) + (
+                    a.groupe_action.order
+                    if a.groupe_action and a.groupe_action.order
+                    else 0
+                ) * 100
+
+            actions = sorted(actions, key=sort_key)
+        else:
+            actions = sorted(actions, key=lambda a: a.order or 0)
+
         # move action_principale as first of the list
         if self.action_principale in actions:
             actions.remove(self.action_principale)

--- a/unit_tests/qfdmo/test_acteur.py
+++ b/unit_tests/qfdmo/test_acteur.py
@@ -344,23 +344,23 @@ class TestDisplayedActionJsonActeurForDisplay:
         displayed_acteur = DisplayedActeurFactory()
         directionjai = ActionDirectionFactory(code="jai")
         directionjecherche = ActionDirectionFactory(code="jecherche")
-        groupeaction1 = GroupeActionFactory(
+        groupeaction1order2 = GroupeActionFactory(
             code="groupe1",
             icon="icon-groupeaction1",
             couleur="couleur-groupeaction1",
-            order=1,
+            order=2,
         )
-        groupeaction2 = GroupeActionFactory(
+        groupeaction2order1 = GroupeActionFactory(
             code="groupe2",
             icon="icon-groupeaction2",
             couleur="couleur-groupeaction2",
-            order=2,
+            order=1,
         )
         action1 = ActionFactory(
             code="actionjai1",
             icon="icon-actionjai1",
             couleur="couleur-actionjai1",
-            groupe_action=groupeaction1,
+            groupe_action=groupeaction1order2,
             order=1,
         )
         action1.directions.add(directionjai)
@@ -368,7 +368,7 @@ class TestDisplayedActionJsonActeurForDisplay:
             code="actionjai2",
             icon="icon-actionjai2",
             couleur="couleur-actionjai2",
-            groupe_action=groupeaction2,
+            groupe_action=groupeaction2order1,
             order=2,
         )
         action2.directions.add(directionjai)
@@ -376,7 +376,7 @@ class TestDisplayedActionJsonActeurForDisplay:
             code="actionjecherche1",
             icon="icon-actionjecherche1",
             couleur="couleur-actionjecherche1",
-            groupe_action=groupeaction1,
+            groupe_action=groupeaction1order2,
             order=3,
         )
         action3.directions.add(directionjecherche)
@@ -384,7 +384,7 @@ class TestDisplayedActionJsonActeurForDisplay:
             code="actionjecherche2",
             icon="icon-actionjecherche2",
             couleur="couleur-actionjecherche2",
-            groupe_action=groupeaction2,
+            groupe_action=groupeaction2order1,
             order=4,
         )
         action4.directions.add(directionjecherche)
@@ -459,8 +459,8 @@ class TestDisplayedActionJsonActeurForDisplay:
 
         assert acteur_for_display["identifiant_unique"] is not None
         assert acteur_for_display["location"] is not None
-        assert acteur_for_display["icon"] == "icon-groupeaction1"
-        assert acteur_for_display["couleur"] == "couleur-groupeaction1"
+        assert acteur_for_display["icon"] == "icon-groupeaction2"
+        assert acteur_for_display["couleur"] == "couleur-groupeaction2"
 
     def test_json_acteur_for_display_carte_direction(self, displayed_acteur):
 
@@ -471,22 +471,22 @@ class TestDisplayedActionJsonActeurForDisplay:
 
         assert acteur_for_display["identifiant_unique"] is not None
         assert acteur_for_display["location"] is not None
-        assert acteur_for_display["icon"] == "icon-groupeaction1"
-        assert acteur_for_display["couleur"] == "couleur-groupeaction1"
+        assert acteur_for_display["icon"] == "icon-groupeaction2"
+        assert acteur_for_display["couleur"] == "couleur-groupeaction2"
 
     def test_json_acteur_for_display_carte_action_list(self, displayed_acteur):
 
         CachedDirectionAction.reload_cache()
         acteur_for_display = json.loads(
             displayed_acteur.json_acteur_for_display(
-                carte=True, action_list="actionjai2|actionjecherche2"
+                carte=True, action_list="actionjai1|actionjecherche1"
             )
         )
 
         assert acteur_for_display["identifiant_unique"] is not None
         assert acteur_for_display["location"] is not None
-        assert acteur_for_display["icon"] == "icon-groupeaction2"
-        assert acteur_for_display["couleur"] == "couleur-groupeaction2"
+        assert acteur_for_display["icon"] == "icon-groupeaction1"
+        assert acteur_for_display["couleur"] == "couleur-groupeaction1"
 
         CachedDirectionAction.reload_cache()
         acteur_for_display = json.loads(
@@ -497,8 +497,8 @@ class TestDisplayedActionJsonActeurForDisplay:
 
         assert acteur_for_display["identifiant_unique"] is not None
         assert acteur_for_display["location"] is not None
-        assert acteur_for_display["icon"] == "icon-groupeaction1"
-        assert acteur_for_display["couleur"] == "couleur-groupeaction1"
+        assert acteur_for_display["icon"] == "icon-groupeaction2"
+        assert acteur_for_display["couleur"] == "couleur-groupeaction2"
 
     def test_json_acteur_for_display_action_principale_basic(self, displayed_acteur):
         displayed_acteur.action_principale = ActionFactory(code="actionjai2")


### PR DESCRIPTION
# Description succincte du problème résolu

Suite a l'implémentation de l'action principale de l'acteur, les actions n'étaient pas correctement triées

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :
- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :
- [x] J'ai bien relu mon code
- [ ] La CI passe bien

## Comment tester

En local / staging :
- En mode carte, les boites à livre doivent afficher l'icone `donner` au lieu de `echanger`

