### PR TITLE
Utiliser le UUID pour affiche le détails des acteurs digitaux

### DIFF
--- a/jinja2/qfdmo/carte/_digital_results.html
+++ b/jinja2/qfdmo/carte/_digital_results.html
@@ -5,7 +5,7 @@
             <div data-action="click->search-solution-form#displayDigitalActeur
                               keydown.enter->search-solution-form#displayDigitalActeur
                               keydown.space->search-solution-form#displayDigitalActeur"
-                 data-identifiant-unique="{{ adresse.identifiant_unique }}"
+                 data-uuid="{{ adresse.uuid }}"
                  class="qf-cursor-pointer qf-rounded qf-border-solid qf-border qf-border-light-gray qf-content-start fr-p-1w fr-mb-1w
                         {{ loop.cycle('qf-bg-grey-975','qf-bg-grey-950') }}
                         qf-flex qf-flex-col"

--- a/static/to_compile/js/search_solution_form_controller.ts
+++ b/static/to_compile/js/search_solution_form_controller.ts
@@ -219,8 +219,8 @@ export default class extends Controller<HTMLElement> {
   }
 
   displayDigitalActeur(event) {
-    const identifiantUnique = event.currentTarget.dataset.identifiantUnique
-    window.location.hash = identifiantUnique
+    const uuid = event.currentTarget.dataset.uuid
+    window.location.hash = uuid
     document
       .querySelector("[aria-controls='acteurDetailsPanel'][aria-expanded='true']")
       ?.setAttribute("aria-expanded", "false")


### PR DESCRIPTION
# Description succincte du problème résolu

Régression, oublie d'utiliser le uuid pour afficher les acteurs digitaux, la fonction n'étant pas la même que pour les acteurs sur la carte

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
