### PR TITLE
fix bbox still being set when equal None

### DIFF
--- a/integration_tests/qfdmo/test_adresses_view.py
+++ b/integration_tests/qfdmo/test_adresses_view.py
@@ -220,7 +220,7 @@ class TestReparacteur:
 
 @pytest.mark.django_db
 class TestReparerAlternateIcon:
-    def test_no_action_reparer_selected_do_not_add_reparer_attribute(
+    def test_no_action_reparer_selected_does_not_add_reparer_attribute(
         self, adresses_view, displayed_acteur_donner_reparer, action_donner
     ):
         request = HttpRequest()
@@ -259,7 +259,7 @@ class TestReparerAlternateIcon:
 
 @pytest.mark.django_db
 class TestExclusiviteReparation:
-    def test_pas_action_reparer_exclut_acteurs_avec_exclusivite(
+    def test_no_action_reparer_excludes_acteurs_avec_exclusivite(
         self, adresses_view, displayed_acteur_reparer, action_preter
     ):
         request = HttpRequest()
@@ -276,7 +276,7 @@ class TestExclusiviteReparation:
 
         assert context["acteurs"].count() == 0
 
-    def test_action_reparer_exclut_par_defaut_acteurs_avec_exclusivite(
+    def test_action_reparer_excludes_acteurs_avec_exclusivite_by_default(
         self, adresses_view, displayed_acteur_reparer, action_reparer, action_preter
     ):
         request = HttpRequest()
@@ -293,7 +293,7 @@ class TestExclusiviteReparation:
 
         assert context["acteurs"].count() == 0
 
-    def test_action_reparer_et_exclusivite_inclut_acteurs_avec_exclusivite(
+    def test_action_reparer_and_exclusivite_includes_acteurs_with_exclusivite(
         self, adresses_view, displayed_acteur_reparer, action_reparer
     ):
         request = HttpRequest()
@@ -450,7 +450,9 @@ class TestBBOX:
         assert bbox == leaflet_bbox
 
     @override_settings(DISTANCE_MAX=100000000000)
-    def test_no_bbox_is_returned_if_no_acteurs_found_in_bbox(self):
+    def test_no_bbox_and_acteurs_from_center_if_no_acteurs_found_in_bbox(
+        self,
+    ):
         request = HttpRequest()
         adresses_view = CarteView()
         bbox = [0, 0, 0, 0]

--- a/integration_tests/qfdmo/test_adresses_view.py
+++ b/integration_tests/qfdmo/test_adresses_view.py
@@ -391,3 +391,23 @@ class TestFilters:
 
         assert DisplayedActeur.objects.count() > 1
         assert context["acteurs"].count() == 1
+
+
+@pytest.mark.django_db
+class TestBBOX:
+    def test_no_acteurs_in_bbox_no_bbox_is_returned(self):
+        DisplayedActeurFactory.create_batch(2)
+        request = HttpRequest()
+        adresses_view = CarteView()
+        request.GET = query_dict_from(
+            {
+                "latitude": [1],
+                "longitude": [1],
+                # "bounding_box": [json.loads(compile_leaflet_bbox([-3, -3, 3, 3]))]
+            }
+        )
+        adresses_view.setup(request)
+        acteurs = DisplayedActeur.objects.all()
+        bbox, acteurs = adresses_view._bbox_and_acteurs_from_location_or_epci(acteurs)
+        assert bbox is None
+        assert acteurs.count() == 0

--- a/integration_tests/qfdmo/test_adresses_view.py
+++ b/integration_tests/qfdmo/test_adresses_view.py
@@ -1,7 +1,9 @@
 import pytest
 from django.contrib.gis.geos import Point
 from django.http import HttpRequest
+from django.test import override_settings
 
+from qfdmo.leaflet import compile_leaflet_bbox
 from qfdmo.models.acteur import ActeurStatus, DisplayedActeur
 from qfdmo.views.adresses import CarteView
 from unit_tests.core.test_utils import query_dict_from
@@ -217,6 +219,45 @@ class TestReparacteur:
 
 
 @pytest.mark.django_db
+class TestReparerAlternateIcon:
+    def test_no_action_reparer_selected_do_not_add_reparer_attribute(
+        self, adresses_view, displayed_acteur_donner_reparer, action_donner
+    ):
+        request = HttpRequest()
+        request.GET = query_dict_from(
+            {
+                "action_list": [action_donner.code],
+                "latitude": [1],
+                "longitude": [1],
+            }
+        )
+        adresses_view.setup(request)
+        context = adresses_view.get_context_data()
+
+        with pytest.raises(AttributeError):
+            context["acteurs"].first().reparer
+
+    def test_action_reparer_selected_adds_reparer_attribute_on_actors_with_reparation(
+        self,
+        adresses_view,
+        displayed_acteur_donner_reparer,
+        action_donner,
+        action_reparer,
+    ):
+        request = HttpRequest()
+        request.GET = query_dict_from(
+            {
+                "action_list": [action_donner.code, action_reparer.code],
+                "latitude": [1],
+                "longitude": [1],
+            }
+        )
+        adresses_view.setup(request)
+        context = adresses_view.get_context_data()
+        assert context["acteurs"].first().reparer
+
+
+@pytest.mark.django_db
 class TestExclusiviteReparation:
     def test_pas_action_reparer_exclut_acteurs_avec_exclusivite(
         self, adresses_view, displayed_acteur_reparer, action_preter
@@ -395,19 +436,51 @@ class TestFilters:
 
 @pytest.mark.django_db
 class TestBBOX:
-    def test_no_acteurs_in_bbox_no_bbox_is_returned(self):
-        DisplayedActeurFactory.create_batch(2)
+    def test_bbox_is_returned_if_no_acteurs(self):
         request = HttpRequest()
         adresses_view = CarteView()
-        request.GET = query_dict_from(
-            {
-                "latitude": [1],
-                "longitude": [1],
-                # "bounding_box": [json.loads(compile_leaflet_bbox([-3, -3, 3, 3]))]
-            }
-        )
+        leaflet_bbox = compile_leaflet_bbox([1, 1, 1, 1])
+        request.GET = query_dict_from({})
+        request.GET.update(bounding_box=leaflet_bbox)
         adresses_view.setup(request)
+
         acteurs = DisplayedActeur.objects.all()
+        assert acteurs.count() == 0
+        bbox, acteurs = adresses_view._bbox_and_acteurs_from_location_or_epci(acteurs)
+        assert bbox == leaflet_bbox
+
+    @override_settings(DISTANCE_MAX=100000000000)
+    def test_no_bbox_is_returned_if_no_acteurs_found_in_bbox(self):
+        request = HttpRequest()
+        adresses_view = CarteView()
+        bbox = [0, 0, 0, 0]
+        leaflet_bbox = compile_leaflet_bbox(bbox)
+        request.GET = query_dict_from({})
+        request.GET.update(bounding_box=leaflet_bbox, latitude="1", longitude="1")
+        adresses_view.setup(request)
+
+        DisplayedActeurFactory.create_batch(2)
+        acteurs = DisplayedActeur.objects.all()
+        assert acteurs.in_bbox(bbox).count() == 0
+        assert acteurs.from_center(1, 1).count() == 2
+
         bbox, acteurs = adresses_view._bbox_and_acteurs_from_location_or_epci(acteurs)
         assert bbox is None
-        assert acteurs.count() == 0
+        assert acteurs.count() == 2
+
+    def test_bbox_and_acteurs_are_returned_if_contained_in_bbox(self):
+        request = HttpRequest()
+        adresses_view = CarteView()
+        bbox = [-2, -2, 4, 4]  # Acteurs in factory are created with a location of 3, 3
+        leaflet_bbox = compile_leaflet_bbox(bbox)
+        request.GET = query_dict_from({})
+        request.GET.update(bounding_box=leaflet_bbox, latitude="1", longitude="1")
+        adresses_view.setup(request)
+
+        DisplayedActeurFactory.create_batch(2)
+        acteurs = DisplayedActeur.objects.all()
+        assert acteurs.in_bbox(bbox).count() == 2
+
+        bbox, acteurs = adresses_view._bbox_and_acteurs_from_location_or_epci(acteurs)
+        assert bbox == bbox
+        assert acteurs.count() == 2

--- a/jinja2/qfdmo/carte/_header.html
+++ b/jinja2/qfdmo/carte/_header.html
@@ -4,10 +4,8 @@
     </div>
 
     {# Recherche adresse #}
-    <div class="fr-my-1w qfdmo-flex-grow qfdmo-flex qfdmo-flex-col md:qfdmo-mr-2w">
-        <div class="fr-input-group">
-            {% include 'qfdmo/_addresses_partials/adresse_input_form.html' %}
-        </div>
+    <div class="fr-my-1w qfdmo-flex-grow qfdmo-flex qfdmo-flex-col md:qfdmo-pl-3w md:qfdmo-pr-6w">
+        {% include 'qfdmo/_addresses_partials/adresse_input_form.html' %}
 
         <div class="lg:qfdmo-hidden fr-mt-1w qfdmo-flex qfdmo-justify-between">
             <button

--- a/jinja2/qfdmo/carte/_map.html
+++ b/jinja2/qfdmo/carte/_map.html
@@ -154,7 +154,7 @@
                             </div>
                         </div>
                     {% endwith %}
-                    {% for acteur in acteurs.with_reparer().with_bonus() %}
+                    {% for acteur in acteurs %}
                         <script type="application/json" data-map-target="acteur">
                             {{ acteur.json_acteur_for_display(direction=form.initial.direction, action_list=form.initial.action_list, carte=carte) | safe }}
                         </script>

--- a/qfdmo/models/acteur.py
+++ b/qfdmo/models/acteur.py
@@ -223,9 +223,9 @@ class DisplayedActeurQuerySet(models.QuerySet):
             .order_by("?")
         )
 
-    def from_center(self, longitude, latitude, distance=settings.DISTANCE_MAX):
+    def from_center(self, longitude, latitude):
         reference_point = Point(float(longitude), float(latitude), srid=4326)
-        distance_in_degrees = distance / 111320
+        distance_in_degrees = settings.DISTANCE_MAX / 111320
 
         return (
             self.physical()

--- a/qfdmo/views/adresses.py
+++ b/qfdmo/views/adresses.py
@@ -189,9 +189,9 @@ class CarteView(TurboFormView, FormView):
             pass
 
         try:
-            return self.request.GET.getlist(key, default)
-        except AttributeError:
             return self.request.GET.get(key, default)
+        except AttributeError:
+            return self.request.GET.getlist(key, default)
 
     def get_context_data(self, **kwargs):
         form = self.get_form_class()(self.request.GET)

--- a/qfdmo/views/adresses.py
+++ b/qfdmo/views/adresses.py
@@ -231,7 +231,16 @@ class CarteView(TurboFormView, FormView):
                 )
 
         kwargs.update(acteurs=acteurs)
-        return super().get_context_data(**kwargs)
+        context = super().get_context_data(**kwargs)
+
+        # TODO : refacto forms, gérer ça autrement
+        try:
+            if bbox is None:
+                context["form"].initial["bounding_box"] = None
+        except NameError:
+            pass
+
+        return context
 
     def _bbox_and_acteurs_from_location_or_epci(self, acteurs):
         custom_bbox = cast(

--- a/static/to_compile/src/solution_map.ts
+++ b/static/to_compile/src/solution_map.ts
@@ -133,7 +133,7 @@ export class SolutionMap {
   }
 
   displayActor(actors: Array<DisplayedActeur>, bboxValue?: Array<Number>): void {
-    let points: Array<Array<Number>> = []
+    const points: Array<Array<Number>> = []
     actors.forEach(function (actor: DisplayedActeur) {
       if (actor.location) {
         const markerHtmlString = this.#generateMarkerHTMLStringFrom(actor)
@@ -178,7 +178,7 @@ export class SolutionMap {
   fitBounds(points, bboxValue) {
     this.points = points
     this.bboxValue = bboxValue
-    if (bboxValue !== undefined) {
+    if (typeof bboxValue !== "undefined") {
       this.map.fitBounds([
         [bboxValue.southWest.lat, bboxValue.southWest.lng],
         [bboxValue.northEast.lat, bboxValue.northEast.lng],

--- a/templates/forms/widgets/autocomplete.html
+++ b/templates/forms/widgets/autocomplete.html
@@ -1,6 +1,6 @@
 {% load custom_filters %}
 <div
-    class="qfdmo-flex-grow"
+    class="fr-my-1w qfdmo-flex-grow"
 >
     <div
         class="{% block wrapper_classes %}{% endblock %}"

--- a/templates/forms/widgets/autocomplete.html
+++ b/templates/forms/widgets/autocomplete.html
@@ -1,6 +1,6 @@
 {% load custom_filters %}
 <div
-    class="fr-my-1w qfdmo-flex-grow"
+    class="qfdmo-flex-grow"
 >
     <div
         class="{% block wrapper_classes %}{% endblock %}"


### PR DESCRIPTION
# Description succincte du problème résolu

[Carte Notion](https://www.notion.so/accelerateur-transition-ecologique-ademe/R-gressions-d-placement-dans-la-carte-1266523d57d7804ea1eee8deb6bcb424?pvs=4)


- Actuellement lorsqu'on est dans une zone qui n'a aucun acteur, le dézoom ne se fait pas malgré le fait qu'on affiche des acteurs affiches en dehors de la bbox affiché par Leaflet. 
- l'input adresse est mal stylisé depuis qu'on a supprimé le bouton rechercher 

**Type de changement** :

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code
