### PR TITLE
Changed the euro icon to the percent icon for the repair bonus

### DIFF
--- a/static/to_compile/entrypoints/qfdmo.css
+++ b/static/to_compile/entrypoints/qfdmo.css
@@ -135,10 +135,10 @@ Style the autocomplete container:
   mask-image: url("svg/shield-check-line.svg");
 }
 
-.fr-icon-money-euro-box-line::before,
-.fr-icon-money-euro-box-line::after {
-  -webkit-mask-image: url("svg/money-euro-box-line.svg");
-  mask-image: url("svg/money-euro-box-line.svg");
+.fr-icon-percent-line::before,
+.fr-icon-percent-line::after {
+  -webkit-mask-image: url("svg/percent-line.svg");
+  mask-image: url("svg/percent-line.svg");
 }
 
 .fr-icon-tools-fill::before,


### PR DESCRIPTION
J'ai modifié l'icône "Euro" par l'icône "Pourcentage" pour le bonus réparation en anticipation de ceci : https://www.figma.com/design/5JebAm7BkWvC6lMMkOu6nN/%F0%9F%AA%91-LVAO---Espace-de-travail?node-id=422-2616&t=YpPty5EKdeFieQk4-1