### PR TITLE
set posthog debug in dvelopment env

### DIFF
--- a/static/to_compile/src/analytics.ts
+++ b/static/to_compile/src/analytics.ts
@@ -7,12 +7,12 @@ const posthogConfig = {
 
 if (process.env.NODE_ENV !== "development") {
   posthog.init("phc_SGbYOrenShCMKJOQYyl62se9ZqCHntjTlzgKNhrKnzm", posthogConfig)
-  posthog.debug()
 } else {
   // TODO : ce serait bien qu'on définisse ces variables dans l'environnement de build,
   // pour qu'elles soient écrites durant cette phase et
   // avoir un environnement PostHog dédié en staging
   posthog.init("phc_SwcKewoXg9MZyAIdl8qsyvwz3Vij8Vlrbr2SjEeN3u9", posthogConfig)
+  posthog.debug()
 }
 
 window.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [Passer tracking Matomo et Posthog en cookieless](https://www.notion.so/accelerateur-transition-ecologique-ademe/Passer-tracking-Matomo-et-Posthog-en-cookieless-18a72684982c42bca564b2a9fce39cfd?pvs=4)

Mettre en place le mode debug en environnement de developpement et non dans les autres environnement comme fait actuellement

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :
- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :
- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En preprod :
- Vérifier la dépose de cookie en preprod

## Développement local

N/A

## Déploiement

N/A
