### PR TITLE
Utiliser le uuid à la place de l'identifiant_unique dans l'url détail de l'adresse

### DIFF
--- a/integration_tests/qfdmo/test_acteur_detail.py
+++ b/integration_tests/qfdmo/test_acteur_detail.py
@@ -11,8 +11,8 @@ from unit_tests.qfdmo.acteur_factory import (
 
 @pytest.fixture
 def get_response(client):
-    def _get_response(identifiant_unique):
-        url = f"/adresse/{identifiant_unique}"
+    def _get_response(uuid):
+        url = f"/adresse/{uuid}"
         response = client.get(url)
         assert response.status_code == 200
         return response, BeautifulSoup(response.content, "html.parser")
@@ -24,13 +24,13 @@ def get_response(client):
 class TestDisplaySource:
     def test_display_no_source(self, get_response):
         adresse = DisplayedActeurFactory()
-        response, _ = get_response(adresse.identifiant_unique)
+        response, _ = get_response(adresse.uuid)
         assert response.context["display_sources_panel"] is False
 
     def test_display_one_source(self, get_response):
         adresse = DisplayedActeurFactory()
         adresse.sources.add(SourceFactory(afficher=True))
-        response, _ = get_response(adresse.identifiant_unique)
+        response, _ = get_response(adresse.uuid)
         assert response.context["display_sources_panel"] is True
 
 
@@ -38,13 +38,13 @@ class TestDisplaySource:
 class TestDisplayNomCommercial:
     def test_nom_is_capitalized(self, get_response):
         adresse = DisplayedActeurFactory(nom="coucou", nom_commercial="")
-        response, soup = get_response(adresse.identifiant_unique)
+        response, soup = get_response(adresse.uuid)
         acteur_title = soup.find(attrs={"data-testid": "acteur-title"})
         assert "Coucou" in acteur_title.text, "Test that the nom field is capitalized"
 
     def test_nom_commercial_is_displayed_if_present(self, get_response):
         adresse = DisplayedActeurFactory(nom="coucou", nom_commercial="youpi")
-        response, soup = get_response(adresse.identifiant_unique)
+        response, soup = get_response(adresse.uuid)
         acteur_title = soup.find(attrs={"data-testid": "acteur-title"})
         assert "Youpi" in acteur_title.text, "Test that the nom commercial is displayed"
 
@@ -87,7 +87,7 @@ class TestDisplayLabel:
                 )
             )
 
-        response, soup = get_response(adresse.identifiant_unique)
+        response, soup = get_response(adresse.uuid)
         assert response.context["display_labels_panel"] == should_display
         label_tag = soup.find(attrs={"data-testid": "acteur-detail-labels"})
         if expected_text:
@@ -116,7 +116,7 @@ class TestAboutPanel:
         adresse.uniquement_sur_rdv = uniquement_sur_rdv
         adresse.save()
 
-        response, soup = get_response(adresse.identifiant_unique)
+        response, soup = get_response(adresse.uuid)
         self.assert_about_panel_text(soup, expected_text, uniquement_sur_rdv)
 
     @pytest.mark.parametrize(
@@ -132,7 +132,7 @@ class TestAboutPanel:
         adresse.exclusivite_de_reprisereparation = exclusivite_de_reprisereparation
         adresse.save()
 
-        response, soup = get_response(adresse.identifiant_unique)
+        response, soup = get_response(adresse.uuid)
         self.assert_about_panel_text(
             soup, expected_text, exclusivite_de_reprisereparation
         )

--- a/integration_tests/qfdmo/test_acteur_detail.py
+++ b/integration_tests/qfdmo/test_acteur_detail.py
@@ -12,7 +12,7 @@ from unit_tests.qfdmo.acteur_factory import (
 @pytest.fixture
 def get_response(client):
     def _get_response(uuid):
-        url = f"/adresse/{uuid}"
+        url = f"/adresse_details/{uuid}"
         response = client.get(url)
         assert response.status_code == 200
         return response, BeautifulSoup(response.content, "html.parser")
@@ -153,25 +153,33 @@ class TestRedirects:
             identifiant_unique="coucou",
             statut=statut,
         )
-        url = f"/adresse/{acteur.identifiant_unique}"
+        url = f"/adresse_details/{acteur.uuid}"
         response = client.get(url)
         assert response.status_code == expected_status_code
 
     def test_inactif_acteur_is_not_in_sitemap(self, client):
-        DisplayedActeurFactory(
+        youpi = DisplayedActeurFactory(
             identifiant_unique="youpi",
             statut=ActeurStatus.ACTIF,
         )
-        DisplayedActeurFactory(
+        coucou = DisplayedActeurFactory(
             identifiant_unique="coucou",
             statut=ActeurStatus.INACTIF,
         )
-        DisplayedActeurFactory(
+        super = DisplayedActeurFactory(
             identifiant_unique="super",
             statut=ActeurStatus.SUPPRIME,
         )
         url = "/sitemap-items.xml"
         response = client.get(url)
-        assert "coucou" not in str(response.content)
-        assert "super" not in str(response.content)
-        assert "youpi" in str(response.content)
+        assert coucou.uuid not in str(response.content)
+        assert super.uuid not in str(response.content)
+        assert youpi.uuid in str(response.content)
+
+    def test_acteur_detail_redirect(self, client):
+        acteur = DisplayedActeurFactory(
+            identifiant_unique="coucou",
+        )
+        url = f"/adresse/{acteur.identifiant_unique}"
+        response = client.get(url)
+        assert response.status_code == 301

--- a/qfdmo/models/acteur.py
+++ b/qfdmo/models/acteur.py
@@ -601,7 +601,7 @@ class DisplayedActeur(BaseActeur):
     )
 
     def get_absolute_url(self):
-        return reverse("qfdmo:acteur-detail", args=[self.identifiant_unique])
+        return reverse("qfdmo:acteur-detail", args=[self.uuid])
 
     def acteur_actions(self, direction=None):
         ps_action_ids = list(
@@ -641,7 +641,7 @@ class DisplayedActeur(BaseActeur):
         actions = sorted(actions, key=sort_actions)
 
         acteur_dict = {
-            "identifiant_unique": self.identifiant_unique,
+            "uuid": self.uuid,
             "location": orjson.loads(self.location.geojson),
         }
 

--- a/qfdmo/urls.py
+++ b/qfdmo/urls.py
@@ -67,7 +67,6 @@ urlpatterns = [
     ),
     path(
         "adresse/<str:identifiant_unique>",
-        # ActeurView.as_view(),
         acteur_detail_redirect,
     ),
     path(

--- a/qfdmo/urls.py
+++ b/qfdmo/urls.py
@@ -72,7 +72,6 @@ urlpatterns = [
     ),
     path(
         "adresse_details/<str:uuid>",
-        # ActeurView.as_view(),
         acteur_detail,
         name="acteur-detail",
     ),

--- a/qfdmo/urls.py
+++ b/qfdmo/urls.py
@@ -65,7 +65,7 @@ urlpatterns = [
         name="get_object_list",
     ),
     path(
-        "adresse/<str:identifiant_unique>",
+        "adresse/<str:uuid>",
         # ActeurView.as_view(),
         acteur_detail,
         name="acteur-detail",

--- a/qfdmo/urls.py
+++ b/qfdmo/urls.py
@@ -7,6 +7,7 @@ from qfdmo.views.adresses import (
     CarteSearchActeursView,
     FormulaireSearchActeursView,
     acteur_detail,
+    acteur_detail_redirect,
     direct_access,
     get_object_list,
     getorcreate_revisionacteur,
@@ -65,7 +66,12 @@ urlpatterns = [
         name="get_object_list",
     ),
     path(
-        "adresse/<str:uuid>",
+        "adresse/<str:identifiant_unique>",
+        # ActeurView.as_view(),
+        acteur_detail_redirect,
+    ),
+    path(
+        "adresse_details/<str:uuid>",
         # ActeurView.as_view(),
         acteur_detail,
         name="acteur-detail",

--- a/qfdmo/views/adresses.py
+++ b/qfdmo/views/adresses.py
@@ -640,7 +640,7 @@ def get_object_list(request):
     )
 
 
-def acteur_detail(request, identifiant_unique):
+def acteur_detail(request, uuid):
     base_template = "layout/base.html"
 
     if request.headers.get("Turbo-Frame"):
@@ -656,7 +656,7 @@ def acteur_detail(request, identifiant_unique):
         "proposition_services__action__groupe_action",
         "labels",
         "sources",
-    ).get(identifiant_unique=identifiant_unique)
+    ).get(uuid=uuid)
 
     if displayed_acteur.statut != ActeurStatus.ACTIF:
         return redirect("https://quefairedemesdechets.ademe.fr", permanent=True)

--- a/qfdmo/views/adresses.py
+++ b/qfdmo/views/adresses.py
@@ -640,6 +640,13 @@ def get_object_list(request):
     )
 
 
+def acteur_detail_redirect(request, identifiant_unique):
+    displayed_acteur = DisplayedActeur.objects.get(
+        identifiant_unique=identifiant_unique
+    )
+    return redirect("qfdmo:acteur-detail", uuid=displayed_acteur.uuid, permanent=True)
+
+
 def acteur_detail(request, uuid):
     base_template = "layout/base.html"
 

--- a/static/to_compile/js/map_controller.ts
+++ b/static/to_compile/js/map_controller.ts
@@ -1,12 +1,11 @@
 import { Controller } from "@hotwired/stimulus"
-import * as Turbo from "@hotwired/turbo"
 import debounce from "lodash/debounce"
+import { removeHash } from "./helpers"
 import { SolutionMap } from "./solution_map"
 import { ActorLocation, DisplayedActeur } from "./types"
-import { removeHash } from "./helpers"
 
 export class Actor implements DisplayedActeur {
-  identifiant_unique: string
+  uuid: string
   location: ActorLocation
   icon: string
   couleur: string
@@ -14,7 +13,7 @@ export class Actor implements DisplayedActeur {
   reparer: boolean
 
   constructor(actorFields: DisplayedActeur) {
-    this.identifiant_unique = actorFields.identifiant_unique
+    this.uuid = actorFields.uuid
     this.location = actorFields.location
     this.icon = actorFields.icon
     this.couleur = actorFields.couleur

--- a/static/to_compile/js/search_solution_form_controller.ts
+++ b/static/to_compile/js/search_solution_form_controller.ts
@@ -104,7 +104,9 @@ export default class extends Controller<HTMLElement> {
     this.displayActionList()
     window.addEventListener("hashchange", this.#setActiveActeur.bind(this))
     // Prevents the leaflet map to move when the user moves panel
-    this.acteurDetailsPanelTarget.addEventListener("touchmove", event => event.stopPropagation())
+    this.acteurDetailsPanelTarget.addEventListener("touchmove", (event) =>
+      event.stopPropagation(),
+    )
 
     if (!this.isIframeValue) {
       this.scrollToContent()
@@ -112,11 +114,11 @@ export default class extends Controller<HTMLElement> {
   }
 
   #setActiveActeur(event?: HashChangeEvent) {
-    const identifiantUnique = event
+    const uuid = event
       ? new URL(event.newURL).hash.substring(1)
       : window.location.hash.substring(1)
-    if (identifiantUnique) {
-      this.displayActeur(identifiantUnique)
+    if (uuid) {
+      this.displayActeur(uuid)
       this.dispatch("captureInteraction")
     } else {
       this.hideActeurDetailsPanel()
@@ -168,7 +170,7 @@ export default class extends Controller<HTMLElement> {
   }
 
   scrollToContent() {
-    this.searchFormTarget.scrollIntoView({ behavior: "smooth"})
+    this.searchFormTarget.scrollIntoView({ behavior: "smooth" })
   }
 
   #hideAddressesPanel() {
@@ -209,7 +211,7 @@ export default class extends Controller<HTMLElement> {
     this.acteurDetailsPanelTarget.addEventListener(
       "animationend",
       () => {
-        this.acteurDetailsPanelTarget.dataset.exitAnimationEnded= "true"
+        this.acteurDetailsPanelTarget.dataset.exitAnimationEnded = "true"
       },
       { once: true },
     )
@@ -226,7 +228,7 @@ export default class extends Controller<HTMLElement> {
     this.#showActeurDetailsPanel()
   }
 
-  displayActeur(identifiantUnique) {
+  displayActeur(uuid: string) {
     const latitude = this.latitudeInputTarget.value
     const longitude = this.longitudeInputTarget.value
 
@@ -237,7 +239,7 @@ export default class extends Controller<HTMLElement> {
     if (this.hasCarteTarget) {
       params.set("carte", "1")
     }
-    const acteurDetailPath = `/adresse/${identifiantUnique}?${params.toString()}`
+    const acteurDetailPath = `/adresse_details/${uuid}?${params.toString()}`
     Turbo.visit(acteurDetailPath, { frame: "acteur-detail" })
     this.#showActeurDetailsPanel()
   }

--- a/static/to_compile/js/solution_map.ts
+++ b/static/to_compile/js/solution_map.ts
@@ -1,9 +1,9 @@
-import * as L from "leaflet"
-import MapController from "./map_controller"
-import pinBackgroundSvg from "bundle-text:../svg/pin-background.svg"
-import pinBackgroundFillSvg from "bundle-text:../svg/pin-background-fill.svg"
 import bonusIconSvg from "bundle-text:../svg/bonus-reparation-fill.svg"
+import pinBackgroundFillSvg from "bundle-text:../svg/pin-background-fill.svg"
+import pinBackgroundSvg from "bundle-text:../svg/pin-background.svg"
+import * as L from "leaflet"
 import { ACTIVE_PINPOINT_CLASSNAME, clearActivePinpoints } from "./helpers"
+import MapController from "./map_controller"
 import type { DisplayedActeur, Location, LVAOMarker } from "./types"
 
 const DEFAULT_LOCATION: L.LatLngTuple = [46.227638, 2.213749]
@@ -91,18 +91,21 @@ export class SolutionMap {
     return htmlTree.join("")
   }
 
-  addActorMarkersToMap(actors: Array<DisplayedActeur>, bboxValue?: Array<Number>): void {
+  addActorMarkersToMap(
+    actors: Array<DisplayedActeur>,
+    bboxValue?: Array<Number>,
+  ): void {
     const points: Array<Array<Number>> = []
     actors.forEach(function (actor: DisplayedActeur) {
       if (actor.location) {
         const markerHtmlString = this.#generateMarkerHTMLStringFrom(actor)
         const actorMarker = L.divIcon({
-            // Empty className ensures default leaflet classes are not added,
-            // they add styles like a border and a background to the marker
-            className: "",
-            iconSize: [34, 45],
-            html: markerHtmlString,
-          })
+          // Empty className ensures default leaflet classes are not added,
+          // they add styles like a border and a background to the marker
+          className: "",
+          iconSize: [34, 45],
+          html: markerHtmlString,
+        })
 
         const marker: LVAOMarker = L.marker(
           [actor.location.coordinates[1], actor.location.coordinates[0]],
@@ -111,7 +114,7 @@ export class SolutionMap {
             riseOnHover: true,
           },
         )
-        marker._identifiant_unique = actor.identifiant_unique
+        marker._uuid = actor.uuid
         marker.on("click", (e) => {
           this.#onClickMarker(e)
         })
@@ -150,7 +153,7 @@ export class SolutionMap {
   #onClickMarker(event: L.LeafletEvent) {
     clearActivePinpoints()
     event.target._icon.classList.add(ACTIVE_PINPOINT_CLASSNAME)
-    window.location.hash = event.target._identifiant_unique
+    window.location.hash = event.target._uuid
   }
 
   #manageZoomControl() {

--- a/static/to_compile/js/types.ts
+++ b/static/to_compile/js/types.ts
@@ -1,16 +1,16 @@
 import type { Marker } from "leaflet"
 
 export interface Location {
-    latitude?: number
-    longitude?: number
+  latitude?: number
+  longitude?: number
 }
 
 export interface ActorLocation {
-    coordinates: number[]
+  coordinates: number[]
 }
 
 export interface DisplayedActeur {
-  identifiant_unique: string
+  uuid: string
   icon: string
   couleur: string
   location: ActorLocation
@@ -19,14 +19,14 @@ export interface DisplayedActeur {
 }
 
 export class SSCatObject {
-    label: string
-    sub_label: string
-    identifier: number
+  label: string
+  sub_label: string
+  identifier: number
 }
 
 export type InteractionType = "map" | "solution_details"
 export type PosthogEventType = "ui_interaction"
 
 export type LVAOMarker = Marker & {
-  _identifiant_unique?: string
+  _uuid?: string
 }

--- a/unit_tests/qfdmo/test_acteur.py
+++ b/unit_tests/qfdmo/test_acteur.py
@@ -508,7 +508,7 @@ class TestDisplayedActeurJsonActeurForDisplay:
     def test_json_acteur_for_display_ordered(self, displayed_acteur):
         acteur_for_display = json.loads(displayed_acteur.json_acteur_for_display())
 
-        assert acteur_for_display["identifiant_unique"] is not None
+        assert acteur_for_display["uuid"] is not None
         assert acteur_for_display["location"] is not None
         assert acteur_for_display["icon"] == "icon-actionjai1"
         assert acteur_for_display["couleur"] == "couleur-actionjai1"
@@ -518,7 +518,7 @@ class TestDisplayedActeurJsonActeurForDisplay:
             displayed_acteur.json_acteur_for_display(direction="jai")
         )
 
-        assert acteur_for_display["identifiant_unique"] is not None
+        assert acteur_for_display["uuid"] is not None
         assert acteur_for_display["location"] is not None
         assert acteur_for_display["icon"] == "icon-actionjai1"
         assert acteur_for_display["couleur"] == "couleur-actionjai1"
@@ -527,7 +527,7 @@ class TestDisplayedActeurJsonActeurForDisplay:
             displayed_acteur.json_acteur_for_display(direction="jecherche")
         )
 
-        assert acteur_for_display["identifiant_unique"] is not None
+        assert acteur_for_display["uuid"] is not None
         assert acteur_for_display["location"] is not None
         assert acteur_for_display["icon"] == "icon-actionjecherche1"
         assert acteur_for_display["couleur"] == "couleur-actionjecherche1"
@@ -537,7 +537,7 @@ class TestDisplayedActeurJsonActeurForDisplay:
             displayed_acteur.json_acteur_for_display(action_list="actionjai2")
         )
 
-        assert acteur_for_display["identifiant_unique"] is not None
+        assert acteur_for_display["uuid"] is not None
         assert acteur_for_display["location"] is not None
         assert acteur_for_display["icon"] == "icon-actionjai2"
         assert acteur_for_display["couleur"] == "couleur-actionjai2"
@@ -548,7 +548,7 @@ class TestDisplayedActeurJsonActeurForDisplay:
             )
         )
 
-        assert acteur_for_display["identifiant_unique"] is not None
+        assert acteur_for_display["uuid"] is not None
         assert acteur_for_display["location"] is not None
         assert acteur_for_display["icon"] == "icon-actionjai1"
         assert acteur_for_display["couleur"] == "couleur-actionjai1"
@@ -558,7 +558,7 @@ class TestDisplayedActeurJsonActeurForDisplay:
             displayed_acteur.json_acteur_for_display(carte=True)
         )
 
-        assert acteur_for_display["identifiant_unique"] is not None
+        assert acteur_for_display["uuid"] is not None
         assert acteur_for_display["location"] is not None
         assert acteur_for_display["icon"] == "icon-groupeaction2"
         assert acteur_for_display["couleur"] == "couleur-groupeaction2"
@@ -568,7 +568,7 @@ class TestDisplayedActeurJsonActeurForDisplay:
             displayed_acteur.json_acteur_for_display(carte=True, direction="jecherche")
         )
 
-        assert acteur_for_display["identifiant_unique"] is not None
+        assert acteur_for_display["uuid"] is not None
         assert acteur_for_display["location"] is not None
         assert acteur_for_display["icon"] == "icon-groupeaction2"
         assert acteur_for_display["couleur"] == "couleur-groupeaction2"
@@ -580,7 +580,7 @@ class TestDisplayedActeurJsonActeurForDisplay:
             )
         )
 
-        assert acteur_for_display["identifiant_unique"] is not None
+        assert acteur_for_display["uuid"] is not None
         assert acteur_for_display["location"] is not None
         assert acteur_for_display["icon"] == "icon-groupeaction1"
         assert acteur_for_display["couleur"] == "couleur-groupeaction1"
@@ -591,7 +591,7 @@ class TestDisplayedActeurJsonActeurForDisplay:
             )
         )
 
-        assert acteur_for_display["identifiant_unique"] is not None
+        assert acteur_for_display["uuid"] is not None
         assert acteur_for_display["location"] is not None
         assert acteur_for_display["icon"] == "icon-groupeaction2"
         assert acteur_for_display["couleur"] == "couleur-groupeaction2"
@@ -602,7 +602,7 @@ class TestDisplayedActeurJsonActeurForDisplay:
 
         acteur_for_display = json.loads(displayed_acteur.json_acteur_for_display())
 
-        assert acteur_for_display["identifiant_unique"] is not None
+        assert acteur_for_display["uuid"] is not None
         assert acteur_for_display["location"] is not None
         assert acteur_for_display["icon"] == "icon-actionjai2"
         assert acteur_for_display["couleur"] == "couleur-actionjai2"
@@ -617,7 +617,7 @@ class TestDisplayedActeurJsonActeurForDisplay:
             displayed_acteur.json_acteur_for_display(direction="jecherche")
         )
 
-        assert acteur_for_display["identifiant_unique"] is not None
+        assert acteur_for_display["uuid"] is not None
         assert acteur_for_display["location"] is not None
         assert acteur_for_display["icon"] == "icon-actionjecherche1"
         assert acteur_for_display["couleur"] == "couleur-actionjecherche1"
@@ -632,7 +632,7 @@ class TestDisplayedActeurJsonActeurForDisplay:
             displayed_acteur.json_acteur_for_display(action_list="actionjai1")
         )
 
-        assert acteur_for_display["identifiant_unique"] is not None
+        assert acteur_for_display["uuid"] is not None
         assert acteur_for_display["location"] is not None
         assert acteur_for_display["icon"] == "icon-actionjai1"
         assert acteur_for_display["couleur"] == "couleur-actionjai1"


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [Titre de la carte](https://notion.so/...)

Pour anonymiser les fiches détaillées des acteurs

Résoud le pb : https://sentry.incubateur.net/organizations/betagouv/issues/132123/?project=115&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0

Vu avec @fabienheureux : ce serait mieux de créer un slug mais on se garde ça pour plus tard lors du retravail de la fiche detail de l'adresse

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [x] Bug fix
- [x] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
