### PR TITLE
Conserver les actions à afficher lors de la recherche sur la carte

### DIFF
--- a/jinja2/qfdmo/_addresses_partials/filters/carte_filters.html
+++ b/jinja2/qfdmo/_addresses_partials/filters/carte_filters.html
@@ -14,6 +14,7 @@
         type="hidden"
         data-search-solution-form-target="direction"
     >
+    {{ form.action_displayed }}
     {% with hidden=hide_object_filter(request) %}
         {% include 'qfdmo/_addresses_partials/filters/_object_filter.html' %}
     {% endwith %}


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [Bug : gestes pas précochés apparaissent quand on utilise un filtre ESS](https://www.notion.so/accelerateur-transition-ecologique-ademe/Bug-gestes-pas-pr-coch-s-apparaissent-quand-on-utilise-un-filtre-ESS-3de5634488d9457483df9d1e106e0b8a?pvs=4)

Les `action_displayed` ne faisaient pas partie des champ de formulaire, si bien qu'on les perdait dès la première requête. Ils font désormais partie du formulaire via un `input` de type `hidden`

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :
- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :
- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- Avec le configurateur d'iFrame, créer une carte qui n'affiche pas toutes les actions
- Faire une nouvelle recherche
-> Les actions affichées doivent être celles demandées et pas plus

