### PR TITLE
Garder le champ `cree_le` lors de la mise à jour des acteurs des EO

### DIFF
--- a/dags/aliapur.py
+++ b/dags/aliapur.py
@@ -28,7 +28,6 @@ with DAG(
             "ecoorganisme": "source_id",
             "adresse_format_ban": "adresse",
             "nom_de_lorganisme": "nom",
-            "_updatedAt": "cree_le",
             "perimetre_dintervention": "",
             "longitudewgs84": "longitude",
             "latitudewgs84": "latitude",

--- a/dags/cma.py
+++ b/dags/cma.py
@@ -30,7 +30,6 @@ with DAG(
             "id": "identifiant_externe",
             "is_enabled": "statut",
             "other_info": "commentaires",
-            "creation_date": "cree_le",
             "update_date": "modifie_le",
             "reparactor_hours": "horaires_description",
         },

--- a/dags/corepile.py
+++ b/dags/corepile.py
@@ -30,7 +30,6 @@ with DAG(
             "adresse_format_ban": "adresse",
             "nom_de_lorganisme": "nom",
             "enseigne_commerciale": "nom_commercial",
-            "_updatedAt": "cree_le",
             "perimetre_dintervention": "",
             "longitudewgs84": "longitude",
             "latitudewgs84": "latitude",

--- a/dags/ecodds.py
+++ b/dags/ecodds.py
@@ -25,7 +25,6 @@ with DAG(
             "reprise": "reprise",
             "nom_de_lorganisme": "nom",
             "enseigne_commerciale": "nom_commercial",
-            "_updatedAt": "cree_le",
             "longitudewgs84": "longitude",
             "latitudewgs84": "latitude",
         },

--- a/dags/ecologic.py
+++ b/dags/ecologic.py
@@ -28,7 +28,6 @@ with DAG(
             "ecoorganisme": "source_id",
             "adresse_format_ban": "adresse",
             "nom_de_lorganisme": "nom",
-            "_updatedAt": "cree_le",
             "perimetre_dintervention": "",
             "longitudewgs84": "longitude",
             "latitudewgs84": "latitude",

--- a/dags/ecomaison.py
+++ b/dags/ecomaison.py
@@ -34,7 +34,6 @@ with DAG(
             "site_web": "url",
             "adresse_format_ban": "adresse",
             "nom_de_lorganisme": "nom",
-            "_updatedAt": "cree_le",
             "perimetre_dintervention": "",
             "longitudewgs84": "longitude",
             "latitudewgs84": "latitude",

--- a/dags/ecosystem.py
+++ b/dags/ecosystem.py
@@ -28,7 +28,6 @@ with DAG(
             "ecoorganisme": "source_id",
             "adresse_format_ban": "adresse",
             "nom_de_lorganisme": "nom",
-            "_updatedAt": "cree_le",
             "perimetre_dintervention": "",
             "longitudewgs84": "longitude",
             "latitudewgs84": "latitude",

--- a/dags/ocab.py
+++ b/dags/ocab.py
@@ -29,7 +29,6 @@ with DAG(
             "ecoorganisme": "source_id",
             "adresse_format_ban": "adresse",
             "nom_de_lorganisme": "nom",
-            "_updatedAt": "cree_le",
             "perimetre_dintervention": "",
             "longitudewgs84": "longitude",
             "latitudewgs84": "latitude",

--- a/dags/pyreo.py
+++ b/dags/pyreo.py
@@ -28,7 +28,6 @@ with DAG(
             "ecoorganisme": "source_id",
             "adresse_format_ban": "adresse",
             "nom_de_lorganisme": "nom",
-            "_updatedAt": "cree_le",
             "perimetre_dintervention": "",
             "longitudewgs84": "longitude",
             "latitudewgs84": "latitude",

--- a/dags/refashion.py
+++ b/dags/refashion.py
@@ -32,7 +32,6 @@ with DAG(
             "adresse_format_ban": "adresse",
             "nom_de_lorganisme": "nom",
             "enseigne_commerciale": "nom_commercial",
-            "_updatedAt": "cree_le",
             "site_web": "url",
             "email": "email",
             "perimetre_dintervention": "",

--- a/dags/soren.py
+++ b/dags/soren.py
@@ -28,7 +28,6 @@ with DAG(
             "ecoorganisme": "source_id",
             "adresse_format_ban": "adresse",
             "nom_de_lorganisme": "nom",
-            "_updatedAt": "cree_le",
             "perimetre_dintervention": "",
             "longitudewgs84": "longitude",
             "latitudewgs84": "latitude",

--- a/dags/utils/dag_ingest_validated_utils.py
+++ b/dags/utils/dag_ingest_validated_utils.py
@@ -82,7 +82,7 @@ def handle_update_actor_event(df_actors, dag_run_id):
     )
 
     df_actors["modifie_le"] = current_time
-    df_actors["cree_le"] = current_time
+    df_actors["cree_le"] = df_actors["cree_le"].fillna(current_time)
 
     for column in update_required_columns:
         if column not in df_actors.columns:

--- a/dags/utils/eo_operators.py
+++ b/dags/utils/eo_operators.py
@@ -51,10 +51,10 @@ def read_data_from_postgres_task(
     )
 
 
-def read_displayedacteur_task(dag: DAG) -> PythonOperator:
+def read_acteur_task(dag: DAG) -> PythonOperator:
     return PythonOperator(
-        task_id="read_displayedacteur",
-        python_callable=dag_eo_utils.read_displayedacteur,
+        task_id="read_acteur",
+        python_callable=dag_eo_utils.read_acteur,
         dag=dag,
     )
 
@@ -149,7 +149,7 @@ def eo_task_chain(dag: DAG) -> None:
 
     chain(
         read_tasks,
-        read_displayedacteur_task(dag),
+        read_acteur_task(dag),
         create_actors_task(dag),
         create_tasks,
         create_proposition_services_sous_categories_task(dag),

--- a/dags/valdelia.py
+++ b/dags/valdelia.py
@@ -30,7 +30,6 @@ with DAG(
             "ecoorganisme": "source_id",
             "adresse_format_ban": "adresse",
             "nom_de_lorganisme": "nom",
-            "_updatedAt": "cree_le",
             "perimetre_dintervention": "",
             "longitudewgs84": "longitude",
             "latitudewgs84": "latitude",


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [Conserver la date initiale de création d’un acteur lors d’une mise à jour (EOs Koumoul, CMA RéparActeurs…)](https://www.notion.so/accelerateur-transition-ecologique-ademe/Conserver-la-date-initiale-de-cr-ation-d-un-acteur-lors-d-une-mise-jour-EOs-Koumoul-CMA-R-parAct-d77140f465a648f9b3ff5ec057158fac?pvs=4)

Correction de cette PR : 
- On utilise la table `qfdmo_acteur` à la place de `qfdmo_displayedacteur` pour comparer les acteurs à modifier et les acteurs qu'on est en train d'importer
- On garde le champ `cree_le` de `qfdmo_acteur` quand l'entité existe déjà, sinon on prend le `now()`
- Plus besoin de filtrer sur la source dans la dataframe car c'est fait en amont, lors du selecten base de données
- Suppression de logs de débug qui trainaient

RAF:
- [x] un test qui prouve qu'on garde le champ `cree_le`

Dans une autre PR:
- [ ] Modification de la suppression des acteurs pour mettre le statut supprimé sur l'acteur importé directement

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :
- [ ] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :
- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- Récupérer la base de production
- Aller sur http://localhost:8000
- Cliquer sur ABC
- …

## Développement local

<!-- Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe -->
- Mettre à jour le `.env`
- Réinstaller les dépendances Python avec `pip install -r requirements.txt -r dev-requirements.txt`
- Réinstaller les dépendances node avec `npm install`
- Rebuild la stack docker avec `docker compose build`
- ...

## Déploiement

<!-- Dans le cas où il y a des instructions spécifiques de déploiement -->

- Exécuter les migrations
- Exécuter la commande `rf -rf /`
- ...
