### PR TITLE
Gestion d'une erreur en cas de description mauvais état non renseignée

### DIFF
--- a/qfdmd/models.py
+++ b/qfdmd/models.py
@@ -208,7 +208,7 @@ class Synonyme(AbstractBaseProduit):
 
         try:
             return self.produit.get_etats_descriptions()[0]
-        except KeyError:
+        except (KeyError, TypeError):
             return ""
 
     def get_absolute_url(self) -> str:


### PR DESCRIPTION
# Description succincte du problème résolu

Une 500 se produit en preprod lorsqu'une description pour une produit en mauvais état n'est pas renseignée. 

On a modifié la manière dont on récupère cette valeur récemment et du coup on a besoin d'échouer silencieusement lorsqu'on accède à la valeur bon état / mauvais état calculée, en effet on suit désormais la logique suivante :
- On tente d'accéder à la valeur sur le **synonyme**, si elle est définie on l'affiche
- On tente d'accéder à la valeur sur le **produit**, si elle est définie on l'affiche 
- On tente d'accéder à la **valeur calculée** depuis le champ description, séparé sur le tag `<b>Bon état</b>` et `<b>Mauvais état</b>`

À noter : cette approche sera dépréciée lorsque toutes les fiches produits seront contribuées. 

**Type de changement** :

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

- Afficher une fiche produit 
- Elle ne doit pas retourner une 500 