### PR TITLE
Renommer l'id du connecteur QFDMO_DJANGO_DB

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -19,3 +19,4 @@ AWS_S3_ENDPOINT_URL='https://s3.fr-par.scw.cloud'
 AWS_STORAGE_BUCKET_NAME='qfdmo-interface'
 AIRFLOW_WEBSERVER_REFRESHACTEUR_URL=http://localhost:8080
 CORS_ALLOWED_ORIGINS=http://localhost:8000,http://127.0.0.1:8000
+AIRFLOW_CONN_QFDMO_DJANGO_DB=postgres://qfdmo:qfdmo@localhost:6543/qfdmo

--- a/README.airflow.md
+++ b/README.airflow.md
@@ -86,7 +86,7 @@ Attention à ajouter le paramètre endpoint_url pour le stockage Cellar de Cleve
 
 #### Gestion de la base de données
 
-La connexion postgres `qfdmo-django-db` doit aussi être configurée dans l'interface d'Airflow
+La connexion postgres `qfdmo_django_db` doit aussi être configurée dans l'interface d'Airflow
 
 ##### Spécificité de l'environnement de développement
 

--- a/dags/.env.template
+++ b/dags/.env.template
@@ -24,4 +24,4 @@ AIRFLOW__SCHEDULER__ENABLE_HEALTH_CHECK='true'
 # WARNING=Use _PIP_ADDITIONAL_REQUIREMENTS option ONLY for a quick checks
 # for other purpose (development, test and especially production usage) build/extend Airflow image.
 _PIP_ADDITIONAL_REQUIREMENTS=${_PIP_ADDITIONAL_REQUIREMENTS:-}
-AIRFLOW_CONN_QFDMO-DJANGO-DB='postgres://qfdmo:qfdmo@lvao-db:5432/qfdmo' # pragma: allowlist secret
+AIRFLOW_CONN_QFDMO_DJANGO_DB='postgres://qfdmo:qfdmo@lvao-db:5432/qfdmo' # pragma: allowlist secret

--- a/dags/annuaire_entreprise_checks.py
+++ b/dags/annuaire_entreprise_checks.py
@@ -46,7 +46,7 @@ dag = DAG(
 
 def fetch_and_parse_data(**context):
     limit = context["params"]["limit"]
-    pg_hook = PostgresHook(postgres_conn_id="qfdmo-django-db")
+    pg_hook = PostgresHook(postgres_conn_id="qfdmo_django_db")
     engine = pg_hook.get_sqlalchemy_engine()
     active_actors_query = """
         SELECT

--- a/dags/annuaire_entreprise_integration.py
+++ b/dags/annuaire_entreprise_integration.py
@@ -35,7 +35,7 @@ WAIT_SECONDS = 5
 
 
 def fetch_and_process_data(url_title, table_name, index_column, schema, **context):
-    pg_hook = PostgresHook(postgres_conn_id="qfdmo-django-db")
+    pg_hook = PostgresHook(postgres_conn_id="qfdmo_django_db")
     engine = pg_hook.get_sqlalchemy_engine()
 
     with pg_hook.get_conn() as conn:

--- a/dags/create_final_actors.py
+++ b/dags/create_final_actors.py
@@ -218,7 +218,7 @@ def write_data_to_postgres(**kwargs):
         inplace=True,
     )
 
-    pg_hook = PostgresHook(postgres_conn_id="qfdmo-django-db")
+    pg_hook = PostgresHook(postgres_conn_id="qfdmo_django_db")
     engine = pg_hook.get_sqlalchemy_engine()
 
     original_table_name_actor = "qfdmo_displayedacteur"

--- a/dags/ingest_validated_dataset_to_db.py
+++ b/dags/ingest_validated_dataset_to_db.py
@@ -28,7 +28,7 @@ dag = DAG(
 
 
 def _get_first_dagrun_to_insert():
-    hook = PostgresHook(postgres_conn_id="qfdmo-django-db")
+    hook = PostgresHook(postgres_conn_id="qfdmo_django_db")
     # get first row from table qfdmo_dagrun with status TO_INSERT
     row = hook.get_first(
         f"SELECT * FROM qfdmo_dagrun WHERE status = '{shared_constants.TO_INSERT}'"
@@ -51,7 +51,7 @@ def fetch_and_parse_data(**context):
     row = _get_first_dagrun_to_insert()
     dag_run_id = row[0]
 
-    pg_hook = PostgresHook(postgres_conn_id="qfdmo-django-db")
+    pg_hook = PostgresHook(postgres_conn_id="qfdmo_django_db")
     engine = pg_hook.get_sqlalchemy_engine()
 
     df_sql = pd.read_sql_query(
@@ -91,7 +91,7 @@ def write_data_to_postgres(**kwargs):
     data_dict = kwargs["ti"].xcom_pull(task_ids="fetch_and_parse_data")
     # If data_set is empty, nothing to do
     dag_run_id = data_dict["dag_run_id"]
-    pg_hook = PostgresHook(postgres_conn_id="qfdmo-django-db")
+    pg_hook = PostgresHook(postgres_conn_id="qfdmo_django_db")
     engine = pg_hook.get_sqlalchemy_engine()
     if "actors" not in data_dict:
         with engine.begin() as connection:

--- a/dags/utils/dag_eo_utils.py
+++ b/dags/utils/dag_eo_utils.py
@@ -26,7 +26,7 @@ def fetch_data_from_api(**kwargs):
 
 
 def load_data_from_postgresql(**kwargs):
-    pg_hook = PostgresHook(postgres_conn_id="qfdmo-django-db")
+    pg_hook = PostgresHook(postgres_conn_id="qfdmo_django_db")
     engine = pg_hook.get_sqlalchemy_engine()
 
     # TODO : check if we need to manage the max id here
@@ -294,7 +294,7 @@ def read_acteur(**kwargs):
         )
         unique_source_ids = df_data_from_api["source_id"].unique()
 
-    pg_hook = PostgresHook(postgres_conn_id="qfdmo-django-db")
+    pg_hook = PostgresHook(postgres_conn_id="qfdmo_django_db")
     engine = pg_hook.get_sqlalchemy_engine()
     joined_source_ids = ",".join([f"'{source_id}'" for source_id in unique_source_ids])
     query = f"SELECT * FROM qfdmo_acteur WHERE source_id IN ({joined_source_ids})"
@@ -307,7 +307,7 @@ def read_acteur(**kwargs):
 def insert_dagrun_and_process_df(df_acteur_updates, metadata, dag_name, run_name):
     if df_acteur_updates.empty:
         return
-    pg_hook = PostgresHook(postgres_conn_id="qfdmo-django-db")
+    pg_hook = PostgresHook(postgres_conn_id="qfdmo_django_db")
     engine = pg_hook.get_sqlalchemy_engine()
     current_date = datetime.now()
 

--- a/dags/utils/db_tasks.py
+++ b/dags/utils/db_tasks.py
@@ -4,7 +4,7 @@ from airflow.providers.postgres.hooks.postgres import PostgresHook
 
 def read_data_from_postgres(**kwargs):
     table_name = kwargs["table_name"]
-    pg_hook = PostgresHook(postgres_conn_id="qfdmo-django-db")
+    pg_hook = PostgresHook(postgres_conn_id="qfdmo_django_db")
     engine = pg_hook.get_sqlalchemy_engine()
     df = pd.read_sql_table(table_name, engine)
     return df


### PR DESCRIPTION
# Description succincte du problème résolu

L'identifiant de connection contenait des '-', cela ne permettait pas de définir ce connecteur en utilisant les variables d'environnement sur certains sstème car ce caractère n'était pas autorisé.
Dans cette PR, on renomme donc l'identifiant de connection en utilisant des '_' en lieu et place des '-'

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
