### PR TITLE
Correction des liens affichés dans les Inline de l'administration

### DIFF
--- a/qfdmo/admin/acteur.py
+++ b/qfdmo/admin/acteur.py
@@ -3,6 +3,7 @@ from typing import Any, List
 import orjson
 from django import forms
 from django.conf import settings
+from django.contrib.admin.utils import quote
 from django.contrib.gis import admin
 from django.contrib.gis.forms.fields import PointField
 from django.contrib.gis.geos import Point
@@ -318,8 +319,10 @@ class RevisionActeurChildInline(NotEditableInlineMixin, admin.TabularInline):
         if obj.identifiant_unique:
             return format_html(
                 '<a href="{}">{} ({})</a>',
+                # Comme dans le code de django : https://github.com/django/django/blob/6cfe00ee438111af38f1e414bd01976e23b39715/django/contrib/admin/models.py#L243
                 reverse(
-                    "admin:qfdmo_revisionacteur_change", args=[obj.identifiant_unique]
+                    "admin:qfdmo_revisionacteur_change",
+                    args=[quote(obj.identifiant_unique)],
                 ),
                 obj.nom,
                 obj.identifiant_unique,


### PR DESCRIPTION
# Description succincte du problème résolu

Dans l'admin / revision_acteur, quand on visualise un parent si un enfant à les caractères "_40" dans l'url, alors ils sont intérprétés et le lien est cassé, il manquait un `quote` du paramètre `identifiant_unique` comportement copié de django lui-même. cf. https://github.com/django/django/blob/6cfe00ee438111af38f1e414bd01976e23b39715/django/contrib/admin/models.py#L243

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
