### PR TITLE
Proposition de suppression du bouton  de la barre d'adresse

### DIFF
--- a/jinja2/qfdmo/_addresses_partials/adresse_input_form.html
+++ b/jinja2/qfdmo/_addresses_partials/adresse_input_form.html
@@ -8,6 +8,7 @@
          data-with-dynamic-form-panel={{"false" if is_carte(request) else "true"}}
          data-testid="rechercher-adresses-submit"
     >
+        <span class="qfdmo-italic qfdmo-text-sm">Taper et sélectionner une adresse ci-dessous pour lancer la recherche</span>
         <div class="form-group">
             {{ form.adresse.label_tag() }}
             {% if form.adresse.help_text %}

--- a/qfdmo/forms.py
+++ b/qfdmo/forms.py
@@ -28,7 +28,7 @@ class AutoCompleteInput(forms.TextInput):
 
 
 class AutoCompleteAndSearchInput(AutoCompleteInput):
-    template_name = "django/forms/widgets/autocomplete_and_search.html"
+    template_name = "django/forms/widgets/autocomplete.html"
 
     def __init__(self, attrs=None, btn_attrs={}, **kwargs):
         self.btn_attrs = btn_attrs
@@ -324,7 +324,7 @@ class CarteAddressesForm(AddressesForm):
             },
             data_controller="address-autocomplete",
             btn_attrs={
-                "data-action": "click -> search-solution-form#advancedSubmit",
+                "data-action": "click -> address-autocomplete#searchAndSubmit",
                 "type": "button",
                 "data-without-zone": "true",
             },

--- a/static/to_compile/src/address_autocomplete_controller.ts
+++ b/static/to_compile/src/address_autocomplete_controller.ts
@@ -45,6 +45,37 @@ export default class extends AutocompleteController {
             })
     }
 
+    async searchAndSubmit(): Promise<void> {
+        const inputTargetValue = this.inputTarget.value
+        const val = this.addAccents(inputTargetValue)
+        const regexPattern = new RegExp(val, "gi")
+
+        if (!val) this.closeAllLists()
+
+        let countResult = 0
+
+        return this.#getOptionCallback(inputTargetValue)
+            .then((data) => {
+                if (data.length > 1) {
+                    const [adresse, latitude, longitude] = data[1].split(SEPARATOR)
+                    console.log("adresse : ", adresse)
+                    console.log("longitude : ", longitude)
+                    console.log("latitude : ", latitude)
+                    this.inputTarget.value = adresse
+                    this.latitudeTarget.value = latitude
+                    this.longitudeTarget.value = longitude
+                    this.#hideInputError()
+                    this.dispatch("optionSelected")
+                    this.dispatch("formSubmit")
+                    return
+                }
+            })
+            .then(() => {
+                this.spinnerTarget.classList.add("qfdmo-hidden")
+                return
+            })
+    }
+
     selectOption(event: Event) {
         let target = event.target as HTMLElement
         while (target && target.nodeName !== "DIV") {
@@ -81,6 +112,10 @@ export default class extends AutocompleteController {
                             .then(() => {
                                 this.dispatch("optionSelected")
                             })
+                            .then(() => {
+                                // TODO : ajout d'une condition pour submit après sélection si selon une value du controller
+                                this.dispatch("formSubmit")
+                            })
                             .catch((error) => {
                                 console.error("error catched : ", error)
                                 this.hideSpinner()
@@ -96,6 +131,8 @@ export default class extends AutocompleteController {
             if (longitude) this.longitudeTarget.value = longitude
             if (latitude) this.latitudeTarget.value = latitude
             this.dispatch("optionSelected")
+            // TODO : ajout d'une condition pour submit après sélection si selon une value du controller
+            this.dispatch("formSubmit")
         }
         this.closeAllLists()
     }


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [Supprimer le bouton “rechercher” pour l’adresse au niveau de la carte](https://www.notion.so/accelerateur-transition-ecologique-ademe/Supprimer-le-bouton-rechercher-pour-l-adresse-au-niveau-de-la-carte-1113cdef565643d186bc08148ef31dc4?pvs=4)

La difficulté est de rester accessible : 
- Explication que la recherche est lancée quand l'utilisateur choisit une adresse
- Soumission du formulaire lors de la sélection de l'adresse

PR en DRAFT, RAF:
- Validation que c'est accessible
- Callback de soumission selon une valeur du controller stimulius

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :
- [ ] Bug fix
- [x] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :
- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- Rechercher 
