### PR TITLE
Activation des filtres qui concernent la réparation en mode carte

### DIFF
--- a/static/to_compile/src/search_solution_form_controller.ts
+++ b/static/to_compile/src/search_solution_form_controller.ts
@@ -115,6 +115,17 @@ export default class extends Controller<HTMLElement> {
 
     connect() {
         this.displayActionList()
+
+        // Mode Carte
+        this.groupedActionInputTargets.forEach((groupedActionInput) => {
+            console.log(groupedActionInput)
+            if (groupedActionInput.value == "reparer") {
+                this.reparerFilterTargets.forEach((element: HTMLInputElement) => {
+                    element.disabled = !groupedActionInput.checked
+                })
+            }
+        })
+
         if (!this.isIframeValue) {
             this.scrollToContent()
         }
@@ -296,6 +307,8 @@ export default class extends Controller<HTMLElement> {
                 groupedActionInput.checked = eventTarget.checked
             }
         })
+        // Mode Carte
+        this.activeReparerFiltersCarte(event)
         this.advancedSubmit(event)
     }
 

--- a/static/to_compile/src/search_solution_form_controller.ts
+++ b/static/to_compile/src/search_solution_form_controller.ts
@@ -116,41 +116,52 @@ export default class extends Controller<HTMLElement> {
     connect() {
         this.displayActionList()
 
-        // Mode Carte
-        this.groupedActionInputTargets.forEach((groupedActionInput) => {
-            console.log(groupedActionInput)
-            if (groupedActionInput.value == "reparer") {
-                this.reparerFilterTargets.forEach((element: HTMLInputElement) => {
-                    element.disabled = !groupedActionInput.checked
-                })
-            }
-        })
-
         if (!this.isIframeValue) {
             this.scrollToContent()
         }
     }
 
     activeReparerFilters(activate: boolean = true) {
-        if (this.#selectedOption == "jai") {
-            if (this.reparerInputTarget.checked) {
-                this.reparerFilterTargets.forEach((element: HTMLInputElement) => {
-                    element.disabled = false
-                })
-                return
-            }
-        }
-        this.reparerFilterTargets.forEach((element: HTMLInputElement) => {
-            element.disabled = true
-        })
+        // Carte mode
+        this.activeReparerFiltersCarte()
+
+        // Form mode
+        this.activeReparerFiltersForm()
     }
 
-    activeReparerFiltersCarte(event: Event) {
-        const target = event.target as HTMLInputElement
-        if (target.value == "reparer") {
+    activeReparerFiltersForm() {
+        if (this.groupedActionInputTargets.length == 0) {
+            if (this.#selectedOption == "jai") {
+                if (this.reparerInputTarget.checked) {
+                    this.reparerFilterTargets.forEach((element: HTMLInputElement) => {
+                        element.disabled = false
+                    })
+                    return
+                }
+            }
             this.reparerFilterTargets.forEach((element: HTMLInputElement) => {
-                element.disabled = !target.checked
+                element.disabled = true
             })
+        }
+    }
+
+    activeReparerFiltersCarte() {
+        if (this.groupedActionInputTargets.length > 0) {
+            let reparerFilterIsDisplayed = false
+            this.groupedActionInputTargets.forEach((groupedActionInput) => {
+                if (groupedActionInput.value == "reparer") {
+                    reparerFilterIsDisplayed = true
+                    this.reparerFilterTargets.forEach((element: HTMLInputElement) => {
+                        element.disabled = !groupedActionInput.checked
+                    })
+                }
+                return reparerFilterIsDisplayed
+            })
+            if (!reparerFilterIsDisplayed) {
+                this.reparerFilterTargets.forEach((element: HTMLInputElement) => {
+                    element.disabled = true
+                })
+            }
         }
     }
 
@@ -308,7 +319,7 @@ export default class extends Controller<HTMLElement> {
             }
         })
         // Mode Carte
-        this.activeReparerFiltersCarte(event)
+        this.activeReparerFiltersCarte()
         this.advancedSubmit(event)
     }
 


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [Désactivation des options de réparation ne fonctionne pas en mode carte](https://www.notion.so/accelerateur-transition-ecologique-ademe/D-sactivation-des-options-de-r-paration-ne-fonctionne-pas-en-mode-carte-bdca30d0375f41b48f6733cd7cbc88c8?pvs=4)

Réfacto  des fonctions d'activation des gestes

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :
- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [x] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :
- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- Afficher ou pas l'option réparer 
- cocher par défaut l'option réparer 
- Cocher décocher l'option reparer
- en mode mobile et desktop
- vérifier que mes action de filtres réparer sont activer ou désactivé à propos
