### PR TITLE
Ajout des commandes run-all et db-restore dans le makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ extract-dsfr:
 	$(PYTHON) ./dsfr_hacks/extract_used_colors.py
 	$(PYTHON) ./dsfr_hacks/extract_used_icons.py
 
-# RESTAURE DB LOCALLY
+# RESTORE DB LOCALLY
 .PHONY: db-restore
 db-restore:
 	mkdir -p tmpbackup

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ run-django:
 run-all:
 	docker compose --profile airflow up -d
 	rm -rf .parcel-cache
-	.venv/bin/python manage.py runserver 0.0.0.0:8000
+	$(DJANGO_ADMIN) runserver 0.0.0.0:8000
 	npm run watch
 
 # Local django operations

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ endif
 PYTHON := .venv/bin/python
 DJANGO_ADMIN := $(PYTHON) manage.py
 PYTEST := $(PYTHON) -m pytest
+DB_URL := postgres://qfdmo:qfdmo@localhost:6543/qfdmo # pragma: allowlist secret
 
 # Makefile config
 .PHONY: check
@@ -61,6 +62,12 @@ run-airflow:
 run-django:
 	rm -rf .parcel-cache
 	honcho start -f Procfile.dev
+
+run-all:
+	docker compose --profile airflow up -d
+	rm -rf .parcel-cache
+	.venv/bin/python manage.py runserver 0.0.0.0:8000
+	npm run watch
 
 # Local django operations
 .PHONY: migrate
@@ -139,3 +146,18 @@ extract-dsfr:
 	$(PYTHON) ./dsfr_hacks/extract_dsfr_colors.py
 	$(PYTHON) ./dsfr_hacks/extract_used_colors.py
 	$(PYTHON) ./dsfr_hacks/extract_used_icons.py
+
+# RESTAURE DB LOCALLY
+.PHONY: db-restore
+db-restore:
+	mkdir -p tmpbackup
+	scalingo --app quefairedemesobjets --addon postgresql backups-download --output tmpbackup/backup.tar.gz
+	tar xfz tmpbackup/backup.tar.gz --directory tmpbackup
+	@DUMP_FILE=$$(find tmpbackup -type f -name "*.pgsql" -print -quit); \
+	for table in $$(psql "$(DB_URL)" -t -c "SELECT tablename FROM pg_tables WHERE schemaname='public'"); do \
+	    psql "$(DB_URL)" -c "DROP TABLE IF EXISTS $$table CASCADE"; \
+	done || true
+	@DUMP_FILE=$$(find tmpbackup -type f -name "*.pgsql" -print -quit); \
+	pg_restore -d "$(DB_URL)" --clean --no-acl --no-owner --no-privileges "$$DUMP_FILE" || true
+	rm -rf tmpbackup
+	$(DJANGO_ADMIN) migrate


### PR DESCRIPTION
# Description succincte du problème résolu

2 commandes:

- run-all : lance airflow et l'interface
- db-restore : télécharge la base de prod, la restaure en local et joue les migrations

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [ ] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [x] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
