### PR TITLE
Correctif évitant de ne plus avoir d'événement posthog au clic sur la carte 

### DIFF
--- a/jinja2/qfdmo/shared/main.html
+++ b/jinja2/qfdmo/shared/main.html
@@ -11,6 +11,7 @@
         data-turbo-frame="addressesPanel"
         data-action="map:displayActeur->search-solution-form#displayActeur
         map:updateBbox->search-solution-form#updateBboxInput
+        search-solution-form:captureInteraction->analytics#captureInteractionWithMap
         address-autocomplete:formSubmit->search-solution-form#advancedSubmit
         ss-cat-object-autocomplete:formSubmit->search-solution-form#advancedSubmit
         ss-cat-object-autocomplete:optionSelected->search-solution-form#checkSsCatObjetErrorForm


### PR DESCRIPTION
# Description succincte du problème résolu

https://www.notion.so/accelerateur-transition-ecologique-ademe/Posthog-Mesure-des-interactions-de-la-carte-0-depuis-20-novembre-14b6523d57d780fdb3cdc1da565a32f8?pvs=4

Lors du passage la nouvelle fiche détaillée, un event listener Stimulus écoutait un événement envoyé par le controller de la map alors qu'il était désormais envoyé par `search-form-controller`, ça avait pour conséquence de ne pas envoyer les événements d'ouverture de fiche détaillée à Posthog 

Note : devrait être couvert par des tests e2e, à voir en 2025 :) 


**Type de changement** :

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- cliquer sur un point de la carte, sur http://localhost:8000/carte?epci_codes=200043123 par exemple
- vérifier que ça envoie bien un événement à posthog 