### PR TITLE
fix any not being imported from the right place

### DIFF
--- a/qfdmo/views/configurator.py
+++ b/qfdmo/views/configurator.py
@@ -6,7 +6,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponse
 from django.shortcuts import render
 from django.views.generic.edit import FormView
-from typing_extensions import Any
+from typing import Any
 
 from qfdmo.forms import AdvancedConfiguratorForm, ConfiguratorForm
 

--- a/qfdmo/views/configurator.py
+++ b/qfdmo/views/configurator.py
@@ -6,7 +6,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponse
 from django.shortcuts import render
 from django.views.generic.edit import FormView
-from pandas.core.apply import Any
+from typing_extensions import Any
 
 from qfdmo.forms import AdvancedConfiguratorForm, ConfiguratorForm
 


### PR DESCRIPTION
# Description succincte du problème résolu

Suite au merge du configurateur collectivité (#890), on avait un soucis de déploiement. 
C'est un mystère de pourquoi ce soucis se produisait durant le `postdeploy` Scalingo et pas en local, en revanche la cause venait d'un import pandas fait dans `urls.py` qui aurait du venir de `typing`

# Comment tester 
Ça a été déployé en preprod (via la GitHub actions) et corrige le bug qui survenait jusqu'à à présent 