### PR TITLE
Commande pour ré-initialiser les tables dagrun et dagrunchange

### DIFF
--- a/.github/workflows/sync_databases.yml
+++ b/.github/workflows/sync_databases.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Execute migrations in one-off container
         run: |
           scalingo --app ${PREPROD_APP} run python manage.py migrate
+      - name: Truncate the dagruns table
+        run: |
+          scalingo --app ${PREPROD_APP} run python manage.py reinitialize_dagrun
 
   sync_prod_to_preprod_s3:
     name: Copy Prod s3 bucket to Copy Preprod s3 bucket

--- a/qfdmo/management/commands/reinitialize_dagrun.py
+++ b/qfdmo/management/commands/reinitialize_dagrun.py
@@ -1,0 +1,15 @@
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+
+class Command(BaseCommand):
+    help = "Export Ressources using CSV format"
+
+    def handle(self, *args, **options):
+        with connection.cursor() as cursor:
+            # Truncate the table qfdmo_dagrun and qfdmo_dagrunchange
+            cursor.execute("TRUNCATE TABLE qfdmo_dagrun CASCADE")
+
+            # Set auto-increment to 1
+            cursor.execute("ALTER SEQUENCE qfdmo_dagrun_id_seq RESTART WITH 1")
+            cursor.execute("ALTER SEQUENCE qfdmo_dagrunchange_id_seq RESTART WITH 1")


### PR DESCRIPTION
# Description succincte du problème résolu

On en a eu besoin car parfois l'intégration des DAG bloque et empèche les dagrun suivant de s'executer.
De plus, c'est utile pour ne pas avoir les dagrun qui ont été joué en prod sur la preprod.

Attention cela implique que la table dagrun sera vidé tous les week-end en preprod.

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [ ] Bug fix
- [x] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
