### PR TITLE
Afficher un message quand il n'y a pas de solution

### DIFF
--- a/jinja2/qfdmo/_addresses_partials/map_and_detail.html
+++ b/jinja2/qfdmo/_addresses_partials/map_and_detail.html
@@ -49,7 +49,7 @@
                         data-turbo-frame="adresses"
                         data-action="click -> search-solution-form#advancedSubmit"
                         class="fr-btn fr-btn--sm fr-btn--secondary fr-m-1w fr-p-1v
-                        qfdmo-absolute qfdmo-z-[2000] qfdmo-right-0 qfdmo-hidden qfdmo-bg-white"
+                        qfdmo-absolute qfdmo-z-[1010] qfdmo-right-0 qfdmo-hidden qfdmo-bg-white"
                         type="button"
                         data-with-controls={{"false" if is_carte(request) else "true"}}
                         data-testid="searchInZone"
@@ -104,13 +104,13 @@
                                 <p class="qfdmo-max-w-xl qfdmo-text-lg mx-auto qfdmo-text-grey-50">
                                     Saisissez une adresse et recherchez des établissements à proximité qui vous aideront à remettre votre objet en circulation.</p>
                             </div>
-                            <div
-                                class="qfdmo-absolute qfdmo-inset-0 qfdmo-bg-white qfdmo-opacity-80 qfdmo-font-black qfdmo-z-[4000] {% if acteurs or not address_ok %} qfdmo-hidden{% endif %}"
-                                data-search-solution-form-target="NoLocalSolution"
-                            >
-                                <div class="qfdmo-flex qfdmo-h-full qfdmo-w-full qfdmo-items-center qfdmo-justify-center qfdmo-text-2xl sm:qfdmo-text-4xl qfdmo-text-center">
-                                    Il n'existe pas de solution {% if bounding_box %}dans cette zone{% else %}localisée proche de chez vous (&lt;30 km){% endif %}, essayez avec une autre combinaison de filtres.
-                                </div>
+                        </div>
+                        <div
+                            class="qfdmo-absolute qfdmo-inset-0 qfdmo-bg-white qfdmo-opacity-80 qfdmo-font-black qfdmo-z-[1020] {% if acteurs or not address_ok %} qfdmo-hidden{% endif %}"
+                            data-search-solution-form-target="NoLocalSolution"
+                        >
+                            <div class="qfdmo-flex qfdmo-h-full qfdmo-w-full qfdmo-items-center qfdmo-justify-center qfdmo-text-2xl sm:qfdmo-text-4xl qfdmo-text-center{% if is_carte(request) %} lg:qfdmo-pl-[350px]{% endif %}">
+                                Il n'existe pas de solution {% if bounding_box %}dans cette zone{% else %}localisée proche de chez vous (&lt;30 km){% endif %}, essayez avec une autre combinaison de filtres.
                             </div>
                         </div>
                     {% endwith %}

--- a/templates/django/forms/widgets/autocomplete.html
+++ b/templates/django/forms/widgets/autocomplete.html
@@ -21,7 +21,7 @@
         type="{{ widget.type }}"
         name="{{ widget.name }}"
         id="{{ widget.id }}"
-        {% if widget.value != None %} value="{{ widget.value.0|stringformat:'s' }}"{% endif %}
+        {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}
         {% include "django/forms/widgets/attrs.html" %}
         >
         <span data-{{ widget.data_controller }}-target="spinner" class="fr-icon-refresh-line qfdmo-absolute qfdmo-right-0 qfdmo-top-0 qfdmo-m-1w qfdmo-animate-spin qfdmo-hidden"></span>

--- a/templates/django/forms/widgets/autocomplete_and_search.html
+++ b/templates/django/forms/widgets/autocomplete_and_search.html
@@ -16,7 +16,7 @@
     type="{{ widget.type }}"
     name="{{ widget.name }}"
     id="{{ widget.name }}"
-    {% if widget.value != None %} value="{{ widget.value.0|stringformat:'s' }}"{% endif %}
+    {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}
     {% include "django/forms/widgets/attrs.html" %}
     >
     <span data-{{ widget.data_controller }}-target="spinner" class="fr-icon-refresh-line qfdmo-absolute qfdmo-right-0 qfdmo-top-0 qfdmo-m-1w qfdmo-animate-spin qfdmo-hidden"></span>


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [Message quand il n’y a pas de solution](https://www.notion.so/accelerateur-transition-ecologique-ademe/Message-quand-il-n-y-a-pas-de-solution-f4e7e2283b2246de8317c6d9659ecc27?pvs=4)

- Déplacement du layer qui ne s'affichait plus
- Permettre de modifier les filtres quand il n'y a pas de solution
- Fix d'iun pug d'affichage des dans la barre de recherche qui n'a rien à voir :)

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :
- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :
- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- Chercher quelques chose qui n'a pas de solution, ex : http://localhost:8000/?carte=&r=196&adresse=Rue+Anatole+France+01100+Oyonnax&longitude=5.657282&latitude=46.259178&bounding_box=&legend_grouped_action=donner%7Cechanger&legend_grouped_action=preter%7Cemprunter%7Clouer%7Cmettreenlocation&direction=&action_displayed=preter%7Cemprunter%7Clouer%7Cmettreenlocation%7Creparer%7Cdonner%7Cechanger%7Cacheter%7Crevendre%7Ctrier&sous_categorie_objet=Prot%C3%A8ge-tibia&sc_id=112&grouped_action=preter%7Cemprunter%7Clouer%7Cmettreenlocation
