### PR TITLE
Prise en compte de la foreignKey action_principale quand on crée un RévisionActeur

### DIFF
--- a/qfdmo/models/acteur.py
+++ b/qfdmo/models/acteur.py
@@ -355,6 +355,7 @@ class RevisionActeur(BaseActeur):
                         "id",
                         "acteur_type",
                         "source",
+                        "action_principale",
                         "proposition_services",
                         "acteur_services",
                         "labels",
@@ -366,6 +367,7 @@ class RevisionActeur(BaseActeur):
                     else ActeurType.objects.get(code="commerce")
                 ),
                 source=self.source,
+                action_principale=self.action_principale,
             )
             self.identifiant_unique = acteur.identifiant_unique
             self.identifiant_externe = acteur.identifiant_externe

--- a/unit_tests/qfdmo/test_acteur.py
+++ b/unit_tests/qfdmo/test_acteur.py
@@ -217,6 +217,20 @@ class TestCreateRevisionActeur:
         assert revision_acteur.source == acteur.source
         assert revision_acteur.acteur_type == acteur.acteur_type
 
+    def test_new_revision_acteur_with_action_principale(self):
+        acteur_type = ActeurTypeFactory(code="fake")
+        action_principale = ActionFactory(code="action 1")
+        revision_acteur = RevisionActeur.objects.create(
+            nom="Test Object 1",
+            location=Point(1, 1),
+            acteur_type=acteur_type,
+            action_principale=action_principale,
+        )
+        acteur = Acteur.objects.get(
+            identifiant_unique=revision_acteur.identifiant_unique
+        )
+        assert revision_acteur.action_principale == acteur.action_principale
+
 
 @pytest.mark.django_db
 class TestActeurService:


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [Err 500 : Action principale : Cannot assign](https://www.notion.so/accelerateur-transition-ecologique-ademe/Err-500-Action-principale-Cannot-assign-4-Acteur-action_principale-must-be-a-Action-insta-2c54d1eed3e34a2fbde0b254f6baa517?pvs=4)

la fonction `model_to_dict` extrait les `foreignKey` comme des `entier`. Pour contourner le problème, j'exclus les `foreignKey` de la fonction `model_to_dict` et je les ajoute aux paramètres nommés de la fonction `create` du manager

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :
- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :
- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- Créer un RevisionActeur avec une `Action pricinpale`, l'interface ne doit pas planter 

