### PR TITLE
:rocket: CLUSTERING: DAG airflow - Sélection des acteurs

### DIFF
--- a/dags/clustering/dags/clustering_acteur.py
+++ b/dags/clustering/dags/clustering_acteur.py
@@ -1,0 +1,153 @@
+from typing import Dict, List
+
+from airflow import DAG
+from airflow.decorators import task
+from airflow.models.param import Param
+from shared.tasks.database_logic.db_manager import PostgresConnectionManager
+from sources.tasks.airflow_logic.operators import default_args
+from sources.tasks.business_logic.read_mapping_from_postgres import (
+    read_mapping_from_postgres,
+)
+from sqlalchemy import inspect
+from utils import logging_utils as log
+
+default_args["retries"] = 0
+
+# -------------------------------------------
+# Gestion des dropdowns des paramètres
+# -------------------------------------------
+# A noter que ce design pattern est a éviter au maximum
+# car le code est executé au parsing des fichiers DAG
+# selon min_file_process_interval
+# https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#config-scheduler-min-file-process-interval
+# https://airflow.apache.org/docs/apache-airflow/stable/best-practices.html#top-level-python-code
+# En revanche sans cette approche, il va falloir:
+# - soit laisser le métier rentrer des paramètres complexes à la main
+# - soit maintenir des mapping statiques ici
+# Ces deux options semblent pires que l'inconvénient du top-level code
+# sachant que le code executé demeure assez légé
+
+# Récupération données DB
+mapping_source_id_by_code = read_mapping_from_postgres(table_name="qfdmo_source")
+mapping_acteur_type_id_by_code = read_mapping_from_postgres(
+    table_name="qfdmo_acteurtype"
+)
+# Création des dropdowns
+dropdown_sources = list(f"{k} (id {v})" for k, v in mapping_source_id_by_code.items())
+dropdown_acteur_types = list(
+    f"{k} (id {v})" for k, v in mapping_acteur_type_id_by_code.items()
+)
+
+
+# Récupérer les IDs des valeurs sélectionnées
+def ids_from_dropdowns(
+    mapping_id_by_code: Dict[str, int],
+    dropdown_all: List[str],
+    dropdown_selected: List[str],
+) -> List[int]:
+    """Récupère les IDs correspondants aux valeurs
+    sélectionnées dans un dropdown."""
+    ids = list(mapping_id_by_code.values())
+    dropdown_indices = [dropdown_all.index(v) for v in dropdown_selected]
+    return [ids[i] for i in dropdown_indices]
+
+
+def table_columns_get(table_name: str) -> List[str]:
+    """
+    Récupère la liste des colonnes d'une table dans une base de données.
+    """
+    engine = PostgresConnectionManager().engine
+    inspector = inspect(engine)
+    columns = inspector.get_columns(table_name)  # type: ignore
+    return [column["name"] for column in columns]
+
+
+dropdown_acteur_columns = table_columns_get("qfdmo_revisionacteur")
+
+
+with DAG(
+    dag_id="clustering_acteur",
+    dag_display_name="Clustering - Acteur",
+    default_args=default_args,
+    description=("Un DAG pour générer des suggestions de clustering pour les acteurs"),
+    params={
+        "sources": Param(
+            [],
+            type="array",
+            examples=dropdown_sources,
+            description="Sources à inclure dans le clustering",
+        ),
+        "acteur_types": Param(
+            [],
+            type="array",
+            # La terminologie Airflow n'est pas très heureuse
+            # mais "examples" est bien la façon de faire des dropdowns
+            # voir https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/params.html
+            examples=dropdown_acteur_types,
+            description="Types d'acteurs à inclure dans le clustering",
+        ),
+        "colonnes_match_fuzzy": Param(
+            [],
+            type="array",
+            examples=dropdown_acteur_columns,
+            description="Colonnes à utiliser pour le match fuzzy (algo ML)",
+        ),
+        "colonnes_match_exact": Param(
+            [],
+            type="array",
+            examples=dropdown_acteur_columns,
+            description="""Clusteriser les acteurs SI les valeurs
+            de ces colonnes sont identiques""",
+        ),
+        "intra_source": Param(
+            False,
+            type="boolean",
+            description="Clusteriser les acteurs au sein d'une même source",
+        ),
+        "similarity_threshold": Param(
+            0.8,
+            type="number",
+            minimum=0,
+            maximum=1,
+            description="Seuil de similarité pour le clustering",
+        ),
+    },
+    schedule=None,
+) as dag:
+
+    @task()
+    def clustering_acteur_config_validate(**kwargs) -> None:
+        """Valider les paramètres du DAG pour le clustering acteur."""
+        params = kwargs["params"]
+
+        source_ids = ids_from_dropdowns(
+            mapping_id_by_code=mapping_source_id_by_code,
+            dropdown_all=dropdown_sources,
+            dropdown_selected=params["sources"],
+        )
+        acteur_type_ids = ids_from_dropdowns(
+            mapping_id_by_code=mapping_acteur_type_id_by_code,
+            dropdown_all=dropdown_acteur_types,
+            dropdown_selected=params["acteur_types"],
+        )
+        log.preview("sources sélectionnées", params["sources"])
+        log.preview("sources ids correspondant", source_ids)
+        log.preview("acteur_types sélectionnés", params["acteur_types"])
+        log.preview("acteur_types ids correspondant", acteur_type_ids)
+
+        columns_match_fuzzy = set(params["colonnes_match_fuzzy"])
+        columns_match_exact = set(params["colonnes_match_exact"])
+        columns_dups = columns_match_fuzzy.intersection(columns_match_exact)
+        log.preview("colonnes match fuzzy", columns_match_fuzzy)
+        log.preview("colonnes match exact", columns_match_exact)
+        if columns_dups:
+            raise ValueError(f"Colonnes {columns_dups} présentes dans fuzzy et exact")
+        if not columns_match_fuzzy and not columns_match_exact:
+            raise ValueError("Aucune colonne sélectionnée pour le clustering")
+
+        intra_source = params["intra_source"]
+        log.preview("intra_source", intra_source)
+        if len(source_ids) == 1 and not intra_source:
+            raise ValueError(f"1 source sélectionnée mais {intra_source=}")
+
+    clustering_acteur_config_validate()

--- a/dags/clustering/tasks/airflow_logic/clustering_config_validate_task.py
+++ b/dags/clustering/tasks/airflow_logic/clustering_config_validate_task.py
@@ -1,0 +1,55 @@
+"""
+Tâche Airflow pour valider la configuration de clustering
+"""
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from clustering.tasks.business_logic.clustering_config_validate import (
+    clustering_acteur_config_validate,
+)
+from sources.tasks.business_logic.read_mapping_from_postgres import (
+    read_mapping_from_postgres,
+)
+from utils import logging_utils as log
+
+mapping_source_id_by_code = read_mapping_from_postgres(table_name="qfdmo_source")
+mapping_acteur_type_id_by_code = read_mapping_from_postgres(
+    table_name="qfdmo_acteurtype"
+)
+
+
+def clustering_acteur_config_validate_wrapper(**kwargs) -> None:
+    """Wrapper de la tâche Airflow pour échanger les paramètres
+    et pouvoir tester la tâche sans mock."""
+    params = kwargs["params"]
+
+    log.preview("sources sélectionnées", params["include_source_codes"])
+    log.preview("acteur_types sélectionnés", params["include_acteur_type_codes"])
+    log.preview("inclure si champs non-vide", params["include_if_all_fields_filled"])
+    log.preview("exclude si champ vide", params["exclude_if_any_field_filled"])
+    log.preview(
+        "champs à la fois inclure/exclure", params["include_if_all_fields_filled"]
+    )
+
+    include_source_ids, include_acteur_type_ids = clustering_acteur_config_validate(
+        mapping_source_id_by_code=mapping_source_id_by_code,
+        mapping_acteur_type_id_by_code=mapping_acteur_type_id_by_code,
+        include_source_codes=params["include_source_codes"],
+        include_acteur_type_codes=params["include_acteur_type_codes"],
+        include_if_all_fields_filled=params["include_if_all_fields_filled"],
+        exclude_if_any_field_filled=params["exclude_if_any_field_filled"],
+    )
+    params["include_source_ids"] = include_source_ids
+    params["include_acteur_type_ids"] = include_acteur_type_ids
+
+    # Use xcom to pass the params to the next task
+    kwargs["ti"].xcom_push(key="params", value=params)
+
+
+def clustering_acteur_config_validate_task(dag: DAG) -> PythonOperator:
+    """La tâche Airflow qui ne fait que appeler le wrapper"""
+    return PythonOperator(
+        task_id="clustering_acteur_config_validate",
+        python_callable=clustering_acteur_config_validate_wrapper,
+        dag=dag,
+    )

--- a/dags/clustering/tasks/airflow_logic/clustering_db_data_read_acteurs_task.py
+++ b/dags/clustering/tasks/airflow_logic/clustering_db_data_read_acteurs_task.py
@@ -1,0 +1,45 @@
+import pandas as pd
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from clustering.tasks.business_logic.clustering_db_data_read_acteurs import (
+    clustering_db_data_read_acteurs,
+)
+from shared.tasks.database_logic.db_manager import PostgresConnectionManager
+from utils import logging_utils as log
+
+
+def clustering_db_data_read_acteurs_wrapper(**kwargs) -> pd.DataFrame:
+
+    # use xcom to get the params from the previous task
+    params = kwargs["ti"].xcom_pull(
+        key="params", task_ids="clustering_acteur_config_validate"
+    )
+
+    log.preview("paramètres reçus", params)
+    log.preview("sources sélectionnées", params["include_source_ids"])
+    log.preview("acteur_types sélectionnés", params["include_acteur_type_ids"])
+    log.preview("inclure si champs remplis", params["include_if_all_fields_filled"])
+    log.preview("exclude si champs remplis", params["exclude_if_any_field_filled"])
+
+    df, query = clustering_db_data_read_acteurs(
+        include_source_ids=params["include_source_ids"],
+        include_acteur_type_ids=params["include_acteur_type_ids"],
+        include_if_all_fields_filled=params["include_if_all_fields_filled"],
+        exclude_if_any_field_filled=params["exclude_if_any_field_filled"],
+        engine=PostgresConnectionManager().engine,
+    )
+    log.preview("requête SQL utilisée", query)
+    log.preview("acteurs sélectionnés", df)
+    log.preview("# acteurs par source_id", df.groupby("source_id").size())
+    log.preview("# acteurs par acteur_type_id", df.groupby("acteur_type_id").size())
+
+    return df
+
+
+def clustering_db_data_read_acteurs_task(dag: DAG) -> PythonOperator:
+    """La tâche Airflow qui ne fait que appeler le wrapper"""
+    return PythonOperator(
+        task_id="clustering_db_data_read_acteurs",
+        python_callable=clustering_db_data_read_acteurs_wrapper,
+        dag=dag,
+    )

--- a/dags/clustering/tasks/business_logic/clustering_config_validate.py
+++ b/dags/clustering/tasks/business_logic/clustering_config_validate.py
@@ -1,0 +1,41 @@
+"""
+Fonction pour valider la configuration de clustering
+"""
+
+from utils.airflow_params import airflow_params_dropdown_selected_to_ids
+
+
+def clustering_acteur_config_validate(
+    mapping_source_id_by_code: dict[str, int],
+    mapping_acteur_type_id_by_code: dict[str, int],
+    include_source_codes: list[str],
+    include_acteur_type_codes: list[str],
+    include_if_all_fields_filled: list[str],
+    exclude_if_any_field_filled: list[str],
+) -> tuple:
+    """Fonction de validation de la config de clustering"""
+    include_source_ids = airflow_params_dropdown_selected_to_ids(
+        mapping_ids_by_codes=mapping_source_id_by_code,
+        dropdown_selected=include_source_codes,
+    )
+    include_acteur_type_ids = airflow_params_dropdown_selected_to_ids(
+        mapping_ids_by_codes=mapping_acteur_type_id_by_code,
+        dropdown_selected=include_acteur_type_codes,
+    )
+    fields_incl_excl = set(include_if_all_fields_filled) & set(
+        exclude_if_any_field_filled
+    )
+
+    if not include_source_ids:
+        raise ValueError("Au moins une source doit être sélectionnée")
+
+    if not include_acteur_type_ids:
+        raise ValueError("Au moins un type d'acteur doit être sélectionné")
+
+    if not include_if_all_fields_filled:
+        raise ValueError("Au moins un champ non vide doit être sélectionné")
+
+    if fields_incl_excl:
+        raise ValueError(f"Champs à la fois à inclure et à exclure: {fields_incl_excl}")
+
+    return include_source_ids, include_acteur_type_ids

--- a/dags/clustering/tasks/business_logic/clustering_db_data_read_acteurs.py
+++ b/dags/clustering/tasks/business_logic/clustering_db_data_read_acteurs.py
@@ -1,0 +1,121 @@
+import numpy as np
+import pandas as pd
+from sqlalchemy import Column, Integer, MetaData, String, Table, and_, or_
+from sqlalchemy.dialects import postgresql
+
+"""
+TODO:
+ - initialiser django au sein du contexte airflow
+ puis dans le airflow_logic/*_task.py:
+    - charger le modèle DisplayedActeur
+    - appeler la fonction clustering_params_to_django_queryset
+    - convertir le queryset SQL puis en dataframe
+    - supprimer clustering_params_to_sql_query qui n'est plus utilisée
+from django.db.models import Q
+
+def clustering_params_to_django_queryset(
+    model,
+    include_source_ids,
+    include_acteur_type_ids,
+    include_if_fields_filled,
+    exclude_if_any_field_filled,
+):
+    queryset = model.objects.all()
+
+    # Filter by source_id
+    if include_source_ids:
+        queryset = queryset.filter(source_id__in=include_source_ids)
+
+    # Filter by acteur_type_id
+    if include_acteur_type_ids:
+        queryset = queryset.filter(acteur_type_id__in=include_acteur_type_ids)
+
+    # Ensure fields in include_if_fields_filled are not empty
+    if include_if_fields_filled:
+        for field in include_if_fields_filled:
+            queryset = queryset.filter(
+                ~Q(**{f"{field}__isnull": True}), ~Q(**{f"{field}": ""})
+            )
+
+    # Exclude entries where any field in exclude_if_any_field_filled is filled
+    if exclude_if_any_field_filled:
+        for field in exclude_if_any_field_filled:
+            queryset = queryset.exclude(
+                ~Q(**{f"{field}__isnull": True}) & ~Q(**{f"{field}": ""})
+            )
+
+    return queryset
+"""
+
+
+def clustering_params_to_sql_query(
+    table_name,
+    include_source_ids,
+    include_acteur_type_ids,
+    include_if_all_fields_filled,
+    exclude_if_any_field_filled,
+):
+    # Dynamically create metadata and table definition
+    metadata = MetaData()
+    table = Table(
+        table_name,
+        metadata,
+        Column("source_id", Integer),
+        Column("acteur_type_id", Integer),
+        *[
+            Column(field, String)
+            for field in include_if_all_fields_filled + exclude_if_any_field_filled
+        ],
+    )
+
+    query = table.select()
+
+    # Add source_id filter
+    if include_source_ids:
+        query = query.where(table.c.source_id.in_(include_source_ids))
+
+    # Add acteur_type_id filter
+    if include_acteur_type_ids:
+        query = query.where(table.c.acteur_type_id.in_(include_acteur_type_ids))
+
+    # Add include_if_all_fields_filled filters
+    if include_if_all_fields_filled:
+        non_empty_conditions = [
+            and_(table.c[field] != "", table.c[field] is not None)
+            for field in include_if_all_fields_filled
+        ]
+        query = query.where(and_(*non_empty_conditions))
+
+    # Add exclude_if_any_field_filled filters
+    if exclude_if_any_field_filled:
+        empty_conditions = [
+            or_(table.c[field] == "", table.c[field] is None)
+            for field in exclude_if_any_field_filled
+        ]
+        query = query.where(~or_(*empty_conditions))
+
+    # Compile the query into a SQL string
+    compiled_query = str(
+        query.compile(
+            dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+        )
+    ).replace(f"{table_name}.", "")
+    return compiled_query
+
+
+def clustering_db_data_read_acteurs(
+    include_source_ids,
+    include_acteur_type_ids,
+    include_if_all_fields_filled,
+    exclude_if_any_field_filled,
+    engine,
+) -> tuple[pd.DataFrame, str]:
+    query = clustering_params_to_sql_query(
+        "qfdmo_displayedacteur",
+        include_source_ids,
+        include_acteur_type_ids,
+        include_if_all_fields_filled,
+        exclude_if_any_field_filled,
+    )
+    df = pd.read_sql_query(query, engine).replace({np.nan: None})
+    return df, query

--- a/dags/utils/airflow_params.py
+++ b/dags/utils/airflow_params.py
@@ -1,0 +1,59 @@
+"""Utilitaires pour travailler avec les Params UI Airflow.
+https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/params.html
+"""
+
+import re
+
+ID_PREFIX = "id="
+
+
+def airflow_params_dropdown_from_mapping(mapping: dict[str, int]) -> list[str]:
+    """Transforme un mapping de codes à IDs en dropdowns pour Airflow
+    avec le format "{code} (id={ID})". L'inclusion des IDs est utile
+    pour:
+        - chercher par ID
+        - confirmer qu'on a bien sélectionné le bon code (parfois les codes
+            se ressemblent et les IDs enlèvent l'ambiguïté)
+
+    Args:
+        mapping (dict[str, int]): Mapping entre les codes et les IDs
+
+    Returns:
+        list[str]: Dropdowns pour Airflow
+    """
+    ids = list(mapping.values())
+    if len(ids) != len(set(ids)):
+        raise ValueError("Mapping invalide avec des IDs en doublon")
+    return list(f"{code} ({ID_PREFIX}{id})" for code, id in mapping.items())
+
+
+def airflow_params_dropdown_selected_to_ids(
+    mapping_ids_by_codes: dict[str, int],
+    dropdown_selected: list[str],
+) -> list[int]:
+    """Récupère les IDs correspondants aux valeurs
+    sélectionnées dans un dropdown Params UI Airflow
+    "{code} (id={ID})" => extrait le {code} => trouve l'ID correspondant
+    via le mapping.
+
+    Ceci permet de vérifier que les valeurs sélectionnées sont valides
+    sans prendre le risque de faire confiance naïvement à l'ordonnencement
+    des valeurs dans le dropdown qu'on ne maitrise pas.
+
+    Args:
+        mapping_id_by_code (dict[str, int]): Mapping entre les codes et les IDs
+        dropdown_all (list[str]): Toutes les valeurs possibles du dropdown
+        dropdown_selected (list[str]): Valeurs sélectionnées dans le dropdown
+
+    Returns:
+        list[int]: IDs correspondant aux valeurs sélectionnées
+    """
+    invalid = [x for x in dropdown_selected if ID_PREFIX not in x]
+    if invalid:
+        raise ValueError(
+            f"""Valeurs invalides sans ID_PREFIX {ID_PREFIX}: {invalid}.
+                         Utiliser airflow_params_dropdown_from_mapping
+                         pour générer les dropdowns."""
+        )
+    codes = [re.sub(r" \(id=\d+\)$", "", v) for v in dropdown_selected]
+    return [mapping_ids_by_codes[x] for x in codes]

--- a/dags_unit_tests/clustering/tasks/business_logic/test_clustering_config_validate.py
+++ b/dags_unit_tests/clustering/tasks/business_logic/test_clustering_config_validate.py
@@ -1,0 +1,67 @@
+import pytest
+
+from dags.clustering.tasks.business_logic.clustering_config_validate import (
+    clustering_acteur_config_validate,
+)
+
+
+class TestClusteringActeurConfigValidate:
+
+    @pytest.fixture(scope="session")
+    def map_source_codes(self):
+        return {
+            "source1": 1,
+            "source2": 2,
+            "source3": 3,
+        }
+
+    @pytest.fixture(scope="session")
+    def map_atype_codes(self):
+        return {
+            "type1": 1,
+            "type2": 2,
+            "type3": 3,
+        }
+
+    @pytest.fixture
+    def params(self, map_source_codes, map_atype_codes):
+        return {
+            "mapping_source_id_by_code": map_source_codes,
+            "mapping_acteur_type_id_by_code": map_atype_codes,
+            "include_source_codes": ["source1 (id=1)"],
+            "include_acteur_type_codes": ["type1 (id=1)"],
+            "include_if_all_fields_filled": ["nom", "code_postal"],
+            "exclude_if_any_field_filled": ["siret"],
+        }
+
+    def test_include_source_ids_invalid(self, params):
+        params["include_source_codes"] = []
+        with pytest.raises(
+            ValueError, match="Au moins une source doit être sélectionnée"
+        ):
+            clustering_acteur_config_validate(**params)
+
+    def test_include_acteur_type_ids_invalid(self, params):
+        params["include_acteur_type_codes"] = []
+        with pytest.raises(
+            ValueError, match="Au moins un type d'acteur doit être sélectionné"
+        ):
+            clustering_acteur_config_validate(**params)
+
+    def test_include_if_fields_not_empty_invalid(self, params):
+        params["include_if_all_fields_filled"] = []
+        with pytest.raises(
+            ValueError, match="Au moins un champ non vide doit être sélectionné"
+        ):
+            clustering_acteur_config_validate(**params)
+
+    def test_fields_incl_excl_invalid(self, params):
+        params["include_if_all_fields_filled"] = ["nom"]
+        params["exclude_if_any_field_filled"] = ["nom"]
+        with pytest.raises(
+            ValueError, match="Champs à la fois à inclure et à exclure: {'nom'}"
+        ):
+            clustering_acteur_config_validate(**params)
+
+    def test_valid(self, params):
+        clustering_acteur_config_validate(**params)

--- a/dags_unit_tests/clustering/tasks/business_logic/test_clustering_db_data_read_acteurs.py
+++ b/dags_unit_tests/clustering/tasks/business_logic/test_clustering_db_data_read_acteurs.py
@@ -1,0 +1,17 @@
+from dags.clustering.tasks.business_logic.clustering_db_data_read_acteurs import (
+    clustering_params_to_sql_query,
+)
+
+
+def test_clustering_params_to_sql_query():
+    query = clustering_params_to_sql_query(
+        table_name="qfdmo_displayedacteur",
+        # SINOE, REFASHION
+        include_source_ids=[6, 45],
+        # Déchetteries
+        include_acteur_type_ids=[7],
+        include_if_all_fields_filled=["nom"],
+        exclude_if_any_field_filled=["code_postal"],
+    )
+    print(query)
+    # TODO: compléter les tests

--- a/dags_unit_tests/utils/test_airflow_params_dropdown.py
+++ b/dags_unit_tests/utils/test_airflow_params_dropdown.py
@@ -1,0 +1,64 @@
+import pytest
+
+from dags.utils.airflow_params import (
+    airflow_params_dropdown_from_mapping,
+    airflow_params_dropdown_selected_to_ids,
+)
+
+
+class TestAirflowParamsDropdown:
+
+    @pytest.fixture(scope="session")
+    def mapping(self):
+        return {
+            "code1": 1,
+            "code2": 2,
+            "code3": 3,
+        }
+
+    def test_from_mapping(self, mapping):
+        """Les valeurs du dropdown doivents comprendre les codes et les IDs
+        pour aider à chercher via l'un ou l'autre et offrire une validation
+        mutuelle via la UI Airflow (les codes peuvent se ressembler).
+        """
+        expected = ["code1 (id=1)", "code2 (id=2)", "code3 (id=3)"]
+        actual = airflow_params_dropdown_from_mapping(mapping)
+        assert actual == expected
+
+    def test_from_mapping_exception_if_invalid(self, mapping):
+        """Bien qu'on ne devrait pas avoir de doublons dans les IDs,
+        sachant que les conséquences sont graves et qu'on a 0 validation
+        dans Airflow, on préfère implémenter une vérification nous-même.
+        """
+        mapping["code4"] = 1
+        with pytest.raises(ValueError, match="Mapping invalide"):
+            airflow_params_dropdown_from_mapping(mapping)
+
+    def test_to_ids(self, mapping):
+        """On test avec des gaps et dans le désordre pour s'assurer
+        de la robustesse de l'implémentation."""
+        selected = [
+            "code3 (id=3)",
+            "code1 (id=1)",
+        ]
+        expected = [3, 1]
+        actual = airflow_params_dropdown_selected_to_ids(mapping, selected)
+        assert actual == expected
+
+    def test_to_ids_exception_if_code_not_found(self, mapping):
+        """Même raison que pour l'autre _exception_if_invalid: on ne
+        prend pas de risque et on valide nous-même les cas invalides."""
+        selected = [
+            "code3 (id=3)",
+            "code_not_found (id=999)",
+        ]
+        with pytest.raises(KeyError, match="code_not_found"):
+            airflow_params_dropdown_selected_to_ids(mapping, selected)
+
+    def test_to_ids_exception_if_dropdown_has_no_ids(self, mapping):
+        """On veut s'assurer que les valeurs sélectionnées ont bien
+        le format attendu avec ID_PREFIX inséré par
+        airflow_params_dropdown_from_mapping."""
+        selected = ["code3", "code1"]
+        with pytest.raises(ValueError, match="Valeurs invalides sans ID_PREFIX"):
+            airflow_params_dropdown_selected_to_ids(mapping, selected)


### PR DESCRIPTION
# :rocket: CLUSTERING: DAG airflow - Sélection des acteurs

Carte Notion : [CLUSTERING: création du DAG airflow pour générer les suggestions](https://www.notion.so/accelerateur-transition-ecologique-ademe/CLUSTERING-cr-ation-du-DAG-airflow-pour-g-n-rer-les-suggestions-15e6523d57d780a89d89d7da6cd1dfed)

**:green_circle: cette PR ne fait que de la lecture/affichage pour permettre à @chrischarousset de commencer à jouter avec la UI Airflow. 0 risque de casser quoi ce ce soit :green_circle:**

 - **:bulb: quoi**: un `DAG` pour offrir une UI de paramètres et sélectionner/afficher les acteurs 
 - **:dart: pourquoi**: permettre au métier de commencer à jouer avec la sélection
 - **:thinking: comment**: voir instructions ci-dessous

## Reste à faire sur cette tâche (prochaine PR*)

_* car on a besoin de merger celle-ci pour que @chrischarousset puisse l'utiliser_

- [ ] **rajouter des critères de sélection/exclusion** si @chrischarousset en a besoin
- [ ] **convertir la requette SQLAlchemy en Django** = plus robuste et plus lisible
- [ ] **ajouter des tests pour la sélection** une fois qu'on a la version Django
 
## Instructions

### 1) Paramètres de sélection via UI Airflow

 - tâche airflow associée: `clustering_acteur_config_validate`

![image](https://github.com/user-attachments/assets/6d9d241b-3ab8-4f33-8845-2913b33ca1e6)

![image](https://github.com/user-attachments/assets/d9a0b71e-9c5b-47d8-b723-65683917d80e)

### 2) Sélection des acteurs

 - tâche airflow associée: `clustering_db_data_read_acteurs_task`
 
![image](https://github.com/user-attachments/assets/52de5e5d-54a5-4400-bf9e-90d3cd01d1a7)

