### PR TITLE
taches de déduplication en ligne et renommage des taches

### DIFF
--- a/dags/compute_acteurs/tasks/airflow_logic/__init__.py
+++ b/dags/compute_acteurs/tasks/airflow_logic/__init__.py
@@ -1,9 +1,9 @@
-from .apply_corrections_acteur_task import *  # noqa
-from .compute_parent_ps_task import *  # noqa
+from .compute_acteur_services_task import *  # noqa
+from .compute_acteur_task import *  # noqa
+from .compute_labels_task import *  # noqa
 from .compute_ps_task import *  # noqa
 from .db_data_write_task import *  # noqa
 from .deduplicate_acteur_services_task import *  # noqa
 from .deduplicate_acteur_sources_task import *  # noqa
 from .deduplicate_labels_task import *  # noqa
-from .merge_acteur_services_task import *  # noqa
-from .merge_labels_task import *  # noqa
+from .deduplicate_propositionservices_task import *  # noqa

--- a/dags/compute_acteurs/tasks/airflow_logic/compute_acteur_services_task.py
+++ b/dags/compute_acteurs/tasks/airflow_logic/compute_acteur_services_task.py
@@ -2,21 +2,21 @@ import logging
 
 from airflow import DAG
 from airflow.operators.python import PythonOperator
-from compute_acteurs.tasks.business_logic import merge_acteur_services
+from compute_acteurs.tasks.business_logic import compute_acteur_services
 from utils import logging_utils as log
 
 logger = logging.getLogger(__name__)
 
 
-def merge_acteur_services_task(dag: DAG) -> PythonOperator:
+def compute_acteur_services_task(dag: DAG) -> PythonOperator:
     return PythonOperator(
-        task_id="merge_acteur_services",
-        python_callable=merge_acteur_services_wrapper,
+        task_id="compute_acteur_services",
+        python_callable=compute_acteur_services_wrapper,
         dag=dag,
     )
 
 
-def merge_acteur_services_wrapper(**kwargs):
+def compute_acteur_services_wrapper(**kwargs):
     df_acteur_acteur_services = kwargs["ti"].xcom_pull(
         task_ids="load_acteur_acteur_services"
     )
@@ -29,7 +29,7 @@ def merge_acteur_services_wrapper(**kwargs):
     log.preview("df_revisionacteur_acteur_services", df_revisionacteur_acteur_services)
     log.preview("df_revisionacteur", df_revisionacteur)
 
-    return merge_acteur_services(
+    return compute_acteur_services(
         df_acteur_acteur_services=df_acteur_acteur_services,
         df_revisionacteur_acteur_services=df_revisionacteur_acteur_services,
         df_revisionacteur=df_revisionacteur,

--- a/dags/compute_acteurs/tasks/airflow_logic/compute_acteur_task.py
+++ b/dags/compute_acteurs/tasks/airflow_logic/compute_acteur_task.py
@@ -2,27 +2,25 @@ import logging
 
 from airflow import DAG
 from airflow.operators.python import PythonOperator
-from compute_acteurs.tasks.business_logic import apply_corrections_acteur
+from compute_acteurs.tasks.business_logic import compute_acteur
 from utils import logging_utils as log
 
 logger = logging.getLogger(__name__)
 
 
-def apply_corrections_acteur_task(dag: DAG) -> PythonOperator:
+def compute_acteur_task(dag: DAG) -> PythonOperator:
     return PythonOperator(
-        task_id="apply_corrections_acteur",
-        python_callable=apply_corrections_acteur_wrapper,
+        task_id="compute_acteur",
+        python_callable=compute_acteur_wrapper,
         dag=dag,
     )
 
 
-def apply_corrections_acteur_wrapper(**kwargs):
+def compute_acteur_wrapper(**kwargs):
     df_acteur = kwargs["ti"].xcom_pull(task_ids="load_acteur")
     df_revisionacteur = kwargs["ti"].xcom_pull(task_ids="load_revisionacteur")
 
     log.preview("df_acteur", df_acteur)
     log.preview("df_revisionacteur", df_revisionacteur)
 
-    return apply_corrections_acteur(
-        df_acteur=df_acteur, df_revisionacteur=df_revisionacteur
-    )
+    return compute_acteur(df_acteur=df_acteur, df_revisionacteur=df_revisionacteur)

--- a/dags/compute_acteurs/tasks/airflow_logic/compute_labels_task.py
+++ b/dags/compute_acteurs/tasks/airflow_logic/compute_labels_task.py
@@ -2,21 +2,21 @@ import logging
 
 from airflow import DAG
 from airflow.operators.python import PythonOperator
-from compute_acteurs.tasks.business_logic import merge_labels
+from compute_acteurs.tasks.business_logic import compute_labels
 from utils import logging_utils as log
 
 logger = logging.getLogger(__name__)
 
 
-def merge_labels_task(dag: DAG) -> PythonOperator:
+def compute_labels_task(dag: DAG) -> PythonOperator:
     return PythonOperator(
-        task_id="merge_labels",
-        python_callable=merge_labels_wrapper,
+        task_id="compute_labels",
+        python_callable=compute_labels_wrapper,
         dag=dag,
     )
 
 
-def merge_labels_wrapper(**kwargs):
+def compute_labels_wrapper(**kwargs):
     df_acteur_labels = kwargs["ti"].xcom_pull(task_ids="load_acteur_labels")
     df_revisionacteur_labels = kwargs["ti"].xcom_pull(
         task_ids="load_revisionacteur_labels"
@@ -27,7 +27,7 @@ def merge_labels_wrapper(**kwargs):
     log.preview("df_revisionacteur_labels", df_revisionacteur_labels)
     log.preview("df_revisionacteur", df_revisionacteur)
 
-    return merge_labels(
+    return compute_labels(
         df_acteur_labels=df_acteur_labels,
         df_revisionacteur_labels=df_revisionacteur_labels,
         df_revisionacteur=df_revisionacteur,

--- a/dags/compute_acteurs/tasks/airflow_logic/db_data_write_task.py
+++ b/dags/compute_acteurs/tasks/airflow_logic/db_data_write_task.py
@@ -17,12 +17,12 @@ def db_data_write_task(dag: DAG) -> PythonOperator:
 
 
 def db_data_write_wrapper(**kwargs):
-    df_acteur_merged = kwargs["ti"].xcom_pull(task_ids="apply_corrections_acteur")[
+    df_acteur_merged = kwargs["ti"].xcom_pull(task_ids="compute_acteur")[
         "df_acteur_merged"
     ]
     df_labels_updated = kwargs["ti"].xcom_pull(task_ids="deduplicate_labels")
     df_acteur_services_updated = kwargs["ti"].xcom_pull(
-        task_ids="deduplicate_acteur_serivces"
+        task_ids="deduplicate_acteur_services"
     )
     df_acteur_sources_updated = kwargs["ti"].xcom_pull(
         task_ids="deduplicate_acteur_sources"

--- a/dags/compute_acteurs/tasks/airflow_logic/deduplicate_acteur_services_task.py
+++ b/dags/compute_acteurs/tasks/airflow_logic/deduplicate_acteur_services_task.py
@@ -2,31 +2,29 @@ import logging
 
 from airflow import DAG
 from airflow.operators.python import PythonOperator
-from compute_acteurs.tasks.business_logic import deduplicate_acteur_serivces
+from compute_acteurs.tasks.business_logic import deduplicate_acteur_services
 from utils import logging_utils as log
 
 logger = logging.getLogger(__name__)
 
 
-def deduplicate_acteur_serivces_task(dag: DAG) -> PythonOperator:
+def deduplicate_acteur_services_task(dag: DAG) -> PythonOperator:
     return PythonOperator(
-        task_id="deduplicate_acteur_serivces",
-        python_callable=deduplicate_acteur_serivces_wrapper,
+        task_id="deduplicate_acteur_services",
+        python_callable=deduplicate_acteur_services_wrapper,
         dag=dag,
     )
 
 
-def deduplicate_acteur_serivces_wrapper(**kwargs):
+def deduplicate_acteur_services_wrapper(**kwargs):
 
-    df_children = kwargs["ti"].xcom_pull(task_ids="apply_corrections_acteur")[
-        "df_children"
-    ]
-    df_merge_acteur_services = kwargs["ti"].xcom_pull(task_ids="merge_acteur_services")
+    df_children = kwargs["ti"].xcom_pull(task_ids="compute_acteur")["df_children"]
+    df_acteur_services = kwargs["ti"].xcom_pull(task_ids="compute_acteur_services")
 
     log.preview("df_children", df_children)
-    log.preview("df_merged_relationship", df_merge_acteur_services)
+    log.preview("df_merged_relationship", df_acteur_services)
 
-    return deduplicate_acteur_serivces(
+    return deduplicate_acteur_services(
         df_children=df_children,
-        df_merge_acteur_services=df_merge_acteur_services,
+        df_acteur_services=df_acteur_services,
     )

--- a/dags/compute_acteurs/tasks/airflow_logic/deduplicate_acteur_sources_task.py
+++ b/dags/compute_acteurs/tasks/airflow_logic/deduplicate_acteur_sources_task.py
@@ -18,7 +18,7 @@ def deduplicate_acteur_sources_task(dag: DAG) -> PythonOperator:
 
 def deduplicate_acteur_sources_wrapper(**kwargs):
 
-    data_actors = kwargs["ti"].xcom_pull(task_ids="apply_corrections_acteur")
+    data_actors = kwargs["ti"].xcom_pull(task_ids="compute_acteur")
     df_children = data_actors["df_children"]
     df_acteur_merged = data_actors["df_acteur_merged"]
 

--- a/dags/compute_acteurs/tasks/airflow_logic/deduplicate_labels_task.py
+++ b/dags/compute_acteurs/tasks/airflow_logic/deduplicate_labels_task.py
@@ -18,15 +18,13 @@ def deduplicate_labels_task(dag: DAG) -> PythonOperator:
 
 def deduplicate_labels_wrapper(**kwargs):
 
-    df_children = kwargs["ti"].xcom_pull(task_ids="apply_corrections_acteur")[
-        "df_children"
-    ]
-    df_merge_labels = kwargs["ti"].xcom_pull(task_ids="merge_labels")
+    df_children = kwargs["ti"].xcom_pull(task_ids="compute_acteur")["df_children"]
+    df_labels = kwargs["ti"].xcom_pull(task_ids="compute_labels")
 
     log.preview("df_children", df_children)
-    log.preview("df_merged_relationship", df_merge_labels)
+    log.preview("df_merged_relationship", df_labels)
 
     return deduplicate_labels(
         df_children=df_children,
-        df_merge_labels=df_merge_labels,
+        df_labels=df_labels,
     )

--- a/dags/compute_acteurs/tasks/airflow_logic/deduplicate_propositionservices_task.py
+++ b/dags/compute_acteurs/tasks/airflow_logic/deduplicate_propositionservices_task.py
@@ -2,24 +2,22 @@ import logging
 
 from airflow import DAG
 from airflow.operators.python import PythonOperator
-from compute_acteurs.tasks.business_logic import compute_parent_ps
+from compute_acteurs.tasks.business_logic import deduplicate_propositionservices
 from utils import logging_utils as log
 
 logger = logging.getLogger(__name__)
 
 
-def compute_parent_ps_task(dag: DAG) -> PythonOperator:
+def deduplicate_propositionservices_task(dag: DAG) -> PythonOperator:
     return PythonOperator(
         task_id="deduplicate_propositionservices",
-        python_callable=compute_parent_ps_wrapper,
+        python_callable=deduplicate_propositionservices_wrapper,
         dag=dag,
     )
 
 
-def compute_parent_ps_wrapper(**kwargs):
-    df_children = kwargs["ti"].xcom_pull(task_ids="apply_corrections_acteur")[
-        "df_children"
-    ]
+def deduplicate_propositionservices_wrapper(**kwargs):
+    df_children = kwargs["ti"].xcom_pull(task_ids="compute_acteur")["df_children"]
     dfs_ps = kwargs["ti"].xcom_pull(task_ids="compute_ps")
     df_propositionservice_merged = dfs_ps["df_propositionservice_merged"]
     df_propositionservice_sous_categories_merged = dfs_ps[
@@ -33,7 +31,7 @@ def compute_parent_ps_wrapper(**kwargs):
         df_propositionservice_sous_categories_merged,
     )
 
-    return compute_parent_ps(
+    return deduplicate_propositionservices(
         df_children=df_children,
         df_ps=df_propositionservice_merged,
         df_ps_sscat=df_propositionservice_sous_categories_merged,

--- a/dags/compute_acteurs/tasks/business_logic/__init__.py
+++ b/dags/compute_acteurs/tasks/business_logic/__init__.py
@@ -1,9 +1,9 @@
-from .apply_corrections_acteur import *  # noqa
-from .compute_parent_ps import *  # noqa
+from .compute_acteur import *  # noqa
+from .compute_acteur_services import *  # noqa
+from .compute_labels import *  # noqa
 from .compute_ps import *  # noqa
 from .db_data_write import *  # noqa
 from .deduplicate_acteur_services import *  # noqa
 from .deduplicate_acteur_sources import *  # noqa
 from .deduplicate_labels import *  # noqa
-from .merge_acteur_services import *  # noqa
-from .merge_labels import *  # noqa
+from .deduplicate_propositionservices import *  # noqa

--- a/dags/compute_acteurs/tasks/business_logic/compute_acteur.py
+++ b/dags/compute_acteurs/tasks/business_logic/compute_acteur.py
@@ -2,7 +2,7 @@ import pandas as pd
 import shortuuid
 
 
-def apply_corrections_acteur(df_acteur: pd.DataFrame, df_revisionacteur: pd.DataFrame):
+def compute_acteur(df_acteur: pd.DataFrame, df_revisionacteur: pd.DataFrame):
 
     revisionacteur_parent_ids = df_revisionacteur["parent_id"].unique()
 

--- a/dags/compute_acteurs/tasks/business_logic/compute_acteur_services.py
+++ b/dags/compute_acteurs/tasks/business_logic/compute_acteur_services.py
@@ -4,14 +4,14 @@ from compute_acteurs.tasks.transform.merge_and_deduplicate import (
 )
 
 
-def merge_labels(
-    df_acteur_labels: pd.DataFrame,
-    df_revisionacteur_labels: pd.DataFrame,
+def compute_acteur_services(
+    df_acteur_acteur_services: pd.DataFrame,
+    df_revisionacteur_acteur_services: pd.DataFrame,
     df_revisionacteur: pd.DataFrame,
 ):
 
     return merge_acteurs_many2many_relationship(
-        df_link_with_acteur=df_acteur_labels,
-        df_link_with_revisionacteur=df_revisionacteur_labels,
+        df_link_with_acteur=df_acteur_acteur_services,
+        df_link_with_revisionacteur=df_revisionacteur_acteur_services,
         df_revisionacteur=df_revisionacteur,
     )

--- a/dags/compute_acteurs/tasks/business_logic/compute_labels.py
+++ b/dags/compute_acteurs/tasks/business_logic/compute_labels.py
@@ -4,14 +4,14 @@ from compute_acteurs.tasks.transform.merge_and_deduplicate import (
 )
 
 
-def merge_acteur_services(
-    df_acteur_acteur_services: pd.DataFrame,
-    df_revisionacteur_acteur_services: pd.DataFrame,
+def compute_labels(
+    df_acteur_labels: pd.DataFrame,
+    df_revisionacteur_labels: pd.DataFrame,
     df_revisionacteur: pd.DataFrame,
 ):
 
     return merge_acteurs_many2many_relationship(
-        df_link_with_acteur=df_acteur_acteur_services,
-        df_link_with_revisionacteur=df_revisionacteur_acteur_services,
+        df_link_with_acteur=df_acteur_labels,
+        df_link_with_revisionacteur=df_revisionacteur_labels,
         df_revisionacteur=df_revisionacteur,
     )

--- a/dags/compute_acteurs/tasks/business_logic/deduplicate_acteur_services.py
+++ b/dags/compute_acteurs/tasks/business_logic/deduplicate_acteur_services.py
@@ -4,12 +4,12 @@ from compute_acteurs.tasks.transform.merge_and_deduplicate import (
 )
 
 
-def deduplicate_acteur_serivces(
+def deduplicate_acteur_services(
     df_children: pd.DataFrame,
-    df_merge_acteur_services: pd.DataFrame,
+    df_acteur_services: pd.DataFrame,
 ):
     return deduplicate_acteurs_many2many_relationship(
         df_children,
-        df_merge_acteur_services,
+        df_acteur_services,
         "acteurservice_id",
     )

--- a/dags/compute_acteurs/tasks/business_logic/deduplicate_labels.py
+++ b/dags/compute_acteurs/tasks/business_logic/deduplicate_labels.py
@@ -6,10 +6,10 @@ from compute_acteurs.tasks.transform.merge_and_deduplicate import (
 
 def deduplicate_labels(
     df_children: pd.DataFrame,
-    df_merge_labels: pd.DataFrame,
+    df_labels: pd.DataFrame,
 ):
     return deduplicate_acteurs_many2many_relationship(
         df_children,
-        df_merge_labels,
+        df_labels,
         "labelqualite_id",
     )

--- a/dags/compute_acteurs/tasks/business_logic/deduplicate_propositionservices.py
+++ b/dags/compute_acteurs/tasks/business_logic/deduplicate_propositionservices.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 
-def compute_parent_ps(
+def deduplicate_propositionservices(
     df_children: pd.DataFrame,
     df_ps: pd.DataFrame,
     df_ps_sscat: pd.DataFrame,

--- a/dags_unit_tests/compute_acteurs/business_logic/test_apply_correction_acteur.py
+++ b/dags_unit_tests/compute_acteurs/business_logic/test_apply_correction_acteur.py
@@ -1,9 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
-from compute_acteurs.tasks.business_logic.apply_corrections_acteur import (
-    apply_corrections_acteur,
-)
+from compute_acteurs.tasks.business_logic.compute_acteur import compute_acteur
 
 
 class TestApplyCorrections:
@@ -32,10 +30,10 @@ class TestApplyCorrections:
             }
         )
 
-    def test_apply_corrections_acteur(self, df_load_acteur, df_load_revisionacteur):
+    def test_compute_acteur(self, df_load_acteur, df_load_revisionacteur):
 
         # Call the function with the mocked ti
-        result = apply_corrections_acteur(
+        result = compute_acteur(
             df_acteur=df_load_acteur, df_revisionacteur=df_load_revisionacteur
         )
 
@@ -88,11 +86,11 @@ class TestApplyCorrections:
             }
         )
 
-    def test_apply_corrections_acteur_children(
+    def test_compute_acteur_children(
         self, df_load_acteur_with_children, df_load_revisionacteur_with_children
     ):
         # Call the function with the mocked ti
-        result = apply_corrections_acteur(
+        result = compute_acteur(
             df_acteur=df_load_acteur_with_children,
             df_revisionacteur=df_load_revisionacteur_with_children,
         )

--- a/dags_unit_tests/compute_acteurs/business_logic/test_merge_acteur_services.py
+++ b/dags_unit_tests/compute_acteurs/business_logic/test_merge_acteur_services.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
-from compute_acteurs.tasks.business_logic.merge_acteur_services import (
-    merge_acteur_services,
+from compute_acteurs.tasks.business_logic.compute_acteur_services import (
+    compute_acteur_services,
 )
 
 
@@ -91,7 +91,7 @@ class TestMergeActeurServices:
             ),
         ],
     )
-    def test_merge_acteur_services(
+    def test_compute_acteur_services(
         self,
         load_acteur_acteur_services,
         load_revisionacteur_acteur_services,
@@ -99,7 +99,7 @@ class TestMergeActeurServices:
         expected,
     ):
 
-        result = merge_acteur_services(
+        result = compute_acteur_services(
             df_acteur_acteur_services=load_acteur_acteur_services,
             df_revisionacteur_acteur_services=load_revisionacteur_acteur_services,
             df_revisionacteur=load_revisionacteur,

--- a/dags_unit_tests/compute_acteurs/business_logic/test_merge_labels.py
+++ b/dags_unit_tests/compute_acteurs/business_logic/test_merge_labels.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import pytest
-from compute_acteurs.tasks.business_logic.merge_labels import merge_labels
+from compute_acteurs.tasks.business_logic.compute_labels import compute_labels
 
 
 class TestMergeLabels:
@@ -87,7 +87,7 @@ class TestMergeLabels:
             ),
         ],
     )
-    def test_merge_labels(
+    def test_compute_labels(
         self,
         load_acteur_labels,
         load_revisionacteur_labels,
@@ -95,7 +95,7 @@ class TestMergeLabels:
         expected,
     ):
 
-        result = merge_labels(
+        result = compute_labels(
             df_acteur_labels=load_acteur_labels,
             df_revisionacteur_labels=load_revisionacteur_labels,
             df_revisionacteur=load_revisionacteur,


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [[Airflow] Résoudre les Fails des sous-tâches du DAG de synchro vers DisplayedActeurs](https://www.notion.so/accelerateur-transition-ecologique-ademe/Airflow-R-soudre-les-Fails-des-sous-t-ches-du-DAG-de-synchro-vers-DisplayedActeurs-1826523d57d780f38e0cd8a8f0c65c51?pvs=4)

En attendant une résolution en profondeur, cette PR fait en sorte d'executer les taches de déduplications les unes après les autres pour éviter que le scheduler ne tombe

![CleanShot 2025-01-21 at 11 43 59@2x](https://github.com/user-attachments/assets/f249af55-7b22-4e89-9601-d3778c9e368c)

On en profite pour unifier les noms des tâches de ce DAG

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [ ] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [x] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
