### PR TITLE
Ajout de la sous catégorie d'objet aux paramètres d'url de la carte

### DIFF
--- a/qfdmd/models.py
+++ b/qfdmd/models.py
@@ -98,6 +98,7 @@ class Produit(AbstractBaseProduit):
             "first_dir": "jai",
             "limit": 25,
             "sc_id": sous_categorie.id,
+            "sous_categorie_objet": sous_categorie.libelle,
         }
 
     def get_url_carte(self, actions=None):


### PR DESCRIPTION
# Description succincte du problème résolu

Cf https://www.notion.so/accelerateur-transition-ecologique-ademe/Si-mauvais-tat-bon-tat-la-carte-n-est-pas-filtr-e-sur-la-typologie-d-objet-17b6523d57d7800e94d7c701b33e33ab?pvs=4 

Permet de passer la sous catégorie à la vue adresse 

Note : un refacto de cette vue est prévue prochainement qui permettra de passer plus proprement ces ids de catégorie 

**Type de changement** :

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
