### PR TITLE
Fix issue with ordering - accidental scoring 

### DIFF
--- a/qfdmo/models/acteur.py
+++ b/qfdmo/models/acteur.py
@@ -198,14 +198,18 @@ class ActeurQuerySet(models.QuerySet):
             return self.physical()
 
         geometry = GEOSGeometry(geojson)
-        return self.physical().filter(location__within=geometry)
+        return self.physical().filter(location__within=geometry).order_by("?")
 
     def in_bbox(self, bbox):
         if not bbox:
             # TODO : test
             return self.physical()
 
-        return self.physical().filter(location__within=Polygon.from_bbox(bbox))
+        return (
+            self.physical()
+            .filter(location__within=Polygon.from_bbox(bbox))
+            .order_by("?")
+        )
 
     def from_center(self, longitude, latitude, distance=settings.DISTANCE_MAX):
         reference_point = Point(float(longitude), float(latitude), srid=4326)


### PR DESCRIPTION
# Description succincte du problème résolu

On a identifié un _scoring_ accidentel des acteurs qui résulte d'une suppression du tri aléatoire des acteurs.

Ceci corrige cela, avec l'ajout d'un test unitaire qui vérifie qu'on ne casse pas cela dans le futur. 

**Type de changement** :

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- aller sur `?carte`
- chercher `Paris`
- Dézommer
- cliquer sur `rechercher dans cette zone` 
- On doit avoir des points autre que "Réparer"