### PR TITLE
Add pre-commit hooks run to git ignore revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,3 +6,5 @@
 
 # Run pre-commit hooks on all codebase - 27 september 2024
 40baf54727d624c8feac553caea48cc3306fd9cf
+# Add djade and run on all files - 28 September 2024
+830e5434da2b61173225c3f29ba63d3126b18b90

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# git-blame ignored revisions
+# To configure, run
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+# Requires Git > 2.23
+# See https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-fileltfilegt
+
+# Run pre-commit hooks on all codebase - 27 september 2024
+40baf54727d624c8feac553caea48cc3306fd9cf


### PR DESCRIPTION
# Description succincte du problème résolu

Pour que le git blame ne fasse pas ressortir la PR de reformatage 

À run en local : `git config blame.ignoreRevsFile .git-blame-ignore-revs`