### PR TITLE
latest feedback

### DIFF
--- a/qfdmo/forms.py
+++ b/qfdmo/forms.py
@@ -352,12 +352,12 @@ class DagsForm(forms.Form):
 
 class ConfiguratorForm(DsfrBaseForm):
     # TODO: rename this field in all codebase -> actions_displayed
-    action_displayed = GroupeActionChoiceField(
+    action_list = GroupeActionChoiceField(
         queryset=GroupeAction.objects.all(),
         to_field_name="code",
         widget=forms.CheckboxSelectMultiple,
         required=False,
-        initial=GroupeAction.objects.all,
+        initial=GroupeAction.objects.exclude(code="trier"),
         label=mark_safe(
             "<h3>Informations disponibles sur la carte</h3>"
             "Choisissez les actions disponibles pour vos usagers."
@@ -366,14 +366,6 @@ class ConfiguratorForm(DsfrBaseForm):
         "dans la carte que vous intègrerez. Par exemple, si vous ne voulez "
         "faire une carte que sur les points de collecte ou de réparation, il vous "
         "suffit de décocher toutes les autres actions possibles.",
-    )
-    # TODO: rename this field in all codebase to use checked_actions
-    action_list = forms.ModelMultipleChoiceField(
-        queryset=GroupeAction.objects.all(),
-        to_field_name="code",
-        widget=forms.MultipleHiddenInput,
-        required=False,
-        initial=GroupeAction.objects.exclude(code="trier"),
     )
     epci_codes = EPCIField(
         label=mark_safe(


### PR DESCRIPTION
# Description succincte du problème résolu

Dernière correction suite à https://www.notion.so/accelerateur-transition-ecologique-ademe/Configurateur-simplifi-pour-les-collectivit-s-4db7e146958942bb973910d2e92e78a3?pvs=4 


> Suite à échange avec Coline : à afficher mais pas coché
> 
> ”Je dépose en point de collecte” ne doit pas être coché par défaut dans “Choisissez les actions…”. Mais il est affiché dans la carte et dans la légende comme non coché.
> 
> Quelque soit les actions disponibles choisies dans le configurateur, tous les gestes doivent être affichés sur la carte et dans la légende.
> Mais si ils ne sont pas cochés dans “choisissez les actions”, ils sont non cochés dans la légende.