### PR TITLE
Ajout de l'application data dans le docker AIRFLOW - Scheduler

### DIFF
--- a/airflow-scheduler.Dockerfile
+++ b/airflow-scheduler.Dockerfile
@@ -40,6 +40,7 @@ COPY sync_dags.sh /opt/airflow/sync_dags.sh
 COPY ./core/ /opt/airflow/core/
 COPY ./qfdmo/ /opt/airflow/qfdmo/
 COPY ./qfdmd/ /opt/airflow/qfdmd/
+COPY ./data/ /opt/airflow/data/
 COPY ./dsfr_hacks/ /opt/airflow/dsfr_hacks/
 
 # Classique Airflow


### PR DESCRIPTION
# Description succincte du problème résolu

Pourquoi ?
On a une erreur sur le cluster Airflow qui n'arrive pas à charger l'application data de django en preprod
Comment ?
Copie de l'application `data` dans le docker `airflow-scheduler`

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
