### PR TITLE
Les displayedacteurs doivent être modifiables en environnement de dev pour faciliter les tests

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -2,4 +2,7 @@ from django.conf import settings
 
 
 def environment(request):
-    return {"ENVIRONMENT": settings.ENVIRONMENT}
+    return {
+        "ENVIRONMENT": settings.ENVIRONMENT,
+        "DEBUG": settings.DEBUG,
+    }

--- a/qfdmo/admin/acteur.py
+++ b/qfdmo/admin/acteur.py
@@ -471,7 +471,7 @@ class DisplayedActeurAdmin(import_export_admin.ExportMixin, BaseActeurAdmin):
     resource_classes = [DisplayedActeurResource]
 
     def get_readonly_fields(self, request, obj=None):
-        if settings.ENVIRONMENT == "development":
+        if settings.DEBUG:
             return list(super().get_readonly_fields(request, obj))
         return [f.name for f in self.model._meta.fields if f.name != "location"]
 

--- a/qfdmo/admin/acteur.py
+++ b/qfdmo/admin/acteur.py
@@ -471,6 +471,8 @@ class DisplayedActeurAdmin(import_export_admin.ExportMixin, BaseActeurAdmin):
     resource_classes = [DisplayedActeurResource]
 
     def get_readonly_fields(self, request, obj=None):
+        if settings.ENVIRONMENT == "development":
+            return list(super().get_readonly_fields(request, obj))
         return [f.name for f in self.model._meta.fields if f.name != "location"]
 
     def has_add_permission(self, request: HttpRequest, obj=None) -> bool:

--- a/qfdmo/templates/admin/displayed_acteur/change_form.html
+++ b/qfdmo/templates/admin/displayed_acteur/change_form.html
@@ -9,7 +9,7 @@
             <a href="{% add_preserved_filters changelist_url %}" class="closelink">{% translate 'Close' %}</a>
         </div>
     {% endblock %}
-    {% if ENVIRONMENT == "development"%}
+    {% if DEBUG %}
         {{ block.super }}
     {% endif %}
 {% endblock %}

--- a/qfdmo/templates/admin/displayed_acteur/change_form.html
+++ b/qfdmo/templates/admin/displayed_acteur/change_form.html
@@ -9,4 +9,7 @@
             <a href="{% add_preserved_filters changelist_url %}" class="closelink">{% translate 'Close' %}</a>
         </div>
     {% endblock %}
+    {% if ENVIRONMENT == "development"%}
+        {{ block.super }}
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : N/A

Rendre modifiable les displayedacteur en environnement de dev permet de tester l'affichage des acteurs plus simplement sans avoir a lancer le DAG de compilation des acteurs

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :
- [ ] Bug fix
- [x] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :
- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- Editer un displayedacteur en local, ne pas pouvoir l'éditer en preprod et en prod

## Développement local

N/A

## Déploiement

N/A