### PR TITLE
Attempt to speed up e2e tests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        shard: [1/4, 2/4, 3/4, 4/4]
+        shard: [1/5, 2/5, 3/5, 4/5, 5/5]
     services:
       postgres:
         image: postgis/postgis:15-3.3-alpine

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Dependencies
         run: pip install --require-hashes --no-deps -r airflow-requirements.txt -r requirements.txt -r dev-requirements.txt
       - name: Run tests
-        run: pytest {{ matrix.tests_directory }}
+        run: pytest ${{ matrix.tests_directory }}
       - name: Check code formatting
         run: black --check --diff .
       - uses: chartboost/ruff-action@v1

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Dependencies
         run: pip install --require-hashes --no-deps -r airflow-requirements.txt -r requirements.txt -r dev-requirements.txt
       - name: Run tests
-        run: pytest ${{ matrix.tests_directory }}
+        run: pytest {{ matrix.tests_directory }}
       - name: Check code formatting
         run: black --check --diff .
       - uses: chartboost/ruff-action@v1

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -29,20 +29,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
+          cache: "pip"
           python-version: "3.12.1"
       - name: Install GIS Packages
         run: |
           sudo apt-get update
           sudo apt-get install gdal-bin
-      - name: Cache pip dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/dev-requirements.txt', '**/airflow-requirements.rxt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
       - name: Install Dependencies
-        run: pip install --require-hashes --no-deps -r  airflow-requirements.txt -r requirements.txt -r dev-requirements.txt
+        run: pip install --require-hashes --no-deps -r airflow-requirements.txt -r requirements.txt -r dev-requirements.txt
       - name: Run unit tests
         run: pytest unit_tests
       - name: Run integration tests
@@ -65,18 +59,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".tool-versions"
-      - name: Cache node modules
-        id: cache-npm
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          cache: "npm"
       - name: Build assets
         run: |
           npm ci
@@ -111,19 +94,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".tool-versions"
-
-      - name: Cache node modules
-        id: cache-npm
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          cache: "npm"
 
       - name: Build assets
         run: |
@@ -140,16 +111,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install gdal-bin
 
-      - name: Cache pip dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/dev-requirements.txt', '**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
       - name: Install Dependencies
-        run: pip install --require-hashes --no-deps -r  requirements.txt -r dev-requirements.txt
+        run: pip install --require-hashes --no-deps -r requirements.txt -r dev-requirements.txt
 
       - name: Set env variables
         run: cp .env.template .env

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -29,14 +29,20 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          cache: "pip"
           python-version: "3.12.1"
       - name: Install GIS Packages
         run: |
           sudo apt-get update
           sudo apt-get install gdal-bin
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/dev-requirements.txt', '**/airflow-requirements.rxt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install Dependencies
-        run: pip install --require-hashes --no-deps -r airflow-requirements.txt -r requirements.txt -r dev-requirements.txt
+        run: pip install --require-hashes --no-deps -r  airflow-requirements.txt -r requirements.txt -r dev-requirements.txt
       - name: Run unit tests
         run: pytest unit_tests
       - name: Run integration tests
@@ -59,7 +65,18 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".tool-versions"
-          cache: "npm"
+      - name: Cache node modules
+        id: cache-npm
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
       - name: Build assets
         run: |
           npm ci
@@ -94,7 +111,19 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".tool-versions"
-          cache: "npm"
+
+      - name: Cache node modules
+        id: cache-npm
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
 
       - name: Build assets
         run: |
@@ -111,8 +140,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install gdal-bin
 
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/dev-requirements.txt', '**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Install Dependencies
-        run: pip install --require-hashes --no-deps -r requirements.txt -r dev-requirements.txt
+        run: pip install --require-hashes --no-deps -r  requirements.txt -r dev-requirements.txt
 
       - name: Set env variables
         run: cp .env.template .env

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -10,6 +10,9 @@ defaults:
 jobs:
   unit_tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        test_directory: [unit_tests, integration_testss, dags_unit_tests]
     services:
       postgres:
         image: postgis/postgis:15-3.3-alpine
@@ -24,7 +27,6 @@ jobs:
           --health-retries 50
         ports:
           - 6543:5432
-
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -37,12 +39,8 @@ jobs:
           sudo apt-get install gdal-bin
       - name: Install Dependencies
         run: pip install --require-hashes --no-deps -r airflow-requirements.txt -r requirements.txt -r dev-requirements.txt
-      - name: Run unit tests
-        run: pytest unit_tests
-      - name: Run integration tests
-        run: pytest integration_tests
-      - name: Run data tests
-        run: pytest dags_unit_tests
+      - name: Run tests
+        run: pytest {{ matrix.tests_directory }}
       - name: Check code formatting
         run: black --check --diff .
       - uses: chartboost/ruff-action@v1
@@ -71,6 +69,7 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+
     strategy:
       matrix:
         shard: [1/5, 2/5, 3/5, 4/5, 5/5]

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -10,9 +10,6 @@ defaults:
 jobs:
   unit_tests:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        test_directory: [unit_tests, integration_testss, dags_unit_tests]
     services:
       postgres:
         image: postgis/postgis:15-3.3-alpine
@@ -27,6 +24,7 @@ jobs:
           --health-retries 50
         ports:
           - 6543:5432
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -39,8 +37,12 @@ jobs:
           sudo apt-get install gdal-bin
       - name: Install Dependencies
         run: pip install --require-hashes --no-deps -r airflow-requirements.txt -r requirements.txt -r dev-requirements.txt
-      - name: Run tests
-        run: pytest {{ matrix.tests_directory }}
+      - name: Run unit tests
+        run: pytest unit_tests
+      - name: Run integration tests
+        run: pytest integration_tests
+      - name: Run data tests
+        run: pytest dags_unit_tests
       - name: Check code formatting
         run: black --check --diff .
       - uses: chartboost/ruff-action@v1
@@ -69,7 +71,6 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         shard: [1/5, 2/5, 3/5, 4/5, 5/5]

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -71,6 +71,9 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1/4, 2/4, 3/4, 4/4]
     services:
       postgres:
         image: postgis/postgis:15-3.3-alpine
@@ -131,7 +134,9 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Run Playwright tests
-        run: npx playwright test --reporter=list --update-snapshots
+        run: npx playwright test --reporter=list --update-snapshots --shard=${{ matrix.shard }}
+
+
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,40 +37,12 @@ export default defineConfig({
             grepInvert: /Mobile/,
             use: { ...devices["Desktop Chrome"] },
         },
-
-        {
-            name: "firefox",
-            grepInvert: /Mobile/,
-            use: {
-                ...devices["Desktop Firefox"],
-            },
-        },
-
-        {
-            name: "webkit",
-            grepInvert: /Mobile/,
-            use: { ...devices["Desktop Safari"] },
-        },
-
-        /* Test against mobile viewports. */
-        {
-            name: "Mobile Chrome",
-            grepInvert: /Desktop/,
-            use: { ...devices["Pixel 5"] },
-        },
         {
             name: "Mobile Safari",
             grepInvert: /Desktop/,
             use: {
                 ...devices["iPhone 12"],
             },
-        },
-
-        /* Test against branded browsers. */
-        {
-            name: "Microsoft Edge",
-            grepInvert: /Mobile/,
-            use: { ...devices["Desktop Edge"], channel: "msedge" },
         },
     ],
 


### PR DESCRIPTION
# Description succincte du problème résolu

**Tentative d'accélérer les tests e2e**

J'en avais un peu marre (comme Nico) du temps de run des e2e. 
**Plusieurs choses :**
- **Utilisation du [sharding](https://playwright.dev/docs/test-sharding)** de Playwright pour répartir les tests dans plusieurs process
- **Suppression de cibles de navigateurs** dans les tests playwright. Sur la base de https://gs.statcounter.com, on peut facilement considérer chromium desktop et safari mobile. Edge est basé sur webkit (et donc chrome), safari macOS est assez peu utilisé, et firefox...j'ai envie de pleurer, mais est bien bien bas, au même niveau que Samsung internet 🥲 
- **Utilisation de `matrix`** pour lancer les tests sur plusieurs runners 
- ~~Ajout de cache sur l'installation des dépendances https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#example-using-the-cache-action~~ a priori celui qu'on a dejà suffit  

### **Mesures** 
**Avant** la PR : [en moyenne la CI](https://github.com/incubateur-ademe/quefairedemesobjets/actions/workflows/ci.yml) met **7min30** à tourner 

**Après**
- 👍 Avec le sharding, sans modifier la config playwriht : **4m30s** 
- 👍 Avec le sharding, en supprimant des cibles de navigateur : **3m40s**
- 👎 Avec le sharding, en supprimant des cibles de navigateur, en utilisant matrix pour les tests python : **4m11s**. 
  Ça s'explique car les tests unitaires et d'intégration mettent vraiment peu de temps à tourner, donc on perd surtout du temps dans le spawn des runners  installation de dépendances. 
