### PR TITLE
add link to reparacteurs modal

### DIFF
--- a/jinja2/qfdmo/_addresses_partials/filters/_labels_filters.html
+++ b/jinja2/qfdmo/_addresses_partials/filters/_labels_filters.html
@@ -34,7 +34,6 @@
             </div>
             <span class="fr-hint-text">{{ form.label_reparacteur.help_text }}</span>
         </div>
-        {% include "qfdmo/partials/label_reparacteur_icon.html" %}
     </div>
 
     <div class="fr-fieldset__element fr-fieldset__element--inline qfdmo-font-normal">

--- a/qfdmo/forms.py
+++ b/qfdmo/forms.py
@@ -153,11 +153,26 @@ class AddressesForm(forms.Form):
         ),
         label="Label Répar’Acteurs",
         help_text=mark_safe(
-            "Afficher uniquement les artisans labellisés (uniquement valable lorsque le"
-            " geste « réparer » est sélectionné). En savoir plus <a href="
-            '"https://www.artisanat.fr/nous-connaitre/vous-accompagner/reparacteurs"'
-            ' target="_blank" rel="noreferrer" title="sur le site de la CMA - Nouvelle'
-            ' fenêtre"> sur le site de la CMA</a>'
+            """Afficher uniquement les artisans labellisés
+            (uniquement valable lorsque le geste « réparer » est sélectionné).
+            Les <span
+                class="qfdmo-underline qfdmo-cursor-pointer"
+                title="Ouvre la modale Répar'Acteurs"
+                onclick="document
+                .getElementById('display_modale_reparacteur')
+                .setAttribute('data-fr-opened', 'true');"
+            >
+                Répar'Acteurs
+            </span>
+             sont une initiative de la
+            <a
+                href='https://www.artisanat.fr/nous-connaitre/vous-accompagner/reparacteurs'
+                target="_blank"
+                rel="noreferrer"
+                title="sur le site de la CMA - Nouvelle fenêtre"
+            >
+                Chambre des Métiers et de l’Artisanat
+            </a>"""
         ),
         label_suffix="",
         required=False,

--- a/qfdmo/forms.py
+++ b/qfdmo/forms.py
@@ -156,14 +156,13 @@ class AddressesForm(forms.Form):
             """Afficher uniquement les artisans labellisés
             (uniquement valable lorsque le geste « réparer » est sélectionné).
             Les <span
-                class="qfdmo-underline qfdmo-cursor-pointer"
+                class="qfdmo-underline qfdmo-cursor-pointer
+                qfdmo-underline-offset-[3px] hover:qfdmo-decoration-[1.5px]"
                 title="Ouvre la modale Répar'Acteurs"
                 onclick="document
                 .getElementById('display_modale_reparacteur')
                 .setAttribute('data-fr-opened', 'true');"
-            >
-                Répar'Acteurs
-            </span>
+            >Répar'Acteurs</span>
              sont une initiative de la
             <a
                 href='https://www.artisanat.fr/nous-connaitre/vous-accompagner/reparacteurs'

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -63,6 +63,7 @@ module.exports = {
         "qfdmo-w-full",
         "qfdmo-text-white",
         "qfdmo-rounded-full",
+        "qfdmo-underline"
     ],
     theme: {
         colors: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -63,7 +63,10 @@ module.exports = {
         "qfdmo-w-full",
         "qfdmo-text-white",
         "qfdmo-rounded-full",
-        "qfdmo-underline"
+        "qfdmo-underline",
+        "hover:qfdmo-decoration-[1.5px]",
+        "qfdmo-underline-offset-[3px]"
+
     ],
     theme: {
         colors: {


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [[ACCESSIBILITÉ - CARTE] - Retirer le logo “Répar’acteurs” cliquable des filtres et le remplacer par un lien](https://www.notion.so/accelerateur-transition-ecologique-ademe/ACCESSIBILIT-CARTE-Retirer-le-logo-R-par-acteurs-cliquable-des-filtres-et-le-remplacer-par-u-17cd6e9244774af6b0bb4bdce4c29a38?pvs=4)

Remplacement de l'icône Réparacteur par un lien 

**Type de changement** :
- [x] Nouvelle fonctionnalité

## Auto-review

Les trucs à faire avant de demander une review :
- [ ] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- Aller sur http://localhost:8000
- Cliquer sur les filtres avancés 
- Un lien est présent sur le mot Reparacteur et ouvre la modale

<img width="1171" alt="image" src="https://github.com/user-attachments/assets/f1b3d126-8221-455e-8ae8-7e2dd340f522">
