### PR TITLE
Masquer le bouton formulaire de contact en mode iframe 

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -22,6 +22,7 @@ def content(request):
 def assistant(request) -> dict:
     return {
         "assistant": {
+            "is_iframe": "iframe" in request.GET,
             "is_home": request.path == reverse("qfdmd:home"),
             "POSTHOG_KEY": settings.ASSISTANT["POSTHOG_KEY"],
             "MATOMO_ID": settings.ASSISTANT["MATOMO_ID"],

--- a/templates/components/sidebar/sidebar.html
+++ b/templates/components/sidebar/sidebar.html
@@ -11,6 +11,8 @@
     >
         {% include "./embed/action.html" %}
         {% include "./share/action.html" %}
-        {% include "./email/action.html" %}
+        {% if not assistant.is_iframe %}
+            {% include "./email/action.html" %}
+        {% endif %}
     </nav>
 </aside>


### PR DESCRIPTION
# En mode iframe on masque le bouton formulaire de contact 

https://www.notion.so/accelerateur-transition-ecologique-ademe/masquer-le-bouton-nous-contacter-en-mode-iframe-1596523d57d780fca8fbfe37ea64b878?pvs=4

Tout est dans le titre :) 

- Ajout d'une variable basée sur la requête dans le context processor 
- Suppression dans le dom du bouton 

**Type de changement** :

- [ ] Bug fix
- [x] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

- Charger `/dechet/?iframe`
- Vérifier que le bouton du formulaire de contact est absent 
<img width="1075" alt="image" src="https://github.com/user-attachments/assets/83b54015-da89-4c9d-b019-7e879fd021bf" />
