### PR TITLE
Précision de la plateforme dans la conf docker-compose lvao

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -160,7 +160,7 @@
         "filename": "docker-compose.yml",
         "hashed_secret": "3cf2012487b086bba2adb3386d69c2ab67a268b6",
         "is_verified": false,
-        "line_number": 39
+        "line_number": 40
       }
     ],
     "iframe_without_js.html": [
@@ -207,5 +207,5 @@
       }
     ]
   },
-  "generated_at": "2024-11-21T09:58:18Z"
+  "generated_at": "2024-11-28T17:01:19Z"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ x-airflow-common:
 services:
   lvao-db:
     image: postgis/postgis:15-3.3-alpine
+    platform: linux/amd64
     environment:
       - POSTGRES_USER=qfdmo
       - POSTGRES_PASSWORD=qfdmo # pragma: allowlist secret


### PR DESCRIPTION
# Description succincte du problème résolu

Pour eviter le warning suivant :
```
lvao-db The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
```

@max.corbeau : Peux-tu vérifier si tu n'as pas d'alerte docker en `rebuild` et `up` s'il te plait ?

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [ ] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [x] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
