### PR TITLE
Mise à jour du mapping produit pour CITEO

### DIFF
--- a/dags/sources/config/db_mapping.json
+++ b/dags/sources/config/db_mapping.json
@@ -25,6 +25,7 @@
     ],
     "gem froid": "gros electromenager (refrigerant)",
     "gem hors froid": "gros electromenager (hors refrigerant)",
+    "grands cartons": "emballage_carton",
     "huisseries": "Huisseries (produits et matériaux de construction du bâtiment)",
     "jeux et jouets": "jouet",
     "laine de roche": "Laine de roche (produits et matériaux de construction du bâtiment)",
@@ -43,6 +44,16 @@
     "pam (petits appareils ménagers)": "petit electromenager",
     "panneaux photovoltaïques": "Panneaux photovoltaïques",
     "papiers graphiques": "papiers_graphiques",
+    "papiers graphiques et emballages papiers-carton": [
+      "autres_emballages_menagers",
+      "emballage_carton",
+      "papiers_graphiques"
+    ],
+    "papiers graphiques, emballages papiers-carton et briques alimentaires": [
+      "autres_emballages_menagers",
+      "emballage_carton",
+      "papiers_graphiques"
+    ],
     "plâtre": "Plâtre - PMCB (produits et matériaux de construction du bâtiment)",
     "pmcb - bois": "Bois - PMCB (produits et matériaux de construction du bâtiment)",
     "pmcb - métal": "Métal - PMCB (produits et matériaux de construction du bâtiment)",


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [Importer le fichier v2 Citeo (incl. Fibreux)](https://www.notion.so/accelerateur-transition-ecologique-ademe/Importer-le-fichier-v2-Citeo-incl-Fibreux-1666523d57d780d1b16cffea591c3a0d?pvs=4)

Mini PR qui consiste uniquement à ajouter des produits possibles de la source CITEO dans la table de mapping des produits
-> On pourrait réfechir à rendre administrable ce mapping de produit 🤔 

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [ ] Bug fix
- [x] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
