### PR TITLE
Correction du DAG SINOE, l'année à observé est maintenant 2025

### DIFF
--- a/dags/sources/dags/source_sinoe.py
+++ b/dags/sources/dags/source_sinoe.py
@@ -17,7 +17,7 @@ with DAG(
     params={
         "endpoint": (
             "https://data.ademe.fr/data-fair/api/v1/datasets/"
-            "sinoe-(r)-annuaire-des-decheteries-dma/lines?size=10000&q_mode=simple&ANNEE_eq=2024"
+            "sinoe-(r)-annuaire-des-decheteries-dma/lines?size=10000&q_mode=simple&ANNEE_eq=2025"
         ),
         "normalization_rules": [
             # 1. Renommage des colonnes

--- a/dags/sources/tasks/business_logic/source_data_normalize.py
+++ b/dags/sources/tasks/business_logic/source_data_normalize.py
@@ -237,7 +237,7 @@ def df_normalize_sinoe(
 ) -> pd.DataFrame:
 
     # DOUBLONS: extra sécurité: même si on ne devrait pas obtenir
-    # de doublon grâce à l'API (q_mode=simple&ANNEE_eq=2024)
+    # de doublon grâce à l'API (q_mode=simple&ANNEE_eq=2025)
     # on vérifie qu'on a qu'une année
     log.preview("ANNEE uniques", df["ANNEE"].unique().tolist())
     if df["ANNEE"].nunique() != 1:


### PR DESCRIPTION
# Description succincte du problème résolu

Pourquoi ?
le DAG SINOE finit en erreur car l'année 2024 n'est plus disponible et a été remplacé par l'année 2025
Comment ?
Remplacement de 2024 par 2025

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
