### PR TITLE
Désactiver les acteurs d'EO qui accueillent uniquement des professionnels

### DIFF
--- a/dags/utils/dag_eo_utils.py
+++ b/dags/utils/dag_eo_utils.py
@@ -456,6 +456,8 @@ def create_actors(**kwargs):
     else:
         df = mapping_utils.process_actors(df)
 
+    # By default, all actors are active
+    # TODO : manage constant as an enum in config
     df["statut"] = "ACTIF"
 
     for old_col, new_col in column_mapping.items():

--- a/unit_tests/dags/utils/test_dag_eo_utils.py
+++ b/unit_tests/dags/utils/test_dag_eo_utils.py
@@ -662,13 +662,19 @@ def mock_config():
 class TestCreateActorSeriesTransformations:
 
     @pytest.mark.parametrize(
-        "public_accueilli,expected_public_accueilli",
+        "public_accueilli, expected_public_accueilli, expected_statut",
         [
-            (None, None),
-            ("fake", None),
-            ("Particuliers", "Particuliers"),
-            ("PARTICULIERS", "Particuliers"),
-            ("professionnels", "Professionnels"),
+            (None, None, "ACTIF"),
+            ("fake", None, "ACTIF"),
+            ("PARTICULIERS", "Particuliers", "ACTIF"),
+            ("Particuliers", "Particuliers", "ACTIF"),
+            (
+                "Particuliers et professionnels",
+                "Particuliers et professionnels",
+                "ACTIF",
+            ),
+            ("PROFESSIONNELS", "Professionnels", "SUPPRIME"),
+            ("Professionnels", "Professionnels", "SUPPRIME"),
         ],
     )
     def test_create_actor_public_accueilli(
@@ -677,6 +683,7 @@ class TestCreateActorSeriesTransformations:
         df_empty_displayed_acteurs_from_db,
         public_accueilli,
         expected_public_accueilli,
+        expected_statut,
     ):
         mock = MagicMock()
         mock.xcom_pull.side_effect = lambda task_ids="": {
@@ -721,11 +728,8 @@ class TestCreateActorSeriesTransformations:
             },
         }
         result = create_actors(**kwargs)
-        if expected_public_accueilli == "Professionnels":
-            assert result["df"]["statut"].iloc[0] == "SUPPRIME"
-        else:
-            assert result["df"]["statut"].iloc[0] == "ACTIF"
         assert result["df"]["public_accueilli"][0] == expected_public_accueilli
+        assert result["df"]["statut"][0] == expected_statut
 
     @pytest.mark.parametrize(
         "uniquement_sur_rdv,expected_uniquement_sur_rdv",


### PR DESCRIPTION
# Description succincte du problème résolu
Désactiver les acteurs d'EO qui accueillent uniquement des professionnels 
Quand public_accueilli = professionnels on set le statut de l'acteur à supprimer 

Carte Notion : [Titre de la carte](https://notion.so/...)

Description plus détaillée de l'intention, l'approche ou de l'implémentation (ce qui n’est pas visible directement en lisant le code)

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :
- [ ] Bug fix
- [ ] Nouvelle fonctionnalité
- [x] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :
- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- Récupérer la base de production
- Aller sur http://localhost:8000
- Cliquer sur ABC
- …

## Développement local

<!-- Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe -->
- Mettre à jour le `.env`
- Réinstaller les dépendances Python avec `pip install -r requirements.txt -r dev-requirements.txt`
- Réinstaller les dépendances node avec `npm install`
- Rebuild la stack docker avec `docker compose build`
- ...

## Déploiement

<!-- Dans le cas où il y a des instructions spécifiques de déploiement -->

- Exécuter les migrations
- Exécuter la commande `rf -rf /`
- ...
