### PR TITLE
fix issue when querying epci codes

### DIFF
--- a/qfdmo/forms.py
+++ b/qfdmo/forms.py
@@ -5,7 +5,7 @@ from django.core.cache import cache
 from django.http import HttpRequest
 from django.utils.safestring import mark_safe
 
-from qfdmo.geo_api import all_epci_codes
+from qfdmo.geo_api import all_epci_codes_as_tuples
 from qfdmo.models import DagRun, DagRunStatus, SousCategorieObjet
 from qfdmo.models.action import (
     Action,
@@ -301,7 +301,7 @@ class CarteAddressesForm(AddressesForm):
     )
 
     epci_codes = forms.MultipleChoiceField(
-        choices=all_epci_codes,
+        choices=all_epci_codes_as_tuples,
         widget=forms.MultipleHiddenInput(),
         required=False,
     )

--- a/qfdmo/geo_api.py
+++ b/qfdmo/geo_api.py
@@ -1,16 +1,21 @@
-from typing import List, cast
+from typing import List, Tuple, cast
+
+import requests
 from django.contrib.gis.geos import GEOSGeometry
 from django.core.cache import caches
-import requests
 
 db_cache = caches["database"]
 
 
-def fetch_epci_codes() -> List[str]:
-    """Retrieves EPCI codes from geo.api"""
+def fetch_epci_data(fields=["code"]) -> List[any]:
+    """Retrieves EPCI codes from geo.api with fields passed in parameter"""
     response = requests.get("https://geo.api.gouv.fr/epcis/?fields=code")
-    codes = [item["code"] for item in response.json()]
-    return codes
+    fields = [(item[field] for field in fields) for item in response.json()]
+    return fields
+
+
+def fetch_epci_codes() -> List[str]:
+    return fetch_epci_data(["code"])
 
 
 def all_epci_codes() -> List[str]:
@@ -20,6 +25,11 @@ def all_epci_codes() -> List[str]:
             "all_epci_codes", fetch_epci_codes, timeout=3600 * 24 * 365
         ),
     )
+
+
+def all_epci_codes_as_tuples() -> List[Tuple[str, str]]:
+    # Just a callable to use in forms
+    return [(item, item) for item in all_epci_codes()]
 
 
 def retrieve_epci_geojson(epci):


### PR DESCRIPTION
# Description succincte du problème résolu

Hotfix du hotfix d'hier soir. 
La fonction utilisée ici https://github.com/incubateur-ademe/quefairedemesobjets/pull/920 sert à retourner un tuple tel qu'attendu par le multiplechoicefield. 

Mais il faut lui passer un callable pour éviter que la vue, qui est importée et interprètee quand django construit le registre des urls, ne déclencher un appel au cache (et par extension à geo api, je ne sais pas jusqu'où ca va). 