### PR TITLE
Mise à jour calcul posthog + correctif iframe

### DIFF
--- a/static/to_compile/js/controllers/assistant/analytics.ts
+++ b/static/to_compile/js/controllers/assistant/analytics.ts
@@ -2,10 +2,9 @@ import { Controller } from "@hotwired/stimulus"
 import { InteractionType as PosthogUIInteractionType, PosthogEventType } from "./types"
 import posthog from "posthog-js"
 
-type PersonProperties=  {
+type PersonProperties = {
   iframe: boolean
   iframeReferrer?: string
-
 }
 
 export default class extends Controller<HTMLElement> {

--- a/templates/components/search/_search_result.html
+++ b/templates/components/search/_search_result.html
@@ -1,6 +1,6 @@
 <a
     href="{% url 'qfdmd:synonyme-detail' slug=result.slug %}"
-    target="_top"
+    target="_self"
     style="background-image: none;"
     class="
     focus:!no-underline


### PR DESCRIPTION
# Description succincte du problème résolu

Deux pour le prix d'un 
- [Correctifs sur le calcul du score PostHog](https://www.notion.so/accelerateur-transition-ecologique-ademe/AST-1-Mise-en-place-du-tracking-nouvelle-archi-assistant-sur-Posthog-et-Matomo-1266523d57d780399115d465f94dfa88?pvs=4)
- Fusion de deux événements `$set` en un seul pour alléger le billing PostHog
- Suppression d'un `target="_top"` remplacé par un `"_self"` pour éviter que le clic sur un résultat de recherche fasse sortir de l'iframe 

**Type de changement** :

- [x] Bug fix
- [x] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

- Aller sur /dechet
- Vérifier dans [PostHog](https://eu.posthog.com/project/43401/activity/explore#q=%7B%22kind%22%3A%22DataTableNode%22%2C%22full%22%3Atrue%2C%22source%22%3A%7B%22kind%22%3A%22EventsQuery%22%2C%22select%22%3A%5B%22*%22%2C%22event%22%2C%22person%22%2C%22coalesce(properties.%24current_url%2C%20properties.%24screen_name)%20--%20Url%20%2F%20Screen%22%2C%22properties.%24lib%22%2C%22timestamp%22%2C%22person.properties.conversionScore%22%2C%22person.properties.iframe%22%5D%2C%22orderBy%22%3A%5B%22timestamp%20DESC%22%5D%2C%22after%22%3A%22-24h%22%7D%2C%22propertiesViaUrl%22%3Atrue%2C%22showSavedQueries%22%3Atrue%2C%22showPersistentColumnConfigurator%22%3Atrue%7D) que le `conversionScore` vaut 0 
- Aller sur une fiche déchet 
- Vérifier qu'il vaut désormais 1 
- Vérifier qu'on a bien un seul event $set par pageView