### PR TITLE
Afficher l'adresse et l'onglet adresse quand l'acteur n'a pas d'adresse mais a un CP et/ou une ville

### DIFF
--- a/core/jinja2_handler.py
+++ b/core/jinja2_handler.py
@@ -46,7 +46,8 @@ def action_by_direction(request: HttpRequest, direction: str):
 
 def display_infos_panel(adresse: DisplayedActeur) -> bool:
     return (
-        bool(adresse.horaires_description or adresse.adresse) and not adresse.is_digital
+        bool(adresse.horaires_description or adresse.display_postal_address())
+        and not adresse.is_digital
     )
 
 

--- a/jinja2/qfdmo/adresse/detail.html
+++ b/jinja2/qfdmo/adresse/detail.html
@@ -304,7 +304,7 @@
                 </div>
             {% endif %}
 
-            {% if adresse.adresse %}
+            {% if adresse.display_postal_address() %}
                 <h3 class="fr-text--sm fr-m-0 qfdmo-text-grey-425">Adresse</h3>
                 <div class="fr-p-1w fr-my-1w qfdmo-bg-grey-975">
                     {{ adresse.adresse|title }}<br>

--- a/jinja2/qfdmo/adresse/detail.html
+++ b/jinja2/qfdmo/adresse/detail.html
@@ -307,11 +307,18 @@
             {% if adresse.display_postal_address() %}
                 <h3 class="fr-text--sm fr-m-0 qfdmo-text-grey-425">Adresse</h3>
                 <div class="fr-p-1w fr-my-1w qfdmo-bg-grey-975">
-                    {{ adresse.adresse|title }}<br>
+                    {% if adresse.adresse %}
+                        {{ adresse.adresse|title }}<br>
+                    {% endif %}
                     {% if adresse.adresse_complement %}
                         {{ adresse.adresse_complement }}<br>
                     {% endif %}
-                    {{ adresse.code_postal }} {{ adresse.ville|title }}
+                    {% if adresse.code_postal %}
+                        {{ adresse.code_postal }}
+                    {% endif %}
+                    {% if adresse.ville %}
+                        {{ adresse.ville|title }}
+                    {% endif %}
                 </div>
             {% endif %}
 

--- a/qfdmo/models/acteur.py
+++ b/qfdmo/models/acteur.py
@@ -435,6 +435,11 @@ class DisplayedActeur(BaseActeur):
 
         return orjson.dumps(acteur_dict).decode("utf-8")
 
+    def display_postal_address(self):
+        return bool(
+            self.adresse or self.adresse_complement or self.code_postal or self.ville
+        )
+
 
 class DisplayedActeurTemp(BaseActeur):
     labels = models.ManyToManyField(

--- a/qfdmo/models/acteur.py
+++ b/qfdmo/models/acteur.py
@@ -435,7 +435,7 @@ class DisplayedActeur(BaseActeur):
 
         return orjson.dumps(acteur_dict).decode("utf-8")
 
-    def display_postal_address(self):
+    def display_postal_address(self) -> bool:
         return bool(
             self.adresse or self.adresse_complement or self.code_postal or self.ville
         )

--- a/unit_tests/qfdmo/test_acteur.py
+++ b/unit_tests/qfdmo/test_acteur.py
@@ -564,4 +564,5 @@ class TestDisplayedActeurDisplayPostalAddress:
     )
     def test_display_postal_address_not_empty(self, fields):
         displayed_acteur = DisplayedActeurFactory.build(**fields)
+
         assert displayed_acteur.display_postal_address() is True

--- a/unit_tests/qfdmo/test_acteur.py
+++ b/unit_tests/qfdmo/test_acteur.py
@@ -3,6 +3,7 @@ import json
 import pytest
 from django.contrib.gis.geos import Point
 from django.forms import ValidationError, model_to_dict
+from factory import Faker
 
 from qfdmo.models import (
     Acteur,
@@ -337,7 +338,7 @@ class TestDisplayActeurActeurActions:
 
 
 @pytest.mark.django_db
-class TestDisplayedActionJsonActeurForDisplay:
+class TestDisplayedActeurJsonActeurForDisplay:
 
     @pytest.fixture
     def displayed_acteur(self):
@@ -543,3 +544,24 @@ class TestDisplayedActionJsonActeurForDisplay:
         assert acteur_for_display["location"] is not None
         assert acteur_for_display["icon"] == "icon-actionjai1"
         assert acteur_for_display["couleur"] == "couleur-actionjai1"
+
+
+class TestDisplayedActeurDisplayPostalAddress:
+
+    def test_display_postal_address_empty(self):
+        displayed_acteur = DisplayedActeurFactory.build()
+
+        assert displayed_acteur.display_postal_address() is False
+
+    @pytest.mark.parametrize(
+        "fields",
+        [
+            {"adresse": Faker("address")},
+            {"adresse_complement": Faker("address")},
+            {"code_postal": Faker("postalcode")},
+            {"ville": Faker("city")},
+        ],
+    )
+    def test_display_postal_address_not_empty(self, fields):
+        displayed_acteur = DisplayedActeurFactory.build(**fields)
+        assert displayed_acteur.display_postal_address() is True


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [Carte : manque l’onglet “Adresse” quand celle-ci n’est pas complète dans la BDD (même si on a bien la ville)](https://www.notion.so/accelerateur-transition-ecologique-ademe/Carte-manque-l-onglet-Adresse-quand-celle-ci-n-est-pas-compl-te-dans-la-BDD-m-me-si-on-a-bien-l-e4d102c8bea94d05bbe5e5e6ac70f485?pvs=4.)

L'adresse doit-être afficher même si il en manque une partie

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :
- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :
- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- Afficher des acteurs avec une adresse incomplète

## Développement local

N/A

## Déploiement

N/A