### PR TITLE
Ne pas afficher le titre du configurateur

### DIFF
--- a/jinja2/qfdmo/configurator/base.html
+++ b/jinja2/qfdmo/configurator/base.html
@@ -6,7 +6,7 @@ Réutiliser la carte | {{ super() }}
 
 {% block content %}
     <div class="fr-container fr-my-3w">
-        <h1>Réutiliser la carte sur mon site Internet</h1>
+        <h1 class='qfdmo-sr-only'>Réutiliser la carte sur mon site Internet</h1>
         <h2>Paramètres de l’intégration</h2>
         <form action="{{ url('qfdmo:iframe_configurator') }}" method="post">
             {{ csrf_input }}


### PR DESCRIPTION
# Description succincte du problème résolu

Comme on va afficher le configurateur dans longuevieauxobjets.adee.fr, le titre de la page configurateur doit-être marqué

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [ ] Bug fix
- [x] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
