### PR TITLE
Interprétation des colonnes oui/non et transformation en booléen

### DIFF
--- a/dags/utils/dag_eo_utils.py
+++ b/dags/utils/dag_eo_utils.py
@@ -378,10 +378,12 @@ def _force_column_value(
     )
 
 
-def _column_to_bool(df_column: pd.Series) -> pd.Series:
-    return df_column.apply(
-        lambda x: x is True or isinstance(x, str) and x.lower().strip() == "oui"
-    )
+def cast_eo_boolean_or_string_to_boolean(value: str | bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.lower().strip() == "oui"
+    return False
 
 
 def merge_produits_accepter(group):
@@ -490,7 +492,7 @@ def create_actors(**kwargs):
                     lambda x: "SUPPRIME" if x == "Professionnels" else "ACTIF"
                 )
             elif old_col in ["uniquement_sur_rdv", "exclusivite_de_reprisereparation"]:
-                df[new_col] = _column_to_bool(df[old_col])
+                df[new_col] = df[old_col].apply(cast_eo_boolean_or_string_to_boolean)
             elif old_col == "reprise":
                 df[new_col] = _force_column_value(
                     df[old_col],

--- a/dags/utils/dag_eo_utils.py
+++ b/dags/utils/dag_eo_utils.py
@@ -378,6 +378,12 @@ def _force_column_value(
     )
 
 
+def _column_to_bool(df_column: pd.Series) -> pd.Series:
+    return df_column.apply(
+        lambda x: x is True or isinstance(x, str) and x.lower().strip() == "oui"
+    )
+
+
 def merge_produits_accepter(group):
     produits_sets = set()
     for produits in group:
@@ -483,8 +489,8 @@ def create_actors(**kwargs):
                 df["statut"] = df["public_accueilli"].apply(
                     lambda x: "SUPPRIME" if x == "Professionnels" else "ACTIF"
                 )
-            elif old_col == "uniquement_sur_rdv":
-                df[new_col] = df[old_col].astype(bool)
+            elif old_col in ["uniquement_sur_rdv", "exclusivite_de_reprisereparation"]:
+                df[new_col] = _column_to_bool(df[old_col])
             elif old_col == "reprise":
                 df[new_col] = _force_column_value(
                     df[old_col],
@@ -495,8 +501,6 @@ def create_actors(**kwargs):
                         "oui": "1 pour 1",
                     },
                 )
-            elif old_col == "exclusivite_de_reprisereparation":
-                df[new_col] = df[old_col].apply(lambda x: True if x == "oui" else False)
             else:
                 df[new_col] = df[old_col]
 

--- a/dags_unit_tests/dags/utils/test_dag_eo_utils.py
+++ b/dags_unit_tests/dags/utils/test_dag_eo_utils.py
@@ -738,6 +738,15 @@ class TestCreateActorSeriesTransformations:
             (None, False),
             (False, False),
             (True, True),
+            ("oui", True),
+            ("Oui", True),
+            (" Oui ", True),
+            ("non", False),
+            ("NON", False),
+            (" NON ", False),
+            ("", False),
+            (" ", False),
+            ("fake", False),
         ],
     )
     def test_create_actor_uniquement_sur_rdv(
@@ -861,8 +870,16 @@ class TestCreateActorSeriesTransformations:
         "exclusivite_de_reprisereparation, expected_exclusivite_de_reprisereparation",
         [
             (None, False),
-            ("non", False),
+            (False, False),
+            (True, True),
             ("oui", True),
+            ("Oui", True),
+            (" Oui ", True),
+            ("non", False),
+            ("NON", False),
+            (" NON ", False),
+            ("", False),
+            (" ", False),
             ("fake", False),
         ],
     )


### PR DESCRIPTION
# Description succincte du problème résolu

Les colonnes oui / non : `uniquement_sur_rdv et exclusivite_de_reparation ne sont pas interprété de manière robuste

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :
- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :
- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- Récupérer la base de production
- Aller sur http://localhost:8000
- Cliquer sur ABC
- …

## Développement local

<!-- Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe -->
- Mettre à jour le `.env`
- Réinstaller les dépendances Python avec `pip install -r requirements.txt -r dev-requirements.txt`
- Réinstaller les dépendances node avec `npm install`
- Rebuild la stack docker avec `docker compose build`
- ...

## Déploiement

<!-- Dans le cas où il y a des instructions spécifiques de déploiement -->

- Exécuter les migrations
- Exécuter la commande `rf -rf /`
- ...
