### PR TITLE
Prevent API calls in Configurator's EPCI field choices

### DIFF
--- a/qfdmo/forms.py
+++ b/qfdmo/forms.py
@@ -260,6 +260,10 @@ class FormulaireForm(AddressesForm):
     )
 
 
+def get_epcis_for_carte_form():
+    return [(code, code) for code in cast(List[str], epcis_from(["code"]))]
+
+
 class CarteForm(AddressesForm):
     def load_choices(
         self,
@@ -301,7 +305,7 @@ class CarteForm(AddressesForm):
     )
 
     epci_codes = forms.MultipleChoiceField(
-        choices=[(code, code) for code in cast(List[str], epcis_from(["code"]))],
+        choices=get_epcis_for_carte_form,
         widget=forms.MultipleHiddenInput(),
         required=False,
     )
@@ -378,7 +382,7 @@ class ConfiguratorForm(DsfrBaseForm):
         "les propositions de la liste.",
         # TODO: voir comment évaluer cela "lazily"
         # L'utilisation de lazy(all_epci_codes(...)) génère une erreur côté Django DSFR
-        choices=formatted_epcis_as_list_of_tuple(),
+        choices=formatted_epcis_as_list_of_tuple,
         widget=GenericAutoCompleteInput(
             attrs={"data-autocomplete-target": "hiddenInput", "class": "qfdmo-hidden"},
             extra_attrs={


### PR DESCRIPTION
# Description succincte du problème résolu

Suite au merge du configurateur multi epci (#1010), on a des problèmes à l'initialisation de l'application dûs à des appels à un API externe qui sont déclenchés accidentellement

Ceci corrige cela. 

**Type de changement** :

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

