### PR TITLE
Permettre les numéros de téléphone de 5 digits

### DIFF
--- a/dags/utils/mapping_utils.py
+++ b/dags/utils/mapping_utils.py
@@ -50,7 +50,7 @@ def process_phone_number(number, code_postal):
     if number.startswith("33"):
         number = "0" + number[2:]
 
-    if len(number) < 6:
+    if len(number) < 5:
         return None
 
     return number


### PR DESCRIPTION
# Description succincte du problème résolu

Vu avec Christian, les numeros type boite vocal à 5 chiffres existent pour nos partenaires

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
