### PR TITLE
Ajout de la synchro des environnements prod vers preprod tous les WE

### DIFF
--- a/.github/workflows/sync_databases.yml
+++ b/.github/workflows/sync_databases.yml
@@ -2,8 +2,8 @@ name: Sync databases
 
 on:
   workflow_dispatch:
-  # schedule:
-  # - cron: "0 0 * * SUN"
+  schedule:
+  - cron: "0 0 * * SUN"
 
 env:
   DUPLICATE_API_TOKEN: ${{ secrets.DUPLICATE_API_TOKEN }}


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [Synchroniser la base de Prod avec Preprod 1 fois par semaine](https://www.notion.so/accelerateur-transition-ecologique-ademe/Synchroniser-la-base-de-Prod-avec-Preprod-1-fois-par-semaine-4285b5af8dc845389975f743e5c80187?pvs=4)

Comme un cron :)

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [ ] Bug fix
- [x] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
