### PR TITLE
Correction de la commande make db-restore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ endif
 PYTHON := .venv/bin/python
 DJANGO_ADMIN := $(PYTHON) manage.py
 PYTEST := $(PYTHON) -m pytest
-DB_URL := postgres://qfdmo:qfdmo@localhost:6543/qfdmo # pragma: allowlist secret
+DB_URL := postgres://qfdmo:qfdmo@localhost:6543/qfdmo# pragma: allowlist secret
 
 # Makefile config
 .PHONY: check


### PR DESCRIPTION
# Description succincte du problème résolu

Mini correction car la commande db-restore ne fonctionne pas à cause d'un espace à la fin de DB_URL

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
