### PR TITLE
Ignorer les accents dans les recherches dans Django admin

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -1,0 +1,7 @@
+from django.contrib.postgres.lookups import Unaccent
+from django.db.models import CharField, TextField
+
+# Useful to support unaccent lookups in django admin, for
+# acteurs and produits for example
+CharField.register_lookup(Unaccent)
+TextField.register_lookup(Unaccent)

--- a/qfdmd/admin.py
+++ b/qfdmd/admin.py
@@ -34,7 +34,7 @@ class SuggestionAdmin(admin.ModelAdmin):
 @admin.register(Produit)
 class ProduitAdmin(admin.ModelAdmin):
     list_display = ("nom", "id", "synonymes_existants")
-    search_fields = ["nom", "id", "synonymes_existants"]
+    search_fields = ["nom__unaccent", "id", "synonymes_existants__unaccent"]
     # ajout des filtres de recherche sur bdd et code
     list_filter = ["bdd", "code"]
     inlines = [SynonymeInline, LienInline]
@@ -49,5 +49,5 @@ class LienAdmin(NotEditableInlineMixin, admin.ModelAdmin):
 @admin.register(Synonyme)
 class SynonymeAdmin(NotEditableInlineMixin, ImportExportModelAdmin, admin.ModelAdmin):
     resource_classes = [SynonymeResource]
-    search_fields = ["nom"]
+    search_fields = ["nom__unaccent"]
     list_display = ("nom", "produit", "slug")

--- a/qfdmo/admin/acteur.py
+++ b/qfdmo/admin/acteur.py
@@ -177,7 +177,7 @@ class BaseActeurAdmin(admin.GISModelAdmin):
     search_fields = [
         "code_postal",
         "identifiant_unique",
-        "nom",
+        "nom__unaccent",
         "siret",
         "ville",
     ]


### PR DESCRIPTION
# Description succincte du problème résolu

https://www.notion.so/accelerateur-transition-ecologique-ademe/AST-0-Support-des-recherches-non-accentu-es-dans-Django-Admin-1526523d57d780daa394e9dc77981a3f?pvs=4

Ajout de la gestion des accents dans la recherche django admin : ils sont désormais ignorés 


**Type de changement** :

- [x] Bug fix
- [x] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- Faire une recherche sans accent, par exemple `Derap` http://localhost:8000/admin/qfdmo/revisionacteur/?q=derapa 
- Vérifier que des résultats comportant des accents ressortent, comme `Déparage`
- Comparer avec la prod https://lvao.ademe.fr/admin/qfdmo/revisionacteur/?q=derapa - ces résultats sont sensés être absents 