### PR TITLE
:gift: Suggestion de changement v1

### DIFF
--- a/qfdmo/admin/change_suggestion.py
+++ b/qfdmo/admin/change_suggestion.py
@@ -1,0 +1,11 @@
+from django.contrib.gis import admin
+
+from qfdmo.models.change_suggestion import ChangeSuggestion
+
+
+class ChangeSuggestionAdmin(admin.ModelAdmin):
+    # Pour l'instant on consèrve le modèle admin par défaut
+    pass
+
+
+admin.site.register(ChangeSuggestion, ChangeSuggestionAdmin)

--- a/qfdmo/models/__init__.py
+++ b/qfdmo/models/__init__.py
@@ -1,6 +1,7 @@
 from .acteur import *  # noqa
 from .action import *  # noqa
 from .categorie_objet import *  # noqa
+from .change_suggestion import *  # noqa
 from .data import *  # noqa
 from .lvao import *  # noqa
 from .utils import *  # noqa

--- a/qfdmo/models/change_suggestion.py
+++ b/qfdmo/models/change_suggestion.py
@@ -1,0 +1,126 @@
+"""
+Modèle de données Django pour les suggestions de changements
+"""
+
+from textwrap import dedent
+
+from django.db import models
+from django.utils import timezone
+
+
+class ChangeSuggestion(models.Model):
+    """
+    Modèle de données Django pour les suggestions de changements
+
+    Gestion des données:
+     - change_data: ne doit contenir que le strict minimum pour gérer le changement
+        (ex: pour un cluster d'acteur = cluster_id -> acteur_id). Ne pas stocker
+        d'autres données qui pourraient devenir obsolètes au moment de la revue.
+        Si on souhaite fournir de la donnée supplémentaire, il faut le faire à
+        la vollée (ex: au moment de l'affichage ou de l'export)
+
+     - debug_data (optionnel): si on veut expliquer comment on est arrivé à cette
+        suggestion, on peut stocker ici des données de debug (ex: valeurs des champs,
+        scores de similarité, etc.)
+    """
+
+    class Meta:
+        db_table = "qfdmo_change_suggestions"
+        verbose_name = "Suggestion de changement"
+        verbose_name_plural = "Suggestions de changements"
+
+    # ------------------------------------
+    # Champs liés à la suggestion
+    # ------------------------------------
+    id = models.AutoField(primary_key=True)
+    task_run_id = models.CharField(
+        max_length=200, verbose_name="ID de la tâche qui a généré la suggestion"
+    )
+    task_run_at = models.DateTimeField(
+        verbose_name="Date/heure de la tâche qui a généré la suggestion"
+    )
+    debug_data = models.JSONField(
+        verbose_name=dedent(
+            """Données de debug de la suggestion
+        (quelles données ont été utilisées pour la suggestion)"""
+        ),
+        default=None,
+    )
+    change_type = models.CharField(
+        max_length=20,
+        choices=(("acteur_cluster", "Cluster d'acteur"),),
+        verbose_name="Type de changement",
+    )
+    change_data = models.JSONField(
+        verbose_name=dedent(
+            """Données du changement
+         (stocker uniquement le strict minimum pour
+         gérer le changement)"""
+        ),
+    )
+    change_description = models.TextField(verbose_name="Description")
+
+    # ------------------------------------
+    # Champs liés aux revues
+    # ------------------------------------
+    review_status = models.CharField(
+        max_length=20,
+        choices=(
+            ("pending", "En attente"),
+            ("accepted", "Acceptée"),
+            ("rejected", "Rejetée"),
+        ),
+        default="pending",
+        verbose_name="Statut de la revue",
+    )
+    review_at = models.DateTimeField(
+        verbose_name="Date/heure de la revue (géré automatiquement à la sauvegarde)",
+        editable=False,
+    )
+    review_comments = models.TextField(
+        blank=True, null=True, verbose_name="Commentaires de revue"
+    )
+
+    def __str__(self) -> str:
+        return f"Suggestion de changement {self.id=} ({self.review_status=})"
+
+    def clean(self):
+        """Normalisation/validation des données"""
+        super().clean()
+
+        # ------------------------------
+        # Remplissages automatiques
+        # ------------------------------
+        # On remplit review_at si la revue est effectuée ET
+        # que c'est la première fois qu'on change le statut (sinon
+        # on garde la valeur originale)
+        if self.review_status != "pending" and self.review_at is None:
+            self.review_at = timezone.now()
+
+        # ------------------------------
+        # Validation de change_data
+        # ------------------------------
+        # Par défaut on s'attend à un dict ou une list
+        if not isinstance(self.change_data, (dict, list)):
+            raise ValueError("change_data doit être un dict ou list")
+
+        # Validations spécifiques aux différents types de changements
+        if self.change_type == "acteur_cluster":
+            if not isinstance(self.change_data, dict):
+                raise ValueError("acteur_cluster: change_data doit être un dict pour ")
+            acteur_id = self.change_data.get("acteur_id")
+            cluster_id = self.change_data.get("cluster_id")
+            if not acteur_id:
+                raise ValueError("acteur_cluster: change_data à besoin de acteur_id")
+            if not cluster_id:
+                raise ValueError("acteur_cluster: change_data à besoin de cluster_id")
+
+        else:
+            raise NotImplementedError(
+                f"Pas de gestion change_data pour: {self.change_type}"
+            )
+
+    def save(self, *args, **kwargs):
+        """Pour appliquer toutes les normalisations/validations"""
+        self.full_clean()
+        super().save(*args, **kwargs)


### PR DESCRIPTION
# :gift: Suggestion de changement v1

## :red_circle: Mergée mais remplacée postérieurement par https://github.com/incubateur-ademe/quefairedemesobjets/pull/1174 :red_circle:

Carte Notion : [CLUSTERING: Modèles & UI django pour le stockage des clusters](https://www.notion.so/accelerateur-transition-ecologique-ademe/CLUSTERING-Mod-les-UI-django-pour-le-stockage-des-clusters-15e6523d57d780c19b75f432d4a18448)

 - **quoi**: un modèle et une UI Django pour suggérer et revoir (rejeter, approuver) des suggestions de changements
 - **pourquoi**: initialement pour le clustering, mais on veut s'en servir à l'avenir pour suggérer d'autres changements (diff d'ingestion des acteurs)
 - **comment**: en rendant le schema/nomenclature générique mais en validant les données fournies

## Approche

 - **Suite à une réunion ce matin on a décidé** avec @kolok et @chrischarousset de partir sur **une approche abstraite de la notion de changement**, pour l'utiliser dans d'autres contextes que le clustering (ex: diff d'ingestion)
 - **Par conséquent on a besoin d'un champ `JSON`** pour représenter le changement, car tout changement n'aura pas la même structure (ex: pour le clustering on a besoin d'un cluster_id, pas pour le diff d'ingestion des acteurs)
 - **En ce qui concerne la validation du `JSON`**
    - Manque d’XP django de ma part pour savoir ce qui est le mieux
    - Je vois des champs `JSONField` dans notre code (ex: `DagRun.meta_data`) mais je ne trouve pas de validation associée
    - Donc par défaut je suis parti sur `JSONField` avec de la validation dans le modèle sous `clean`

# :arrow_right: Restant à faire

 - [ ] Comprendre/résoudre problème d'affichage dans Django Admin UI
 - [ ] Une fois le modèle finalisé: écrire des tests unitaires pour valider le cas clustering et s'assurer que les problèmes de formatage de données soulèvent bien des exceptions
 - [ ] Tester le modèle en important les clusters de déchetteries