### PR TITLE
Désactiver l'autocomplétion sur les champs adresse et objet

### DIFF
--- a/templates/forms/widgets/autocomplete.html
+++ b/templates/forms/widgets/autocomplete.html
@@ -21,6 +21,10 @@
                 type="{{ widget.type }}"
                 name="{{ widget.name }}"
                 autocomplete="off"
+                autocorrect="off"
+                autocapitalize="off"
+                spellcheck="false"
+                data-form-type="other"
                 {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}
                 {% include "django/forms/widgets/attrs.html" %}
             >

--- a/templates/forms/widgets/generic_autocomplete.html
+++ b/templates/forms/widgets/generic_autocomplete.html
@@ -18,6 +18,7 @@
                 autocorrect="off"
                 autocapitalize="off"
                 spellcheck="false"
+                data-form-type="other"
                 type="text"
                 name="search"
                 class="fr-input"


### PR DESCRIPTION
# Description succincte du problème résolu

Empêcher dashlane, l'autocomplete, l'auto correcteur etc de venir en travers de l'utilisateur lors de la saisie d'une adresse ou un objet 

https://www.notion.so/accelerateur-transition-ecologique-ademe/Carte-Champ-Adresse-Enlever-l-affichage-de-la-pr-saisie-navigateur-1376523d57d780a3b2c4db0a4cd5b267?pvs=4

Sources : 
- https://stackoverflow.com/a/69190988 
- https://dashlane.github.io/SAWF/


**Type de changement** :

- [x] Bug fix
- [x] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …
