### PR TITLE
Réorganisation des groupes d'action dans le configurateur 

### DIFF
--- a/qfdmo/forms.py
+++ b/qfdmo/forms.py
@@ -357,7 +357,7 @@ class DagsForm(forms.Form):
 class ConfiguratorForm(DsfrBaseForm):
     # TODO: rename this field in all codebase -> actions_displayed
     action_list = GroupeActionChoiceField(
-        queryset=GroupeAction.objects.all(),
+        queryset=GroupeAction.objects.all().order_by("order"),
         to_field_name="code",
         widget=forms.CheckboxSelectMultiple,
         required=False,


### PR DESCRIPTION
# Description succincte du problème résolu

https://www.notion.so/accelerateur-transition-ecologique-ademe/Configurateur-Pouvoir-le-param-trer-avec-plusieurs-codes-EPCI-1226523d57d780cfa6f1cbd9c5ddf70b?pvs=4

Les groupes d'actions devraient être ordonnés comme sur la légende 

**Type de changement** :

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- Aller sur `/configurator` 
- Vérifier que l'ordre des groupes d'action est le même que sur `/?carte` 

