### PR TITLE
[REGRESSION] afficher les propositions de services quand il n'y a pas de direction appliquée

### DIFF
--- a/jinja2/qfdmo/_addresses_partials/filters/carte_filters.html
+++ b/jinja2/qfdmo/_addresses_partials/filters/carte_filters.html
@@ -10,7 +10,7 @@
     <input
         id="{{ form.direction.id_for_label}}"
         name="{{ form.direction.html_name}}"
-        value="{{ form.direction.value() }}"
+        value="{{ form.direction.value() or '' }}"
         type="hidden"
         data-search-solution-form-target="direction"
     >

--- a/jinja2/qfdmo/_addresses_partials/map_and_detail.html
+++ b/jinja2/qfdmo/_addresses_partials/map_and_detail.html
@@ -183,7 +183,7 @@
                         <turbo-frame id="adr_detail"
                             data-search-solution-form-target="srcDetailsAddress"
                             {% if request.GET.get('detail') %}
-                                src="{{ url('qfdmo:adresse_detail', args=[request.GET.get('detail')])}}?{% if is_carte(request) %}carte=1&{% endif %}direction={{ direction }}&latitude={{ latitude }}&longitude={{ longitude }}"
+                                src="{{ url('qfdmo:adresse_detail', args=[request.GET.get('detail')])}}?{% if is_carte(request) %}carte=1&{% endif %}{% if direction %}direction={{ direction }}&{% endif %}latitude={{ latitude }}&longitude={{ longitude }}"
                             {% endif %}
                         >
                         </turbo-frame>


### PR DESCRIPTION


# Description succincte du problème résolu

Carte Notion : [Le paramètre “direction” en mode carte est buggé](https://www.notion.so/accelerateur-transition-ecologique-ademe/Le-param-tre-direction-en-mode-carte-est-bugg-c2fd728bca1e4519ae773409bcf99ff6?pvs=4)

Regression sur la carte détaillé qui n'affichait plus les propositions de service si aucune direction n'était configurée

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :
- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :
- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- Afficher une carte détaillée en mode carte les propositions de services doivent être affichées