### PR TITLE
Résoudre l'application de la direction en mode carte

### DIFF
--- a/jinja2/qfdmo/_addresses_partials/filters/carte_filters.html
+++ b/jinja2/qfdmo/_addresses_partials/filters/carte_filters.html
@@ -7,6 +7,13 @@
 {% endblock %}
 
 {% block filters_content %}
+    <input
+        id="{{ form.direction.id_for_label}}"
+        name="{{ form.direction.html_name}}"
+        value="{{ form.direction.value() }}"
+        type="hidden"
+        data-search-solution-form-target="direction"
+    >
     {% with hidden=hide_object_filter(request) %}
         {% include 'qfdmo/_addresses_partials/filters/_object_filter.html' %}
     {% endwith %}

--- a/static/to_compile/src/search_solution_form_controller.ts
+++ b/static/to_compile/src/search_solution_form_controller.ts
@@ -238,7 +238,7 @@ export default class extends Controller<HTMLElement> {
         }
         const direction = this.directionTarget
         // In "La Carte" mode, the direction is a hidden input
-        if (direction.tagName == "INPUT") {
+        if (direction instanceof HTMLInputElement) {
             this.#selectedOption = direction.value
             return
         }

--- a/static/to_compile/src/search_solution_form_controller.ts
+++ b/static/to_compile/src/search_solution_form_controller.ts
@@ -237,6 +237,12 @@ export default class extends Controller<HTMLElement> {
             return
         }
         const direction = this.directionTarget
+        // In "La Carte" mode, the direction is a hidden input
+        if (direction.tagName == "INPUT") {
+            this.#selectedOption = direction.value
+            return
+        }
+        // In form mode, the direction is a fieldset
         const options = direction.getElementsByTagName("input")
         for (let i = 0; i < options.length; i++) {
             if (options[i].checked && options[i].value == "jai") {


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [Le paramètre “direction” en mode carte est buggé](https://www.notion.so/accelerateur-transition-ecologique-ademe/Le-param-tre-direction-en-mode-carte-est-bugg-c2fd728bca1e4519ae773409bcf99ff6?pvs=4)

On garde la `direction` grâce à un input hidden
On affiche que les actions de la direction

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :
- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :
- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- Afficher la carte avec une direction et afficher un acteur

## Développement local

N/A

## Déploiement

N/A