### PR TITLE
Remplacer chaussures par pantalon dans les suggestions en homepage

### DIFF
--- a/qfdmo/forms.py
+++ b/qfdmo/forms.py
@@ -69,7 +69,7 @@ class AddressesForm(forms.Form):
         widget=AutoCompleteInput(
             attrs={
                 "class": "fr-input fr-icon-search-line sm:qfdmo-w-[596px]",
-                "placeholder": "chaussures, perceuse, canapé...",
+                "placeholder": "pantalon, perceuse, canapé...",
                 "autocomplete": "off",
                 "aria-label": "Indiquer un objet - obligatoire",
             },


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [Changer suggestion automatique “chaussure” par “pantalon”](https://www.notion.so/accelerateur-transition-ecologique-ademe/Changer-suggestion-automatique-chaussure-par-pantalon-fff6523d57d780f6a789c8bc054d6a0b?pvs=4)

Remplacement du placeholder 

**Type de changement** :
- [ ] Bug fix
- [ ] Nouvelle fonctionnalité
- [x] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :
- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- Aller sur http://localhost:8000
- Vérifier que `Chaussures` ne s'affiche plus dans les suggestions du champ objet 

![image](https://github.com/user-attachments/assets/1d9f55e6-08f7-49e7-ab4b-cbc2bf5bdf13)

