### PR TITLE
Afficher toutes les sources d'un acteur

### DIFF
--- a/core/jinja2_handler.py
+++ b/core/jinja2_handler.py
@@ -44,6 +44,7 @@ def action_by_direction(request: HttpRequest, direction: str):
     return [{**a, "active": True} for a in actions_to_display]
 
 
+# TODO : should be deprecated and replaced by a value in context view
 def display_infos_panel(adresse: DisplayedActeur) -> bool:
     return (
         bool(adresse.horaires_description or adresse.display_postal_address())
@@ -51,6 +52,7 @@ def display_infos_panel(adresse: DisplayedActeur) -> bool:
     )
 
 
+# TODO : should be deprecated and replaced by a value in context view
 def display_exclusivite_reparation(acteur: DisplayedActeur) -> bool:
     return acteur.exclusivite_de_reprisereparation
 

--- a/core/jinja2_handler.py
+++ b/core/jinja2_handler.py
@@ -55,14 +55,6 @@ def display_exclusivite_reparation(acteur: DisplayedActeur) -> bool:
     return acteur.exclusivite_de_reprisereparation
 
 
-def display_labels_panel(adresse: DisplayedActeur) -> bool:
-    return bool(adresse.labels.filter(afficher=True, type_enseigne=False).count())
-
-
-def display_sources_panel(adresse: DisplayedActeur) -> bool:
-    return bool(adresse.source and adresse.source.afficher)
-
-
 def hide_object_filter(request) -> bool:
     return bool(request.GET.get("sc_id"))
 
@@ -88,8 +80,6 @@ def environment(**options):
         {
             "action_by_direction": action_by_direction,
             "display_infos_panel": display_infos_panel,
-            "display_sources_panel": display_sources_panel,
-            "display_labels_panel": display_labels_panel,
             "hide_object_filter": hide_object_filter,
             "distance_to_acteur": distance_to_acteur,
             "display_exclusivite_reparation": display_exclusivite_reparation,

--- a/integration_tests/qfdmo/test_adresse_detail.py
+++ b/integration_tests/qfdmo/test_adresse_detail.py
@@ -1,11 +1,47 @@
 import pytest
 from bs4 import BeautifulSoup
 
-from unit_tests.qfdmo.acteur_factory import DisplayedActeurFactory, LabelQualiteFactory
+from unit_tests.qfdmo.acteur_factory import (
+    DisplayedActeurFactory,
+    LabelQualiteFactory,
+    SourceFactory,
+)
+
+
+@pytest.mark.django_db
+class TestDisplaySource:
+    def test_display_no_source(self, client):
+        adresse = DisplayedActeurFactory()
+
+        url = f"/adresse/{adresse.identifiant_unique}"
+
+        response = client.get(url)
+        assert response.status_code == 200
+        assert response.context["display_sources_panel"] is False
+
+    def test_display_one_source(self, client):
+        adresse = DisplayedActeurFactory()
+        source = SourceFactory(afficher=True)
+        adresse.sources.add(source)
+
+        url = f"/adresse/{adresse.identifiant_unique}"
+
+        response = client.get(url)
+        assert response.status_code == 200
+        assert response.context["display_sources_panel"]
 
 
 @pytest.mark.django_db
 class TestDisplayLabel:
+    def test_display_no_label(self, client):
+        adresse = DisplayedActeurFactory()
+
+        url = f"/adresse/{adresse.identifiant_unique}"
+
+        response = client.get(url)
+        assert response.status_code == 200
+        assert response.context["display_labels_panel"] is False
+
     def test_display_ess_label(self, client):
         adresse = DisplayedActeurFactory()
         label_ess = LabelQualiteFactory(
@@ -19,6 +55,7 @@ class TestDisplayLabel:
 
         response = client.get(url)
         assert response.status_code == 200
+        assert response.context["display_labels_panel"]
 
         soup = BeautifulSoup(response.content, "html.parser")
         label_tag = soup.find(attrs={"data-testid": "adresse_detail_header_tag"})
@@ -37,6 +74,7 @@ class TestDisplayLabel:
 
         response = client.get(url)
         assert response.status_code == 200
+        assert response.context["display_labels_panel"]
 
         soup = BeautifulSoup(response.content, "html.parser")
         label_tag = soup.find(attrs={"data-testid": "adresse_detail_header_tag"})
@@ -59,6 +97,7 @@ class TestDisplayLabel:
 
         response = client.get(url)
         assert response.status_code == 200
+        assert response.context["display_labels_panel"]
 
         soup = BeautifulSoup(response.content, "html.parser")
         label_tag = soup.find(attrs={"data-testid": "adresse_detail_header_tag"})
@@ -78,6 +117,7 @@ class TestDisplayLabel:
 
         response = client.get(url)
         assert response.status_code == 200
+        assert response.context["display_labels_panel"]
 
         soup = BeautifulSoup(response.content, "html.parser")
         label_tag = soup.find(attrs={"data-testid": "adresse_detail_header_tag"})
@@ -110,6 +150,7 @@ class TestDisplayLabel:
 
         response = client.get(url)
         assert response.status_code == 200
+        assert response.context["display_labels_panel"]
 
         soup = BeautifulSoup(response.content, "html.parser")
         label_tag = soup.find(attrs={"data-testid": "adresse_detail_header_tag"})
@@ -133,6 +174,7 @@ class TestDisplayLabel:
 
         response = client.get(url)
         assert response.status_code == 200
+        assert response.context["display_labels_panel"]
 
         soup = BeautifulSoup(response.content, "html.parser")
         label_tag = soup.find(attrs={"data-testid": "adresse_detail_header_tag"})

--- a/jinja2/qfdmo/adresse/detail.html
+++ b/jinja2/qfdmo/adresse/detail.html
@@ -192,7 +192,7 @@
                 </button>
             </li>
         {% endif %}
-        {% if display_labels_panel(adresse) %}
+        {% if display_labels_panel %}
             <li role="presentation">
                 <button class="fr-tabs__tab fr-tabs__tab--noborder"
                     tabindex="-1"
@@ -206,7 +206,7 @@
                 </button>
             </li>
         {% endif %}
-        {% if display_sources_panel(adresse) %}
+        {% if display_sources_panel %}
             <li role="presentation">
                 <button class="fr-tabs__tab fr-tabs__tab--noborder"
                     tabindex="-1"
@@ -334,7 +334,7 @@
         </div>
     {% endif %}
 
-    {% if display_labels_panel(adresse) %}
+    {% if display_labels_panel %}
         <div id="labelsPanel"
             class="fr-tabs__panel"
             role="tabpanel"
@@ -349,14 +349,14 @@
         </div>
     {% endif %}
 
-    {% if display_sources_panel(adresse) %}
+    {% if display_sources_panel %}
         <div id="sourcesPanel"
             class="fr-tabs__panel"
             role="tabpanel"
             aria-labelledby="sourcesPanel"
             tabindex="0"
         >
-            {% with source_or_label_list=[adresse.source] %}
+            {% with source_or_label_list=adresse.sources.all() %}
                 {% include "qfdmo/_address_card_partials/source_or_label_list.html" %}
             {% endwith %}
         </div>

--- a/qfdmo/views/adresses.py
+++ b/qfdmo/views/adresses.py
@@ -519,7 +519,7 @@ def adresse_detail(request, identifiant_unique):
         "proposition_services__sous_categories__categorie",
         "proposition_services__action__groupe_action",
         "labels",
-        "source",
+        "sources",
     ).get(identifiant_unique=identifiant_unique)
 
     return render(
@@ -530,6 +530,12 @@ def adresse_detail(request, identifiant_unique):
             "latitude": latitude,
             "longitude": longitude,
             "direction": direction,
+            "display_labels_panel": any(
+                label.afficher for label in displayed_acteur.labels.all()
+            ),
+            "display_sources_panel": any(
+                source.afficher for source in displayed_acteur.sources.all()
+            ),
         },
     )
 

--- a/unit_tests/core/test_jinja2_handler.py
+++ b/unit_tests/core/test_jinja2_handler.py
@@ -8,18 +8,12 @@ from django.http import HttpRequest
 from core.jinja2_handler import (
     action_by_direction,
     display_infos_panel,
-    display_labels_panel,
-    display_sources_panel,
     distance_to_acteur,
     is_embedded,
 )
 from qfdmo.models import CachedDirectionAction
 from qfdmo.models.acteur import ActeurType
-from unit_tests.qfdmo.acteur_factory import (
-    ActeurTypeFactory,
-    DisplayedActeurFactory,
-    LabelQualiteFactory,
-)
+from unit_tests.qfdmo.acteur_factory import ActeurTypeFactory, DisplayedActeurFactory
 
 
 @pytest.fixture(scope="session")
@@ -182,35 +176,6 @@ class TestDisplayInfosPanel:
 
         adresse.adresse = None
         assert not display_infos_panel(adresse)
-
-
-@pytest.mark.django_db
-class TestDisplayLabelsPanel:
-
-    def test_display_labels_panel(self, adresse):
-        assert not display_labels_panel(adresse)
-        label = LabelQualiteFactory(
-            afficher=True,
-            type_enseigne=False,
-        )
-        adresse.labels.add(label)
-        assert display_labels_panel(adresse)
-        label.afficher = False
-        label.save()
-        assert not display_labels_panel(adresse)
-        label.afficher = True
-        label.type_enseigne = True
-        label.save()
-        assert not display_labels_panel(adresse)
-
-
-@pytest.mark.django_db
-class TestDisplaySourcesPanel:
-
-    def test_display_sources_panel(self, adresse):
-        assert display_sources_panel(adresse)
-        adresse.source.afficher = False
-        assert not display_sources_panel(adresse)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
# Description succincte du problème résolu

Suite à la déduplication des acteur à afficher, les acteur on maintenant plusieurs sources
Il faut donc afficher toutes les sources liée à un acteur contrairement à avant où une seule source était affichée

Ce développement dépend de la PR #781

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :
- [ ] Bug fix
- [x] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :
- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- Récupérer la base de production
- Aller sur http://localhost:8000
- Cliquer sur ABC
- …

## Développement local

<!-- Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe -->
- Mettre à jour le `.env`
- Réinstaller les dépendances Python avec `pip install -r requirements.txt -r dev-requirements.txt`
- Réinstaller les dépendances node avec `npm install`
- Rebuild la stack docker avec `docker compose build`
- ...

## Déploiement

<!-- Dans le cas où il y a des instructions spécifiques de déploiement -->

- Exécuter les migrations
- Exécuter la commande `rf -rf /`
- ...
