### PR TITLE
Ajout de '0' devant les numéro de téléphone en France métropolitaine

### DIFF
--- a/dags/utils/dag_eo_utils.py
+++ b/dags/utils/dag_eo_utils.py
@@ -539,8 +539,14 @@ def create_actors(**kwargs):
 
     if "siret" in df.columns:
         df["siret"] = df["siret"].apply(mapping_utils.process_siret)
-    if "telephone" in df.columns:
-        df["telephone"] = df["telephone"].apply(mapping_utils.process_phone_number)
+
+    if "telephone" in df.columns and "code_postal" in df.columns:
+        df["telephone"] = df.apply(
+            lambda row: pd.Series(
+                mapping_utils.process_phone_number(row["telephone"], row["code_postal"])
+            ),
+            axis=1,
+        )
 
     df = df.replace({np.nan: None})
 

--- a/dags/utils/mapping_utils.py
+++ b/dags/utils/mapping_utils.py
@@ -6,12 +6,21 @@ from datetime import datetime
 import pandas as pd
 
 
-def process_siret(siret):
-    if pd.isna(siret):
-        return None
-    siret = str(siret).replace(" ", "")
+def _clean_number(number):
+    if pd.isna(number) or number is None:
+        return number
 
-    if not siret.isdigit():
+    # suppression des 2 derniers chiffres si le caractère si == .0
+    number = re.sub(r"\.0$", "", str(number))
+    # suppression de tous les caractères autre que digital
+    number = re.sub(r"[^\d+]", "", number)
+    return number
+
+
+def process_siret(siret):
+    siret = _clean_number(siret)
+
+    if siret is None:
         return None
 
     if len(siret) == 9:
@@ -26,11 +35,15 @@ def process_siret(siret):
     return None
 
 
-def process_phone_number(number):
-    if pd.isna(number):
-        return number
+def process_phone_number(number, code_postal):
 
-    number = re.sub(r"[^\d+]", "", number)
+    number = _clean_number(number)
+
+    if number is None:
+        return None
+
+    if len(number) == 9 and code_postal and int(code_postal) < 96000:
+        number = "0" + number
 
     if number.startswith("33"):
         number = "0" + number[2:]

--- a/dags/utils/mapping_utils.py
+++ b/dags/utils/mapping_utils.py
@@ -2,13 +2,14 @@ import json
 import math
 import re
 from datetime import datetime
+from typing import Any
 
 import pandas as pd
 
 
-def _clean_number(number):
+def _clean_number(number: Any) -> str | None:
     if pd.isna(number) or number is None:
-        return number
+        return None
 
     # suppression des 2 derniers chiffres si le caractère si == .0
     number = re.sub(r"\.0$", "", str(number))

--- a/dags_unit_tests/dags/utils/test_mapping_utils.py
+++ b/dags_unit_tests/dags/utils/test_mapping_utils.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import pandas as pd
 import pytest
 from utils import mapping_utils
@@ -68,6 +69,7 @@ def test_process_siret(siret, expected_siret):
     "phone_number, code_postal, expected_phone_number",
     [
         (None, None, None),
+        (np.NaN, None, None),
         ("1 23 45 67 89", "75001", "0123456789"),
         ("33 1 23 45 67 89", "75001", "0123456789"),
         ("0612345678", "75001", "0612345678"),

--- a/dags_unit_tests/dags/utils/test_mapping_utils.py
+++ b/dags_unit_tests/dags/utils/test_mapping_utils.py
@@ -1,7 +1,7 @@
 import unittest
 
-import numpy as np
 import pandas as pd
+import pytest
 from utils import mapping_utils
 
 
@@ -49,23 +49,36 @@ class TestDataTransformations(unittest.TestCase):
         }
         self.assertEqual(mapping_utils.create_identifiant_unique(row), "ecoorg_123AbC")
 
-    def test_process_siret_value(self):
-        self.assertEqual(mapping_utils.process_siret("123456789012345"), None)
-        self.assertEqual(mapping_utils.process_siret(np.nan), None)
-        self.assertEqual(
-            mapping_utils.process_siret("98765432109876"), "98765432109876"
-        )
-        self.assertEqual(mapping_utils.process_siret("8765432109876"), "08765432109876")
 
-    def test_process_telephone_value(self):
-        self.assertEqual(
-            mapping_utils.process_phone_number("33 1 23 45 67 89"), "0123456789"
-        )
-        self.assertEqual(mapping_utils.process_phone_number("0612345678"), "0612345678")
-        self.assertEqual(mapping_utils.process_phone_number(None), None)
-        self.assertEqual(
-            mapping_utils.process_phone_number("+33612345678"), "+33612345678"
-        )
+@pytest.mark.parametrize(
+    "siret, expected_siret",
+    [
+        (None, None),
+        ("123456789012345", None),
+        ("98765432109876", "98765432109876"),
+        ("8765432109876", "08765432109876"),
+        ("AB123", None),
+    ],
+)
+def test_process_siret(siret, expected_siret):
+    assert mapping_utils.process_siret(siret) == expected_siret
+
+
+@pytest.mark.parametrize(
+    "phone_number, code_postal, expected_phone_number",
+    [
+        (None, None, None),
+        ("1 23 45 67 89", "75001", "0123456789"),
+        ("33 1 23 45 67 89", "75001", "0123456789"),
+        ("0612345678", "75001", "0612345678"),
+        ("+33612345678", "75001", "+33612345678"),
+    ],
+)
+def test_process_phone_number(phone_number, code_postal, expected_phone_number):
+    assert (
+        mapping_utils.process_phone_number(phone_number, code_postal)
+        == expected_phone_number
+    )
 
 
 class TestTransformFloat(unittest.TestCase):

--- a/qfdmo/management/commands/fix_tel_9_char.py
+++ b/qfdmo/management/commands/fix_tel_9_char.py
@@ -1,0 +1,15 @@
+from django.core.management.base import BaseCommand
+from django.db.models import F, Value
+from django.db.models.functions import Concat, Length
+
+from qfdmo.models.acteur import Acteur, DisplayedActeur, RevisionActeur
+
+
+class Command(BaseCommand):
+    help = "Export Ressources using CSV format"
+
+    def handle(self, *args, **options):
+        for cls in [Acteur, RevisionActeur, DisplayedActeur]:
+            cls.objects.annotate(len_tel=Length("telephone")).filter(
+                len_tel=9, code_postal__lt=96000
+            ).update(telephone=Concat(Value("0"), F("telephone")))


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [Ajouter les 0 manquants au début des numéros de téléphone si seulement 9 caractères](https://www.notion.so/accelerateur-transition-ecologique-ademe/Ajouter-les-0-manquants-au-d-but-des-num-ros-de-t-l-phone-si-seulement-9-caract-res-6e40c7b064fd405ea50aab44b9232866?pvs=4)

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
