### PR TITLE
Calculer les ID des proposition de service au moment de l'insertion des données

### DIFF
--- a/dags/aliapur.py
+++ b/dags/aliapur.py
@@ -1,16 +1,5 @@
-from datetime import datetime
-
 from airflow import DAG
-from utils import eo_operators
-
-default_args = {
-    "owner": "airflow",
-    "depends_on_past": False,
-    "start_date": datetime(2024, 3, 23),
-    "email_on_failure": False,
-    "email_on_retry": False,
-    "retries": 1,
-}
+from utils.eo_operators import default_args, eo_task_chain
 
 with DAG(
     dag_id="eo-aliapur",
@@ -47,18 +36,4 @@ with DAG(
     },
     schedule=None,
 ) as dag:
-    (
-        [
-            eo_operators.fetch_data_from_api_task(dag),
-            eo_operators.load_data_from_postgresql_task(dag),
-        ]
-        >> eo_operators.create_actors_task(dag)
-        >> [
-            eo_operators.create_proposition_services_task(dag),
-            eo_operators.create_labels_task(dag),
-            eo_operators.create_acteur_services_task(dag),
-        ]
-        >> eo_operators.create_proposition_services_sous_categories_task(dag)
-        >> eo_operators.serialize_to_json_task(dag)
-        >> eo_operators.write_data_task(dag)
-    )  # type: ignore
+    eo_task_chain(dag)

--- a/dags/cma.py
+++ b/dags/cma.py
@@ -1,16 +1,5 @@
-from datetime import datetime
-
-import utils.eo_operators as eo_operators
 from airflow import DAG
-
-default_args = {
-    "owner": "airflow",
-    "depends_on_past": False,
-    "start_date": datetime(2024, 3, 23),
-    "email_on_failure": False,
-    "email_on_retry": False,
-    "retries": 1,
-}
+from utils.eo_operators import default_args, eo_task_chain
 
 with DAG(
     dag_id="like-eo-from-api-cma",
@@ -49,18 +38,4 @@ with DAG(
     },
     schedule=None,
 ) as dag:
-    (
-        [
-            eo_operators.fetch_data_from_api_task(dag),
-            eo_operators.load_data_from_postgresql_task(dag),
-        ]
-        >> eo_operators.create_actors_task(dag)
-        >> [
-            eo_operators.create_proposition_services_task(dag),
-            eo_operators.create_labels_task(dag),
-            eo_operators.create_acteur_services_task(dag),
-        ]
-        >> eo_operators.create_proposition_services_sous_categories_task(dag)
-        >> eo_operators.serialize_to_json_task(dag)
-        >> eo_operators.write_data_task(dag)
-    )  # type: ignore
+    eo_task_chain(dag)

--- a/dags/corepile.py
+++ b/dags/corepile.py
@@ -1,16 +1,5 @@
-from datetime import datetime
-
-import utils.eo_operators as eo_operators
 from airflow import DAG
-
-default_args = {
-    "owner": "airflow",
-    "depends_on_past": False,
-    "start_date": datetime(2024, 3, 23),
-    "email_on_failure": False,
-    "email_on_retry": False,
-    "retries": 1,
-}
+from utils.eo_operators import default_args, eo_task_chain
 
 with DAG(
     dag_id="eo-corepile",
@@ -49,18 +38,4 @@ with DAG(
     },
     schedule=None,
 ) as dag:
-    (
-        [
-            eo_operators.fetch_data_from_api_task(dag),
-            eo_operators.load_data_from_postgresql_task(dag),
-        ]
-        >> eo_operators.create_actors_task(dag)
-        >> [
-            eo_operators.create_proposition_services_task(dag),
-            eo_operators.create_labels_task(dag),
-            eo_operators.create_acteur_services_task(dag),
-        ]
-        >> eo_operators.create_proposition_services_sous_categories_task(dag)
-        >> eo_operators.serialize_to_json_task(dag)
-        >> eo_operators.write_data_task(dag)
-    )  # type: ignore
+    eo_task_chain(dag)

--- a/dags/create_final_actors.py
+++ b/dags/create_final_actors.py
@@ -4,14 +4,7 @@ import pandas as pd
 from airflow import DAG
 from airflow.operators.python import PythonOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
-
-
-def read_data_from_postgres(**kwargs):
-    table_name = kwargs["table_name"]
-    pg_hook = PostgresHook(postgres_conn_id="qfdmo-django-db")
-    engine = pg_hook.get_sqlalchemy_engine()
-    df = pd.read_sql_table(table_name, engine)
-    return df
+from utils.db_tasks import read_data_from_postgres
 
 
 def apply_corrections_acteur(**kwargs):

--- a/dags/ecodds.py
+++ b/dags/ecodds.py
@@ -1,16 +1,5 @@
-from datetime import datetime
-
-import utils.eo_operators as eo_operators
 from airflow import DAG
-
-default_args = {
-    "owner": "airflow",
-    "depends_on_past": False,
-    "start_date": datetime(2024, 3, 23),
-    "email_on_failure": False,
-    "email_on_retry": False,
-    "retries": 1,
-}
+from utils.eo_operators import default_args, eo_task_chain
 
 with DAG(
     dag_id="eo-ecodds",
@@ -46,18 +35,4 @@ with DAG(
     },
     schedule=None,
 ) as dag:
-    (
-        [
-            eo_operators.fetch_data_from_api_task(dag),
-            eo_operators.load_data_from_postgresql_task(dag),
-        ]
-        >> eo_operators.create_actors_task(dag)
-        >> [
-            eo_operators.create_proposition_services_task(dag),
-            eo_operators.create_labels_task(dag),
-            eo_operators.create_acteur_services_task(dag),
-        ]
-        >> eo_operators.create_proposition_services_sous_categories_task(dag)
-        >> eo_operators.serialize_to_json_task(dag)
-        >> eo_operators.write_data_task(dag)
-    )  # type: ignore
+    eo_task_chain(dag)

--- a/dags/ecologic.py
+++ b/dags/ecologic.py
@@ -1,16 +1,5 @@
-from datetime import datetime
-
-import utils.eo_operators as eo_operators
 from airflow import DAG
-
-default_args = {
-    "owner": "airflow",
-    "depends_on_past": False,
-    "start_date": datetime(2024, 3, 23),
-    "email_on_failure": False,
-    "email_on_retry": False,
-    "retries": 1,
-}
+from utils.eo_operators import default_args, eo_task_chain
 
 with DAG(
     dag_id="eo-ecologic",
@@ -47,18 +36,4 @@ with DAG(
     },
     schedule=None,
 ) as dag:
-    (
-        [
-            eo_operators.fetch_data_from_api_task(dag),
-            eo_operators.load_data_from_postgresql_task(dag),
-        ]
-        >> eo_operators.create_actors_task(dag)
-        >> [
-            eo_operators.create_proposition_services_task(dag),
-            eo_operators.create_labels_task(dag),
-            eo_operators.create_acteur_services_task(dag),
-        ]
-        >> eo_operators.create_proposition_services_sous_categories_task(dag)
-        >> eo_operators.serialize_to_json_task(dag)
-        >> eo_operators.write_data_task(dag)
-    )  # type: ignore
+    eo_task_chain(dag)

--- a/dags/ecomaison.py
+++ b/dags/ecomaison.py
@@ -1,16 +1,5 @@
-from datetime import datetime
-
-import utils.eo_operators as eo_operators
 from airflow import DAG
-
-default_args = {
-    "owner": "airflow",
-    "depends_on_past": False,
-    "start_date": datetime(2024, 3, 23),
-    "email_on_failure": False,
-    "email_on_retry": False,
-    "retries": 1,
-}
+from utils.eo_operators import default_args, eo_task_chain
 
 with DAG(
     dag_id="eo-ecomaison",
@@ -53,18 +42,4 @@ with DAG(
     },
     schedule=None,
 ) as dag:
-    (
-        [
-            eo_operators.fetch_data_from_api_task(dag),
-            eo_operators.load_data_from_postgresql_task(dag),
-        ]
-        >> eo_operators.create_actors_task(dag)
-        >> [
-            eo_operators.create_proposition_services_task(dag),
-            eo_operators.create_labels_task(dag),
-            eo_operators.create_acteur_services_task(dag),
-        ]
-        >> eo_operators.create_proposition_services_sous_categories_task(dag)
-        >> eo_operators.serialize_to_json_task(dag)
-        >> eo_operators.write_data_task(dag)
-    )  # type: ignore
+    eo_task_chain(dag)

--- a/dags/ecosystem.py
+++ b/dags/ecosystem.py
@@ -1,16 +1,5 @@
-from datetime import datetime
-
-import utils.eo_operators as eo_operators
 from airflow import DAG
-
-default_args = {
-    "owner": "airflow",
-    "depends_on_past": False,
-    "start_date": datetime(2024, 3, 23),
-    "email_on_failure": False,
-    "email_on_retry": False,
-    "retries": 1,
-}
+from utils.eo_operators import default_args, eo_task_chain
 
 with DAG(
     dag_id="eo-ecosystem",
@@ -50,18 +39,4 @@ with DAG(
     },
     schedule=None,
 ) as dag:
-    (
-        [
-            eo_operators.fetch_data_from_api_task(dag),
-            eo_operators.load_data_from_postgresql_task(dag),
-        ]
-        >> eo_operators.create_actors_task(dag)
-        >> [
-            eo_operators.create_proposition_services_task(dag),
-            eo_operators.create_labels_task(dag),
-            eo_operators.create_acteur_services_task(dag),
-        ]
-        >> eo_operators.create_proposition_services_sous_categories_task(dag)
-        >> eo_operators.serialize_to_json_task(dag)
-        >> eo_operators.write_data_task(dag)
-    )  # type: ignore
+    eo_task_chain(dag)

--- a/dags/ocab.py
+++ b/dags/ocab.py
@@ -1,16 +1,5 @@
-from datetime import datetime
-
-import utils.eo_operators as eo_operators
 from airflow import DAG
-
-default_args = {
-    "owner": "airflow",
-    "depends_on_past": False,
-    "start_date": datetime(2024, 3, 23),
-    "email_on_failure": False,
-    "email_on_retry": False,
-    "retries": 1,
-}
+from utils.eo_operators import default_args, eo_task_chain
 
 with DAG(
     dag_id="eo-ocab",
@@ -48,18 +37,4 @@ with DAG(
     },
     schedule=None,
 ) as dag:
-    (
-        [
-            eo_operators.fetch_data_from_api_task(dag),
-            eo_operators.load_data_from_postgresql_task(dag),
-        ]
-        >> eo_operators.create_actors_task(dag)
-        >> [
-            eo_operators.create_proposition_services_task(dag),
-            eo_operators.create_labels_task(dag),
-            eo_operators.create_acteur_services_task(dag),
-        ]
-        >> eo_operators.create_proposition_services_sous_categories_task(dag)
-        >> eo_operators.serialize_to_json_task(dag)
-        >> eo_operators.write_data_task(dag)
-    )  # type: ignore
+    eo_task_chain(dag)

--- a/dags/pyreo.py
+++ b/dags/pyreo.py
@@ -1,16 +1,5 @@
-from datetime import datetime
-
-import utils.eo_operators as eo_operators
 from airflow import DAG
-
-default_args = {
-    "owner": "airflow",
-    "depends_on_past": False,
-    "start_date": datetime(2024, 3, 23),
-    "email_on_failure": False,
-    "email_on_retry": False,
-    "retries": 1,
-}
+from utils.eo_operators import default_args, eo_task_chain
 
 with DAG(
     dag_id="eo-pyreo",
@@ -51,18 +40,4 @@ with DAG(
     },
     schedule=None,
 ) as dag:
-    (
-        [
-            eo_operators.fetch_data_from_api_task(dag),
-            eo_operators.load_data_from_postgresql_task(dag),
-        ]
-        >> eo_operators.create_actors_task(dag)
-        >> [
-            eo_operators.create_proposition_services_task(dag),
-            eo_operators.create_labels_task(dag),
-            eo_operators.create_acteur_services_task(dag),
-        ]
-        >> eo_operators.create_proposition_services_sous_categories_task(dag)
-        >> eo_operators.serialize_to_json_task(dag)
-        >> eo_operators.write_data_task(dag)
-    )  # type: ignore
+    eo_task_chain(dag)

--- a/dags/refashion.py
+++ b/dags/refashion.py
@@ -1,16 +1,5 @@
-from datetime import datetime
-
-import utils.eo_operators as eo_operators
 from airflow import DAG
-
-default_args = {
-    "owner": "airflow",
-    "depends_on_past": False,
-    "start_date": datetime(2024, 3, 23),
-    "email_on_failure": False,
-    "email_on_retry": False,
-    "retries": 1,
-}
+from utils.eo_operators import default_args, eo_task_chain
 
 with DAG(
     dag_id="eo-refashion",
@@ -55,18 +44,4 @@ with DAG(
     },
     schedule=None,
 ) as dag:
-    (
-        [
-            eo_operators.fetch_data_from_api_task(dag),
-            eo_operators.load_data_from_postgresql_task(dag),
-        ]
-        >> eo_operators.create_actors_task(dag)
-        >> [
-            eo_operators.create_proposition_services_task(dag),
-            eo_operators.create_labels_task(dag),
-            eo_operators.create_acteur_services_task(dag),
-        ]
-        >> eo_operators.create_proposition_services_sous_categories_task(dag)
-        >> eo_operators.serialize_to_json_task(dag)
-        >> eo_operators.write_data_task(dag)
-    )  # type: ignore
+    eo_task_chain(dag)

--- a/dags/soren.py
+++ b/dags/soren.py
@@ -1,16 +1,5 @@
-from datetime import datetime
-
-import utils.eo_operators as eo_operators
 from airflow import DAG
-
-default_args = {
-    "owner": "airflow",
-    "depends_on_past": False,
-    "start_date": datetime(2024, 3, 23),
-    "email_on_failure": False,
-    "email_on_retry": False,
-    "retries": 1,
-}
+from utils.eo_operators import default_args, eo_task_chain
 
 with DAG(
     dag_id="eo-soren",
@@ -47,18 +36,4 @@ with DAG(
     },
     schedule=None,
 ) as dag:
-    (
-        [
-            eo_operators.fetch_data_from_api_task(dag),
-            eo_operators.load_data_from_postgresql_task(dag),
-        ]
-        >> eo_operators.create_actors_task(dag)
-        >> [
-            eo_operators.create_proposition_services_task(dag),
-            eo_operators.create_labels_task(dag),
-            eo_operators.create_acteur_services_task(dag),
-        ]
-        >> eo_operators.create_proposition_services_sous_categories_task(dag)
-        >> eo_operators.serialize_to_json_task(dag)
-        >> eo_operators.write_data_task(dag)
-    )  # type: ignore
+    eo_task_chain(dag)

--- a/dags/utils/dag_eo_utils.py
+++ b/dags/utils/dag_eo_utils.py
@@ -88,7 +88,7 @@ def create_proposition_services_sous_categories(**kwargs):
     df_sous_categories_map = data_dict["souscategorieobjet"]
     params = kwargs["params"]
     mapping_config_key = params.get("mapping_config_key", "sous_categories")
-    config = utils.get_mapping_config()
+    config = base_utils.get_mapping_config()
     sous_categories = config[mapping_config_key]
     rows_list = []
 

--- a/dags/utils/dag_eo_utils.py
+++ b/dags/utils/dag_eo_utils.py
@@ -80,12 +80,12 @@ def create_proposition_services(**kwargs):
 def create_proposition_services_sous_categories(**kwargs):
     df = kwargs["ti"].xcom_pull(task_ids="create_proposition_services")["df"]
     data_dict = kwargs["ti"].xcom_pull(task_ids="load_data_from_postgresql")
-    config = kwargs["ti"].xcom_pull(task_ids="create_actors")["config"]
     df_sous_categories_map = data_dict["sous_categories"]
     params = kwargs["params"]
     mapping_config_key = params.get("mapping_config_key", "sous_categories")
-    rows_list = []
+    config = utils.get_mapping_config()
     sous_categories = config[mapping_config_key]
+    rows_list = []
 
     for _, row in df.iterrows():
         sous_categories_value = (
@@ -419,7 +419,6 @@ def create_actors(**kwargs):
     df_sources = data_dict["sources"]
     df_acteurtype = data_dict["acteurtype"]
     df_displayedacteurs = data_dict["displayedacteurs"]
-    config = base_utils.get_mapping_config()
     params = kwargs["params"]
     reparacteurs = params.get("reparacteurs", False)
     column_mapping = params.get("column_mapping", {})
@@ -555,7 +554,6 @@ def create_actors(**kwargs):
     return {
         "df": df,
         "metadata": metadata,
-        "config": config,
         "removed_actors": df_missing_actors,
     }
 

--- a/dags/utils/db_tasks.py
+++ b/dags/utils/db_tasks.py
@@ -1,0 +1,10 @@
+import pandas as pd
+from airflow.providers.postgres.hooks.postgres import PostgresHook
+
+
+def read_data_from_postgres(**kwargs):
+    table_name = kwargs["table_name"]
+    pg_hook = PostgresHook(postgres_conn_id="qfdmo-django-db")
+    engine = pg_hook.get_sqlalchemy_engine()
+    df = pd.read_sql_table(table_name, engine)
+    return df

--- a/dags/utils/eo_operators.py
+++ b/dags/utils/eo_operators.py
@@ -24,14 +24,6 @@ def fetch_data_from_api_task(dag: DAG) -> PythonOperator:
     )
 
 
-def load_data_from_postgresql_task(dag: DAG) -> PythonOperator:
-    return PythonOperator(
-        task_id="load_data_from_postgresql",
-        python_callable=dag_eo_utils.load_data_from_postgresql,
-        dag=dag,
-    )
-
-
 def read_data_from_postgres_task(
     *,
     dag: DAG,
@@ -138,7 +130,6 @@ def eo_task_chain(dag: DAG) -> None:
         read_data_from_postgres_task(
             dag=dag, table_name="qfdmo_labelqualite", task_id="read_labelqualite"
         ),
-        load_data_from_postgresql_task(dag),
     ]
 
     create_tasks = [

--- a/dags/utils/eo_operators.py
+++ b/dags/utils/eo_operators.py
@@ -1,6 +1,19 @@
+from datetime import datetime, timedelta
+
 from airflow import DAG
+from airflow.models.baseoperator import chain
 from airflow.operators.python import PythonOperator
 from utils import dag_eo_utils
+from utils.db_tasks import read_data_from_postgres
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2024, 3, 23),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 1,
+}
 
 
 def fetch_data_from_api_task(dag: DAG) -> PythonOperator:
@@ -15,6 +28,33 @@ def load_data_from_postgresql_task(dag: DAG) -> PythonOperator:
     return PythonOperator(
         task_id="load_data_from_postgresql",
         python_callable=dag_eo_utils.load_data_from_postgresql,
+        dag=dag,
+    )
+
+
+def read_data_from_postgres_task(
+    *,
+    dag: DAG,
+    table_name: str,
+    task_id: str,
+    retries: int = 5,
+    retry_delay: timedelta = timedelta(minutes=2),
+) -> PythonOperator:
+
+    return PythonOperator(
+        task_id=task_id,
+        python_callable=read_data_from_postgres,
+        op_kwargs={"table_name": table_name},
+        dag=dag,
+        retries=retries,
+        retry_delay=retry_delay,
+    )
+
+
+def read_displayedacteur_task(dag: DAG) -> PythonOperator:
+    return PythonOperator(
+        task_id="read_displayedacteur",
+        python_callable=dag_eo_utils.read_displayedacteur,
         dag=dag,
     )
 
@@ -72,4 +112,47 @@ def create_acteur_services_task(dag: DAG) -> PythonOperator:
         task_id="create_acteur_services",
         python_callable=dag_eo_utils.create_acteur_services,
         dag=dag,
+    )
+
+
+def eo_task_chain(dag: DAG) -> None:
+    read_tasks = [
+        fetch_data_from_api_task(dag),
+        read_data_from_postgres_task(
+            dag=dag, table_name="qfdmo_acteurtype", task_id="read_acteurtype"
+        ),
+        read_data_from_postgres_task(
+            dag=dag, table_name="qfdmo_source", task_id="read_source"
+        ),
+        read_data_from_postgres_task(
+            dag=dag, table_name="qfdmo_action", task_id="read_action"
+        ),
+        read_data_from_postgres_task(
+            dag=dag, table_name="qfdmo_acteurservice", task_id="read_acteurservice"
+        ),
+        read_data_from_postgres_task(
+            dag=dag,
+            table_name="qfdmo_souscategorieobjet",
+            task_id="read_souscategorieobjet",
+        ),
+        read_data_from_postgres_task(
+            dag=dag, table_name="qfdmo_labelqualite", task_id="read_labelqualite"
+        ),
+        load_data_from_postgresql_task(dag),
+    ]
+
+    create_tasks = [
+        create_proposition_services_task(dag),
+        create_labels_task(dag),
+        create_acteur_services_task(dag),
+    ]
+
+    chain(
+        read_tasks,
+        read_displayedacteur_task(dag),
+        create_actors_task(dag),
+        create_tasks,
+        create_proposition_services_sous_categories_task(dag),
+        serialize_to_json_task(dag),
+        write_data_task(dag),
     )

--- a/dags/valdelia.py
+++ b/dags/valdelia.py
@@ -1,16 +1,5 @@
-from datetime import datetime
-
-import utils.eo_operators as eo_operators
 from airflow import DAG
-
-default_args = {
-    "owner": "airflow",
-    "depends_on_past": False,
-    "start_date": datetime(2024, 3, 23),
-    "email_on_failure": False,
-    "email_on_retry": False,
-    "retries": 1,
-}
+from utils.eo_operators import default_args, eo_task_chain
 
 with DAG(
     dag_id="eo-valdelia",
@@ -49,18 +38,4 @@ with DAG(
     },
     schedule=None,
 ) as dag:
-    (
-        [
-            eo_operators.fetch_data_from_api_task(dag),
-            eo_operators.load_data_from_postgresql_task(dag),
-        ]
-        >> eo_operators.create_actors_task(dag)
-        >> [
-            eo_operators.create_proposition_services_task(dag),
-            eo_operators.create_labels_task(dag),
-            eo_operators.create_acteur_services_task(dag),
-        ]
-        >> eo_operators.create_proposition_services_sous_categories_task(dag)
-        >> eo_operators.serialize_to_json_task(dag)
-        >> eo_operators.write_data_task(dag)
-    )  # type: ignore
+    eo_task_chain(dag)

--- a/dags_unit_tests/dags/utils/test_dag_eo_utils.py
+++ b/dags_unit_tests/dags/utils/test_dag_eo_utils.py
@@ -127,16 +127,12 @@ def get_mock_ti_ps(
     df_acteur_services_from_db,
     df_sous_categories_from_db,
     df_create_actors: pd.DataFrame = pd.DataFrame(),
-    displayedpropositionservice_max_id: int = 1,
 ) -> MagicMock:
     mock = MagicMock()
 
     mock.xcom_pull.side_effect = lambda task_ids="": {
         "create_actors": {
             "df": df_create_actors,
-        },
-        "load_data_from_postgresql": {
-            "displayedpropositionservice_max_id": displayedpropositionservice_max_id,
         },
         "read_action": df_actions_from_db,
         "read_acteurservice": df_acteur_services_from_db,
@@ -153,16 +149,12 @@ def get_mock_ti_label(
     df_sous_categories_from_db,
     df_labels_from_db=pd.DataFrame(),
     df_create_actors: pd.DataFrame = pd.DataFrame(),
-    displayedpropositionservice_max_id: int = 1,
 ) -> MagicMock:
     mock = MagicMock()
 
     mock.xcom_pull.side_effect = lambda task_ids="": {
         "create_actors": {
             "df": df_create_actors,
-        },
-        "load_data_from_postgresql": {
-            "displayedpropositionservice_max_id": displayedpropositionservice_max_id,
         },
         "read_action": df_actions_from_db,
         "read_acteurtype": df_acteurtype_from_db,
@@ -211,7 +203,6 @@ class TestCreatePropositionService:
                         "acteur_id": [1],
                         "action": ["reparer"],
                         "sous_categories": ["téléphones portables"],
-                        "id": [1],
                     },
                 ),
                 {"number_of_merged_actors": 0, "number_of_propositionservices": 1},
@@ -234,7 +225,6 @@ class TestCreatePropositionService:
                         "acteur_id": [1],
                         "action": ["donner"],
                         "sous_categories": ["téléphones portables"],
-                        "id": [1],
                     },
                 ),
                 {"number_of_merged_actors": 0, "number_of_propositionservices": 1},
@@ -257,7 +247,6 @@ class TestCreatePropositionService:
                         "acteur_id": [1],
                         "action": ["reparer"],
                         "sous_categories": ["téléphones portables"],
-                        "id": [1],
                     },
                 ),
                 {"number_of_merged_actors": 0, "number_of_propositionservices": 1},
@@ -280,7 +269,6 @@ class TestCreatePropositionService:
                         "acteur_id": [1],
                         "action": ["trier"],
                         "sous_categories": ["téléphones portables"],
-                        "id": [1],
                     },
                 ),
                 {"number_of_merged_actors": 0, "number_of_propositionservices": 1},
@@ -307,7 +295,6 @@ class TestCreatePropositionService:
                             "téléphones portables",
                             "téléphones portables",
                         ],
-                        "id": [1, 2, 3],
                     },
                 ),
                 {"number_of_merged_actors": 0, "number_of_propositionservices": 3},
@@ -371,7 +358,6 @@ class TestCreatePropositionService:
                 "acteur_id": [1, 2],
                 "action": ["trier", "trier"],
                 "sous_categories": ["téléphones portables", "téléphones portables"],
-                "id": [1, 2],
             }
         )
         expected_metadata = {
@@ -418,7 +404,6 @@ class TestCreatePropositionService:
                 "acteur_id": [1],
                 "action": ["reparer"],
                 "sous_categories": ["téléphones portables | écrans"],
-                "id": [1],
             }
         )
         expected_metadata = {
@@ -431,36 +416,6 @@ class TestCreatePropositionService:
 
         assert result["df"].equals(df_expected)
         assert result["metadata"] == expected_metadata
-
-    def test_create_proposition_services_increment_ids(
-        self,
-        db_mapping_config,
-        df_actions_from_db,
-        df_acteur_services_from_db,
-        df_sous_categories_from_db,
-    ):
-        mock = get_mock_ti_ps(
-            db_mapping_config,
-            df_actions_from_db,
-            df_acteur_services_from_db,
-            df_sous_categories_from_db,
-            df_create_actors=pd.DataFrame(
-                {
-                    "identifiant_unique": [1],
-                    "produitsdechets_acceptes": ["téléphones portables"],
-                    "point_dapport_de_service_reparation": [False],
-                    "point_dapport_pour_reemploi": [False],
-                    "point_de_reparation": [False],
-                    "point_de_collecte_ou_de_reprise_des_dechets": [True],
-                }
-            ),
-            displayedpropositionservice_max_id=123,
-        )
-
-        kwargs = {"ti": mock}
-        result = create_proposition_services(**kwargs)
-
-        assert result["df"]["id"].tolist() == [123]
 
 
 @pytest.fixture
@@ -605,9 +560,6 @@ def mock_ti(
                     "point_de_collecte_ou_de_reprise_des_dechets": [True, True],
                 }
             ),
-        },
-        "load_data_from_postgresql": {
-            "displayedpropositionservice_max_id": 1,
         },
         "read_displayedacteur": df_displayed_acteurs_from_db,
         "read_action": df_actions_from_db,
@@ -1485,7 +1437,6 @@ class TestCeateLabels:
                     "acteur_type_id": [202, 202],
                 }
             ),
-            displayedpropositionservice_max_id=123,
         )
 
         kwargs = {"ti": mock}
@@ -1525,7 +1476,6 @@ class TestCeateLabels:
                     "acteur_type_id": [201, 202],
                 }
             ),
-            displayedpropositionservice_max_id=123,
         )
 
         kwargs = {"ti": mock}
@@ -1571,7 +1521,6 @@ class TestCeateLabels:
                     "acteur_type_id": [202, 202],
                 }
             ),
-            displayedpropositionservice_max_id=123,
         )
 
         kwargs = {"ti": mock}

--- a/dags_unit_tests/dags/utils/test_dag_eo_utils.py
+++ b/dags_unit_tests/dags/utils/test_dag_eo_utils.py
@@ -137,10 +137,10 @@ def get_mock_ti_ps(
         },
         "load_data_from_postgresql": {
             "displayedpropositionservice_max_id": displayedpropositionservice_max_id,
-            "action": df_actions_from_db,
-            "acteurservice": df_acteur_services_from_db,
-            "souscategorieobjet": df_sous_categories_from_db,
         },
+        "read_action": df_actions_from_db,
+        "read_acteurservice": df_acteur_services_from_db,
+        "read_souscategorieobjet": df_sous_categories_from_db,
     }[task_ids]
     return mock
 
@@ -163,12 +163,12 @@ def get_mock_ti_label(
         },
         "load_data_from_postgresql": {
             "displayedpropositionservice_max_id": displayedpropositionservice_max_id,
-            "action": df_actions_from_db,
-            "acteurservice": df_acteur_services_from_db,
-            "souscategorieobjet": df_sous_categories_from_db,
-            "labelqualite": df_labels_from_db,
-            "acteurtype": df_acteurtype_from_db,
         },
+        "read_action": df_actions_from_db,
+        "read_acteurtype": df_acteurtype_from_db,
+        "read_acteurservice": df_acteur_services_from_db,
+        "read_souscategorieobjet": df_sous_categories_from_db,
+        "read_labelqualite": df_labels_from_db,
     }[task_ids]
     return mock
 
@@ -608,14 +608,14 @@ def mock_ti(
         },
         "load_data_from_postgresql": {
             "displayedpropositionservice_max_id": 1,
-            "action": df_actions_from_db,
-            "acteurservice": df_acteur_services_from_db,
-            "souscategorieobjet": df_sous_categories_from_db,
-            "source": df_sources_from_db,
-            "acteurtype": df_acteurtype_from_db,
-            "labelqualite": df_labels_from_db,
-            "displayedacteur": df_displayed_acteurs_from_db,
         },
+        "read_displayedacteur": df_displayed_acteurs_from_db,
+        "read_action": df_actions_from_db,
+        "read_acteurtype": df_acteurtype_from_db,
+        "read_acteurservice": df_acteur_services_from_db,
+        "read_source": df_sources_from_db,
+        "read_souscategorieobjet": df_sous_categories_from_db,
+        "read_labelqualite": df_labels_from_db,
         "create_proposition_services": {"df": df_proposition_services},
         "services_sous_categories": df_proposition_services_sous_categories,
     }[task_ids]
@@ -684,11 +684,9 @@ class TestCreateActorSeriesTransformations:
     ):
         mock = MagicMock()
         mock.xcom_pull.side_effect = lambda task_ids="": {
-            "load_data_from_postgresql": {
-                "source": df_sources_from_db,
-                "acteurtype": None,
-                "displayedacteur": df_empty_displayed_acteurs_from_db,
-            },
+            "read_displayedacteur": df_empty_displayed_acteurs_from_db,
+            "read_acteurtype": None,
+            "read_source": df_sources_from_db,
             "fetch_data_from_api": pd.DataFrame(
                 {
                     "nom_de_lorganisme": ["Eco1"],
@@ -745,11 +743,9 @@ class TestCreateActorSeriesTransformations:
     ):
         mock = MagicMock()
         mock.xcom_pull.side_effect = lambda task_ids="": {
-            "load_data_from_postgresql": {
-                "source": df_sources_from_db,
-                "acteurtype": None,
-                "displayedacteur": df_empty_displayed_acteurs_from_db,
-            },
+            "read_displayedacteur": df_empty_displayed_acteurs_from_db,
+            "read_acteurtype": None,
+            "read_source": df_sources_from_db,
             "fetch_data_from_api": pd.DataFrame(
                 {
                     "nom_de_lorganisme": ["Eco1"],
@@ -809,11 +805,9 @@ class TestCreateActorSeriesTransformations:
     ):
         mock = MagicMock()
         mock.xcom_pull.side_effect = lambda task_ids="": {
-            "load_data_from_postgresql": {
-                "source": df_sources_from_db,
-                "acteurtype": None,
-                "displayedacteur": df_empty_displayed_acteurs_from_db,
-            },
+            "read_displayedacteur": df_empty_displayed_acteurs_from_db,
+            "read_acteurtype": None,
+            "read_source": df_sources_from_db,
             "fetch_data_from_api": pd.DataFrame(
                 {
                     "nom_de_lorganisme": ["Eco1"],
@@ -871,11 +865,9 @@ class TestCreateActorSeriesTransformations:
     ):
         mock = MagicMock()
         mock.xcom_pull.side_effect = lambda task_ids="": {
-            "load_data_from_postgresql": {
-                "source": df_sources_from_db,
-                "acteurtype": None,
-                "displayedacteur": df_empty_displayed_acteurs_from_db,
-            },
+            "read_displayedacteur": df_empty_displayed_acteurs_from_db,
+            "read_acteurtype": None,
+            "read_source": df_sources_from_db,
             "fetch_data_from_api": pd.DataFrame(
                 {
                     "nom_de_lorganisme": ["Eco1"],
@@ -929,9 +921,7 @@ class TestCreateActeurServices:
 
         mock = MagicMock()
         mock.xcom_pull.side_effect = lambda task_ids="": {
-            "load_data_from_postgresql": {
-                "acteurservice": df_acteur_services_from_db,
-            },
+            "read_acteurservice": df_acteur_services_from_db,
             "create_actors": {
                 "df": pd.DataFrame(
                     {
@@ -960,9 +950,7 @@ class TestCreateActeurServices:
 
         mock = MagicMock()
         mock.xcom_pull.side_effect = lambda task_ids="": {
-            "load_data_from_postgresql": {
-                "acteurservice": df_acteur_services_from_db,
-            },
+            "read_acteurservice": df_acteur_services_from_db,
             "create_actors": {
                 "df": pd.DataFrame(
                     {
@@ -1002,9 +990,7 @@ class TestCreateActeurServices:
 
         mock = MagicMock()
         mock.xcom_pull.side_effect = lambda task_ids="": {
-            "load_data_from_postgresql": {
-                "acteurservice": df_acteur_services_from_db,
-            },
+            "read_acteurservice": df_acteur_services_from_db,
             "create_actors": {
                 "df": pd.DataFrame(
                     {
@@ -1228,9 +1214,7 @@ class TestCreatePropositionServicesSousCategories:
         mock = MagicMock()
 
         mock.xcom_pull.side_effect = lambda task_ids="": {
-            "load_data_from_postgresql": {
-                "sous_categories": df_sous_categories_from_db,
-            },
+            "read_souscategorieobjet": df_sous_categories_from_db,
             "create_proposition_services": {
                 "df": pd.DataFrame(
                     {
@@ -1256,9 +1240,7 @@ class TestCreatePropositionServicesSousCategories:
         mock = MagicMock()
 
         mock.xcom_pull.side_effect = lambda task_ids="": {
-            "load_data_from_postgresql": {
-                "souscategorieobjet": df_sous_categories_from_db,
-            },
+            "read_souscategorieobjet": df_sous_categories_from_db,
             "create_proposition_services": {
                 "df": pd.DataFrame(
                     {
@@ -1376,11 +1358,9 @@ def test_acteur_to_delete(
 ):
     mock = MagicMock()
     mock.xcom_pull.side_effect = lambda task_ids="": {
-        "load_data_from_postgresql": {
-            "source": df_sources_from_db,
-            "acteurtype": None,
-            "displayedacteur": df_displatedacteurs,
-        },
+        "read_displayedacteur": df_displatedacteurs,
+        "read_acteurtype": None,
+        "read_source": df_sources_from_db,
         "fetch_data_from_api": pd.DataFrame(
             {
                 "id_point_apport_ou_reparation": ["1"],
@@ -1410,11 +1390,9 @@ def test_create_reparacteurs(
 ):
     mock = MagicMock()
     mock.xcom_pull.side_effect = lambda task_ids="": {
-        "load_data_from_postgresql": {
-            "source": df_sources_from_db,
-            "acteurtype": df_acteurtype_from_db,
-            "displayedacteur": df_empty_displayed_acteurs_from_db,
-        },
+        "read_displayedacteur": df_empty_displayed_acteurs_from_db,
+        "read_acteurtype": df_acteurtype_from_db,
+        "read_source": df_sources_from_db,
         "fetch_data_from_api": pd.DataFrame(
             {
                 "reparactor_description": ["Ceci est une description du réparacteur."],
@@ -1632,11 +1610,9 @@ class TestActorsLocation:
     ):
         mock = MagicMock()
         mock.xcom_pull.side_effect = lambda task_ids="": {
-            "load_data_from_postgresql": {
-                "source": df_sources_from_db,
-                "acteurtype": df_acteurtype_from_db,
-                "displayedacteur": df_empty_displayed_acteurs_from_db,
-            },
+            "read_displayedacteur": df_empty_displayed_acteurs_from_db,
+            "read_acteurtype": df_acteurtype_from_db,
+            "read_source": df_sources_from_db,
             "fetch_data_from_api": pd.DataFrame(
                 {
                     "id_point_apport_ou_reparation": ["1"],

--- a/dags_unit_tests/dags/utils/test_dag_eo_utils.py
+++ b/dags_unit_tests/dags/utils/test_dag_eo_utils.py
@@ -127,7 +127,7 @@ def get_mock_ti_ps(
     df_acteur_services_from_db,
     df_sous_categories_from_db,
     df_create_actors: pd.DataFrame = pd.DataFrame(),
-    max_pds_idx: int = 1,
+    displayedpropositionservice_max_id: int = 1,
 ) -> MagicMock:
     mock = MagicMock()
 
@@ -137,10 +137,10 @@ def get_mock_ti_ps(
             "config": db_mapping_config,
         },
         "load_data_from_postgresql": {
-            "max_pds_idx": max_pds_idx,
-            "actions": df_actions_from_db,
-            "acteur_services": df_acteur_services_from_db,
-            "sous_categories": df_sous_categories_from_db,
+            "displayedpropositionservice_max_id": displayedpropositionservice_max_id,
+            "action": df_actions_from_db,
+            "acteurservice": df_acteur_services_from_db,
+            "souscategorieobjet": df_sous_categories_from_db,
         },
     }[task_ids]
     return mock
@@ -154,7 +154,7 @@ def get_mock_ti_label(
     df_sous_categories_from_db,
     df_labels_from_db=pd.DataFrame(),
     df_create_actors: pd.DataFrame = pd.DataFrame(),
-    max_pds_idx: int = 1,
+    displayedpropositionservice_max_id: int = 1,
 ) -> MagicMock:
     mock = MagicMock()
 
@@ -164,11 +164,11 @@ def get_mock_ti_label(
             "config": db_mapping_config,
         },
         "load_data_from_postgresql": {
-            "max_pds_idx": max_pds_idx,
-            "actions": df_actions_from_db,
-            "acteur_services": df_acteur_services_from_db,
-            "sous_categories": df_sous_categories_from_db,
-            "labels": df_labels_from_db,
+            "displayedpropositionservice_max_id": displayedpropositionservice_max_id,
+            "action": df_actions_from_db,
+            "acteurservice": df_acteur_services_from_db,
+            "souscategorieobjet": df_sous_categories_from_db,
+            "labelqualite": df_labels_from_db,
             "acteurtype": df_acteurtype_from_db,
         },
     }[task_ids]
@@ -456,7 +456,7 @@ class TestCreatePropositionService:
                     "point_de_collecte_ou_de_reprise_des_dechets": [True],
                 }
             ),
-            max_pds_idx=123,
+            displayedpropositionservice_max_id=123,
         )
 
         kwargs = {"ti": mock}
@@ -610,14 +610,14 @@ def mock_ti(
             "config": db_mapping_config,
         },
         "load_data_from_postgresql": {
-            "max_pds_idx": 1,
-            "actions": df_actions_from_db,
-            "acteur_services": df_acteur_services_from_db,
-            "sous_categories": df_sous_categories_from_db,
-            "sources": df_sources_from_db,
+            "displayedpropositionservice_max_id": 1,
+            "action": df_actions_from_db,
+            "acteurservice": df_acteur_services_from_db,
+            "souscategorieobjet": df_sous_categories_from_db,
+            "source": df_sources_from_db,
             "acteurtype": df_acteurtype_from_db,
-            "labels": df_labels_from_db,
-            "displayedacteurs": df_displayed_acteurs_from_db,
+            "labelqualite": df_labels_from_db,
+            "displayedacteur": df_displayed_acteurs_from_db,
         },
         "create_proposition_services": {"df": df_proposition_services},
         "create_proposition_"
@@ -689,9 +689,9 @@ class TestCreateActorSeriesTransformations:
         mock = MagicMock()
         mock.xcom_pull.side_effect = lambda task_ids="": {
             "load_data_from_postgresql": {
-                "sources": df_sources_from_db,
+                "source": df_sources_from_db,
                 "acteurtype": None,
-                "displayedacteurs": df_empty_displayed_acteurs_from_db,
+                "displayedacteur": df_empty_displayed_acteurs_from_db,
             },
             "fetch_data_from_api": pd.DataFrame(
                 {
@@ -750,9 +750,9 @@ class TestCreateActorSeriesTransformations:
         mock = MagicMock()
         mock.xcom_pull.side_effect = lambda task_ids="": {
             "load_data_from_postgresql": {
-                "sources": df_sources_from_db,
+                "source": df_sources_from_db,
                 "acteurtype": None,
-                "displayedacteurs": df_empty_displayed_acteurs_from_db,
+                "displayedacteur": df_empty_displayed_acteurs_from_db,
             },
             "fetch_data_from_api": pd.DataFrame(
                 {
@@ -814,9 +814,9 @@ class TestCreateActorSeriesTransformations:
         mock = MagicMock()
         mock.xcom_pull.side_effect = lambda task_ids="": {
             "load_data_from_postgresql": {
-                "sources": df_sources_from_db,
+                "source": df_sources_from_db,
                 "acteurtype": None,
-                "displayedacteurs": df_empty_displayed_acteurs_from_db,
+                "displayedacteur": df_empty_displayed_acteurs_from_db,
             },
             "fetch_data_from_api": pd.DataFrame(
                 {
@@ -876,9 +876,9 @@ class TestCreateActorSeriesTransformations:
         mock = MagicMock()
         mock.xcom_pull.side_effect = lambda task_ids="": {
             "load_data_from_postgresql": {
-                "sources": df_sources_from_db,
+                "source": df_sources_from_db,
                 "acteurtype": None,
-                "displayedacteurs": df_empty_displayed_acteurs_from_db,
+                "displayedacteur": df_empty_displayed_acteurs_from_db,
             },
             "fetch_data_from_api": pd.DataFrame(
                 {
@@ -934,7 +934,7 @@ class TestCreateActeurServices:
         mock = MagicMock()
         mock.xcom_pull.side_effect = lambda task_ids="": {
             "load_data_from_postgresql": {
-                "acteur_services": df_acteur_services_from_db,
+                "acteurservice": df_acteur_services_from_db,
             },
             "create_actors": {
                 "df": pd.DataFrame(
@@ -965,7 +965,7 @@ class TestCreateActeurServices:
         mock = MagicMock()
         mock.xcom_pull.side_effect = lambda task_ids="": {
             "load_data_from_postgresql": {
-                "acteur_services": df_acteur_services_from_db,
+                "acteurservice": df_acteur_services_from_db,
             },
             "create_actors": {
                 "df": pd.DataFrame(
@@ -1007,7 +1007,7 @@ class TestCreateActeurServices:
         mock = MagicMock()
         mock.xcom_pull.side_effect = lambda task_ids="": {
             "load_data_from_postgresql": {
-                "acteur_services": df_acteur_services_from_db,
+                "acteurservice": df_acteur_services_from_db,
             },
             "create_actors": {
                 "df": pd.DataFrame(
@@ -1311,7 +1311,6 @@ def test_create_actors(mock_ti, mock_config):
     assert metadata["number_of_duplicates"] == 0
     assert metadata["added_rows"] == len(df_result)
     assert "siren" not in df_result.columns
-    assert "sous_categories" in result["config"]
 
 
 @pytest.mark.parametrize(
@@ -1388,9 +1387,9 @@ def test_acteur_to_delete(
     mock = MagicMock()
     mock.xcom_pull.side_effect = lambda task_ids="": {
         "load_data_from_postgresql": {
-            "sources": df_sources_from_db,
+            "source": df_sources_from_db,
             "acteurtype": None,
-            "displayedacteurs": df_displatedacteurs,
+            "displayedacteur": df_displatedacteurs,
         },
         "fetch_data_from_api": pd.DataFrame(
             {
@@ -1422,9 +1421,9 @@ def test_create_reparacteurs(
     mock = MagicMock()
     mock.xcom_pull.side_effect = lambda task_ids="": {
         "load_data_from_postgresql": {
-            "sources": df_sources_from_db,
+            "source": df_sources_from_db,
             "acteurtype": df_acteurtype_from_db,
-            "displayedacteurs": df_empty_displayed_acteurs_from_db,
+            "displayedacteur": df_empty_displayed_acteurs_from_db,
         },
         "fetch_data_from_api": pd.DataFrame(
             {
@@ -1489,7 +1488,6 @@ def test_create_reparacteurs(
     assert metadata["number_of_duplicates"] == 0
     assert metadata["added_rows"] == len(df_result)
     assert "siren" not in df_result.columns
-    assert "sous_categories" in result["config"]
     assert "event" in df_result.columns
 
 
@@ -1519,7 +1517,7 @@ class TestCeateLabels:
                     "acteur_type_id": [202, 202],
                 }
             ),
-            max_pds_idx=123,
+            displayedpropositionservice_max_id=123,
         )
 
         kwargs = {"ti": mock}
@@ -1559,7 +1557,7 @@ class TestCeateLabels:
                     "acteur_type_id": [201, 202],
                 }
             ),
-            max_pds_idx=123,
+            displayedpropositionservice_max_id=123,
         )
 
         kwargs = {"ti": mock}
@@ -1605,7 +1603,7 @@ class TestCeateLabels:
                     "acteur_type_id": [202, 202],
                 }
             ),
-            max_pds_idx=123,
+            displayedpropositionservice_max_id=123,
         )
 
         kwargs = {"ti": mock}

--- a/dags_unit_tests/dags/utils/test_dag_eo_utils.py
+++ b/dags_unit_tests/dags/utils/test_dag_eo_utils.py
@@ -134,7 +134,6 @@ def get_mock_ti_ps(
     mock.xcom_pull.side_effect = lambda task_ids="": {
         "create_actors": {
             "df": df_create_actors,
-            "config": db_mapping_config,
         },
         "load_data_from_postgresql": {
             "displayedpropositionservice_max_id": displayedpropositionservice_max_id,
@@ -161,7 +160,6 @@ def get_mock_ti_label(
     mock.xcom_pull.side_effect = lambda task_ids="": {
         "create_actors": {
             "df": df_create_actors,
-            "config": db_mapping_config,
         },
         "load_data_from_postgresql": {
             "displayedpropositionservice_max_id": displayedpropositionservice_max_id,
@@ -607,7 +605,6 @@ def mock_ti(
                     "point_de_collecte_ou_de_reprise_des_dechets": [True, True],
                 }
             ),
-            "config": db_mapping_config,
         },
         "load_data_from_postgresql": {
             "displayedpropositionservice_max_id": 1,
@@ -620,7 +617,6 @@ def mock_ti(
             "displayedacteur": df_displayed_acteurs_from_db,
         },
         "create_proposition_services": {"df": df_proposition_services},
-        "create_proposition_"
         "services_sous_categories": df_proposition_services_sous_categories,
     }[task_ids]
     return mock
@@ -1232,9 +1228,6 @@ class TestCreatePropositionServicesSousCategories:
         mock = MagicMock()
 
         mock.xcom_pull.side_effect = lambda task_ids="": {
-            "create_actors": {
-                "config": db_mapping_config,
-            },
             "load_data_from_postgresql": {
                 "sous_categories": df_sous_categories_from_db,
             },
@@ -1263,11 +1256,8 @@ class TestCreatePropositionServicesSousCategories:
         mock = MagicMock()
 
         mock.xcom_pull.side_effect = lambda task_ids="": {
-            "create_actors": {
-                "config": db_mapping_config,
-            },
             "load_data_from_postgresql": {
-                "sous_categories": df_sous_categories_from_db,
+                "souscategorieobjet": df_sous_categories_from_db,
             },
             "create_proposition_services": {
                 "df": pd.DataFrame(
@@ -1643,9 +1633,9 @@ class TestActorsLocation:
         mock = MagicMock()
         mock.xcom_pull.side_effect = lambda task_ids="": {
             "load_data_from_postgresql": {
-                "sources": df_sources_from_db,
+                "source": df_sources_from_db,
                 "acteurtype": df_acteurtype_from_db,
-                "displayedacteurs": df_empty_displayed_acteurs_from_db,
+                "displayedacteur": df_empty_displayed_acteurs_from_db,
             },
             "fetch_data_from_api": pd.DataFrame(
                 {


### PR DESCRIPTION
# ⚠️ -> ça ne fonctionne pas 😢 

# Description succincte du problème résolu

je ne sais pas comment on a fait pour que ça ne pête pas avant mais l'insertion des proposition de service fait un peu n'importe quoi au moment de calculer les id des proposition de service, j'ai déporté la logique au moment de l'insertion faute de mieux

Note pour plus tard, si on veut simplifier la gestion des proposition de service, alors le plus simple est certainement de passer sur des id de type uuid -> gros changement en perspective

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :
- [ ] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [x] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :
- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- Récupérer la base de production
- Aller sur http://localhost:8000
- Cliquer sur ABC
- …

## Développement local

<!-- Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe -->
- Mettre à jour le `.env`
- Réinstaller les dépendances Python avec `pip install -r requirements.txt -r dev-requirements.txt`
- Réinstaller les dépendances node avec `npm install`
- Rebuild la stack docker avec `docker compose build`
- ...

## Déploiement

<!-- Dans le cas où il y a des instructions spécifiques de déploiement -->

- Exécuter les migrations
- Exécuter la commande `rf -rf /`
- ...
