### PR TITLE
Correction des transformations quand la colonne origin et destination est la même

### DIFF
--- a/dags/sources/tasks/business_logic/source_data_normalize.py
+++ b/dags/sources/tasks/business_logic/source_data_normalize.py
@@ -57,7 +57,8 @@ def source_data_normalize(
         df[transformation["destination"]] = df[transformation["origin"]].apply(
             TRANSFORMATION_MAPPING[function_name]
         )
-        df.drop(columns=[transformation["origin"]], inplace=True)
+        if transformation["destination"] != transformation["origin"]:
+            df.drop(columns=[transformation["origin"]], inplace=True)
 
     # DEBUT Traitement des identifiants
 

--- a/dags_unit_tests/sources/tasks/business_logic/test_source_data_normalize.py
+++ b/dags_unit_tests/sources/tasks/business_logic/test_source_data_normalize.py
@@ -263,7 +263,7 @@ class TestSourceDataNormalize:
     - [ ] test Suppresion des colonnes non voulues
     - [ ] test ignore_duplicates
     - [ ] test produitsdechets_acceptes vide ou None
-    - [ ] test transformation from column_transformations is called
+    - [x] test transformation from column_transformations is called
     """
 
     @pytest.fixture
@@ -523,7 +523,12 @@ class TestSourceDataNormalize:
                 "origin": "nom origin",
                 "transformation": "test_fct",
                 "destination": "nom destination",
-            }
+            },
+            {
+                "origin": "nom",
+                "transformation": "test_fct",
+                "destination": "nom",
+            },
         ]
         source_data_normalize_kwargs["df_acteur_from_source"] = pd.DataFrame(
             {
@@ -532,7 +537,8 @@ class TestSourceDataNormalize:
                 "source_id": ["source_id1"],
                 "acteur_type_id": ["decheterie"],
                 "produitsdechets_acceptes": ["Plastic Box"],
-                "nom origin": ["nom"],
+                "nom origin": ["nom origin 1"],
+                "nom": ["nom"],
             }
         )
 
@@ -540,6 +546,9 @@ class TestSourceDataNormalize:
         df = source_data_normalize(**source_data_normalize_kwargs)
         assert "nom destination" in df.columns
         assert df["nom destination"].iloc[0] == "success"
+
+        assert "nom" in df.columns
+        assert df["nom"].iloc[0] == "success"
 
 
 class TestDfNormalizePharmacie:


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [Importer les données EMPAP / OCAPEM / Citeo ](https://www.notion.so/accelerateur-transition-ecologique-ademe/Importer-les-donn-es-EMPAP-OCAPEM-Citeo-1306523d57d7804c9e0cd1a52b19269f?pvs=4)

Ne pas supprimer la colonne origin si c'est a même que la destination sinon, on n'a plus la colonne, c'est balo

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [ ] Bug fix
- [x] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
