### PR TITLE
Vérifier le format JSON de la bounding_box dans le cscript de l'iframe

### DIFF
--- a/static/to_compile/entrypoints/iframe_functions.ts
+++ b/static/to_compile/entrypoints/iframe_functions.ts
@@ -1,72 +1,84 @@
 function compileIframeAttributes(
-    baseUrl: string,
-    urlParams: URLSearchParams,
-    maxWidth: string,
-    height: string,
+  baseUrl: string,
+  urlParams: URLSearchParams,
+  maxWidth: string,
+  height: string,
 ): { [Property in keyof HTMLIFrameElement]?: unknown } {
-    return {
-        src: `${baseUrl}?${urlParams.toString()}`,
-        id: "lvao_iframe",
-        frameBorder: "0",
-        scrolling: "no",
-        allow: "geolocation; clipboard-write",
-        allowFullscreen: true,
-        title: "Longue vie aux objets",
-        style: `overflow: hidden; max-width: ${maxWidth}; width: 100%; height: ${height};`,
-    }
+  return {
+    src: `${baseUrl}?${urlParams.toString()}`,
+    id: "lvao_iframe",
+    frameBorder: "0",
+    scrolling: "no",
+    allow: "geolocation; clipboard-write",
+    allowFullscreen: true,
+    title: "Longue vie aux objets",
+    style: `overflow: hidden; max-width: ${maxWidth}; width: 100%; height: ${height};`,
+  }
+}
+
+function parseJSONDataset(dataset: string): any {
+  try {
+    return JSON.stringify(JSON.parse(dataset.replace(/'/g, '"')))
+  } catch (error) {
+    console.error("Failed to parse dataset:", error)
+    return null
+  }
 }
 
 export function buildAndInsertIframeFrom(
-    iframeAttributes: object,
-    iframeExtraAttributes: object,
-    scriptTag: HTMLScriptElement,
+  iframeAttributes: object,
+  iframeExtraAttributes: object,
+  scriptTag: HTMLScriptElement,
 ) {
-    const iframe = document.createElement("iframe")
-    for (var key in iframeAttributes) {
-        iframe.setAttribute(key, iframeAttributes[key])
-    }
-    for (var key in iframeExtraAttributes) {
-        iframe.setAttribute(key, iframeExtraAttributes[key])
-    }
-    scriptTag.insertAdjacentElement("afterend", iframe)
+  const iframe = document.createElement("iframe")
+  for (var key in iframeAttributes) {
+    iframe.setAttribute(key, iframeAttributes[key])
+  }
+  for (var key in iframeExtraAttributes) {
+    iframe.setAttribute(key, iframeExtraAttributes[key])
+  }
+  scriptTag.insertAdjacentElement("afterend", iframe)
 }
 
 export function getIframeAttributesAndExtra(
-    initialParameters: [string, string],
-    scriptTag: HTMLScriptElement,
-    options?: { maxWidth: string },
+  initialParameters: [string, string],
+  scriptTag: HTMLScriptElement,
+  options?: { maxWidth: string },
 ) {
-    let maxWidth = options?.maxWidth || "100%"
-    let height = "700px"
-    const BASE_URL = new URL(scriptTag.getAttribute("src")!).origin
+  let maxWidth = options?.maxWidth || "100%"
+  let height = "700px"
+  const BASE_URL = new URL(scriptTag.getAttribute("src")!).origin
 
-    const urlParams = new URLSearchParams()
-    urlParams.append(...initialParameters)
+  const urlParams = new URLSearchParams()
+  urlParams.append(...initialParameters)
 
-    let iframeExtraAttributes: { [Property in keyof HTMLScriptElement]?: unknown } = {}
+  let iframeExtraAttributes: { [Property in keyof HTMLScriptElement]?: unknown } = {}
 
-    for (const param in scriptTag.dataset) {
-        if (param === "max_width") {
-            maxWidth = scriptTag.dataset[param]!
-            continue
-        }
-        if (param === "height") {
-            height = scriptTag.dataset[param]!
-            continue
-        }
-        if (param === "iframe_attributes") {
-            iframeExtraAttributes = JSON.parse(scriptTag.dataset[param]!)
-            continue
-        }
-
-        urlParams.append(param, scriptTag.dataset[param]!)
+  for (const param in scriptTag.dataset) {
+    if (param === "max_width") {
+      maxWidth = scriptTag.dataset[param]!
+      continue
     }
+    if (param === "height") {
+      height = scriptTag.dataset[param]!
+      continue
+    }
+    if (param === "iframe_attributes") {
+      iframeExtraAttributes = JSON.parse(scriptTag.dataset[param]!)
+      continue
+    }
+    if (param === "bounding_box") {
+      urlParams.append(param, parseJSONDataset(scriptTag.dataset[param]!))
+      continue
+    }
+    urlParams.append(param, scriptTag.dataset[param]!)
+  }
 
-    const iframeAttributes = compileIframeAttributes(
-        BASE_URL,
-        urlParams,
-        maxWidth,
-        height,
-    )
-    return [iframeAttributes, iframeExtraAttributes]
+  const iframeAttributes = compileIframeAttributes(
+    BASE_URL,
+    urlParams,
+    maxWidth,
+    height,
+  )
+  return [iframeAttributes, iframeExtraAttributes]
 }


### PR DESCRIPTION
# Description succincte du problème résolu

Lorsque le JSON de la bounding box de l'iframe utilise des simples quotes, l'application n'arrive pas à interpréter la bounding_box

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :
- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :
- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- Récupérer la base de production
- Aller sur http://localhost:8000
- Cliquer sur ABC
- …

## Développement local

<!-- Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe -->
- Mettre à jour le `.env`
- Réinstaller les dépendances Python avec `pip install -r requirements.txt -r dev-requirements.txt`
- Réinstaller les dépendances node avec `npm install`
- Rebuild la stack docker avec `docker compose build`
- ...

## Déploiement

<!-- Dans le cas où il y a des instructions spécifiques de déploiement -->

- Exécuter les migrations
- Exécuter la commande `rf -rf /`
- ...
