### PR TITLE
Les acteurs d'un code EPCI ne s'affichent pas lorsqu'il est configuré 

### DIFF
--- a/integration_tests/qfdmo/test_adresses_view.py
+++ b/integration_tests/qfdmo/test_adresses_view.py
@@ -486,3 +486,21 @@ class TestBBOX:
         bbox, acteurs = adresses_view._bbox_and_acteurs_from_location_or_epci(acteurs)
         assert bbox == bbox
         assert acteurs.count() == 2
+
+
+@pytest.mark.django_db
+class TestLayers:
+    def test_adresse_missing_layer_is_displayed(self, client):
+        url = "/carte"
+        response = client.get(url)
+        assert 'data-testid="adresse-missing"' in str(response.content)
+
+    def test_adresse_missing_layer_is_not_displayed_with_bbox(self, client):
+        url = "/carte=1&direction=jai&bounding_box=%7B%22southWest%22%3A%7B%22lat%22%3A48.916%2C%22lng%22%3A2.298202514648438%7D%2C%22northEast%22%3A%7B%22lat%22%3A48.98742568330284%2C%22lng%22%3A2.483596801757813%7D%7D"  # noqa: E501
+        response = client.get(url)
+        assert 'data-testid="adresse-missing"' not in str(response.content)
+
+    def test_adresse_missing_layer_is_not_displayed_for_epcis(self, client):
+        url = "/carte?action_list=reparer%7Cdonner%7Cechanger%7Cpreter%7Cemprunter%7Clouer%7Cmettreenlocation%7Cacheter%7Crevendre&epci_codes=200055887&limit=50"  # noqa: E501
+        response = client.get(url)
+        assert 'data-testid="adresse-missing"' not in str(response.content)

--- a/jinja2/qfdmo/shared/disclaimers/adresse_missing.html
+++ b/jinja2/qfdmo/shared/disclaimers/adresse_missing.html
@@ -1,6 +1,7 @@
 <div
     class="qf-absolute qf-top-1w qf-bottom-1w qf-left-1w qf-right-1w qf-border qf-border-grey-900 qf-border-solid
     qf-flex qf-flex-row qf-justify-center group-aria-[busy]:qf-hidden"
+    data-testid="adresse-missing"
 >
     <picture>
         <source srcset="{{ static("map-background-mobile.png")}}" media="(orientation: portrait)">

--- a/jinja2/qfdmo/shared/results.html
+++ b/jinja2/qfdmo/shared/results.html
@@ -6,7 +6,7 @@ The values of 120px and 150px are determined empirically.
 They need to match the css variables used for .grid-map selector in qfdmo.css
 #}
 
-{% with address_ok=(form.initial.adresse or form.initial.bounding_box) %}
+{% with address_ok=(form.initial.adresse or form.initial.bounding_box or form.initial.epci_codes) %}
 <div
     class="
     qf-relative


### PR DESCRIPTION
# Description succincte du problème résolu

L'utilisation d'un code EPCI ne masque pas le visuel d'accueil de la carte. 
**Se produit en prod**

**Type de changement** :

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- aller sur http://localhost:8000/carte?action_list=reparer%7Cdonner%7Cechanger%7Cpreter%7Cemprunter%7Clouer%7Cmettreenlocation%7Cacheter%7Crevendre&epci_codes=200055887&limit=50 
- on doit voir des acteurs sur la carte 
