### PR TITLE
Homogeneisation intitules

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -1,2 +1,2 @@
-bonus_reparation = "Propose le bonus réparation"
+bonus_reparation = "Propose le Bonus Réparation"
 DIGITAL_ACTEUR_CODE = "acteur_digital"

--- a/integration_tests/qfdmo/test_acteur_detail.py
+++ b/integration_tests/qfdmo/test_acteur_detail.py
@@ -68,7 +68,7 @@ class TestDisplayLabel:
             ),
             (
                 [("label", "Mon label", False, True)],
-                "Propose le bonus réparation",
+                "Propose le Bonus Réparation",
                 True,
             ),
         ],

--- a/jinja2/qfdmo/acteur.html
+++ b/jinja2/qfdmo/acteur.html
@@ -9,7 +9,7 @@
                     {% include "qfdmo/acteur/_labels.html" %}
                 {% endif %}
 
-                <h2 class="qf-text-lg qf-m-0 qf-max-w-[90%]" data-testid="acteur-title">{{ object.libelle|capitalize }}</h2>
+                <h2 class="qf-text-lg qf-m-0 qf-max-w-[90%]" data-testid="acteur-title">{{ object.libelle|title }}</h2>
                 <p class="qf-text-sm qf-m-0">
                     {{ object.acteur_services_display }} {{ distance }}
                 </p>

--- a/qfdmo/forms.py
+++ b/qfdmo/forms.py
@@ -7,7 +7,6 @@ from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 from dsfr.forms import DsfrBaseForm
 
-from core.constants import bonus_reparation
 from qfdmo.fields import GroupeActionChoiceField
 from qfdmo.geo_api import epcis_from, formatted_epcis_as_list_of_tuple
 from qfdmo.models import DagRun, DagRunStatus, SousCategorieObjet
@@ -180,7 +179,7 @@ class AddressesForm(forms.Form):
         ),
         label=mark_safe(
             "<span class='fr-icon--sm fr-icon-percent-line'></span>"
-            f"&nbsp;{bonus_reparation}"
+            "&nbsp;Adresse proposant le Bonus Réparation"
         ),
         help_text=mark_safe(
             "Afficher uniquement les adresses éligibles (uniquement valable lorsque l'"


### PR DESCRIPTION
# Description succincte du problème résolu

Corrige 
- https://www.notion.so/accelerateur-transition-ecologique-ademe/Homog-n-isation-des-intitul-s-de-la-modale-FILTRES-1506523d57d7804bad3ed987617c1c3a?pvs=4 
- https://www.notion.so/accelerateur-transition-ecologique-ademe/Capitalisation-du-nom-de-l-acteur-1526523d57d780d089e8cb661d131fb0?pvs=4


Homogénéisation des labels concernant le bonus réparation 
Correction des titres pour afficher le premier mot de chaque acteur en majuscule 


**Type de changement** :

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

- aller voir un acteur avec plusieurs mots dans son nom
- Vérifier que chaque première lettre de chaque mot est en majuscule 

Ouvrir les filtres avancés de la carte 
Vérifier que le filtre bonus réparation est iso avec le screenshot ci dessous 
![image](https://github.com/user-attachments/assets/d607ce94-4935-47f2-946e-7e15a3075880)
