### PR TITLE
Ne pas prendre en compte les acteurs non actif dans displayedacteur

### DIFF
--- a/dags/compute_acteurs/tasks/business_logic/compute_acteur.py
+++ b/dags/compute_acteurs/tasks/business_logic/compute_acteur.py
@@ -25,18 +25,32 @@ def compute_acteur(df_acteur: pd.DataFrame, df_revisionacteur: pd.DataFrame):
         .query("parent_id.notnull()")
         .drop_duplicates(subset=["parent_id", "identifiant_unique"])
     )
+
+    all_parent_ids = set(df_acteur_merged["parent_id"].tolist())
     df_children = df_children[df_children["statut"] == constants.ACTEUR_ACTIF]
+    active_parent_ids = set(df_acteur_merged["parent_id"].tolist())
+    parent_without_children_ids = all_parent_ids - active_parent_ids
+
+    # Get children
     df_children = pd.merge(
         df_children[["parent_id", "identifiant_unique"]],
         df_acteur_merged[["identifiant_unique", "source_id"]],
         on="identifiant_unique",
     )
 
+    # Remove children from acteur_merged
     df_acteur_merged = df_acteur_merged[
         ~df_acteur_merged["identifiant_unique"].isin(
             df_children["identifiant_unique"].tolist()
         )
     ].copy()
+
+    # Remove parent without children
+    df_acteur_merged = df_acteur_merged[
+        ~df_acteur_merged["identifiant_unique"].isin(parent_without_children_ids)
+    ]
+
+    # Remove inactive acteur
     df_acteur_merged = df_acteur_merged[
         df_acteur_merged["statut"] == constants.ACTEUR_ACTIF
     ]

--- a/dags/compute_acteurs/tasks/business_logic/compute_acteur.py
+++ b/dags/compute_acteurs/tasks/business_logic/compute_acteur.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import shortuuid
+from sources.config import shared_constants as constants
 
 
 def compute_acteur(df_acteur: pd.DataFrame, df_revisionacteur: pd.DataFrame):
@@ -24,16 +25,21 @@ def compute_acteur(df_acteur: pd.DataFrame, df_revisionacteur: pd.DataFrame):
         .query("parent_id.notnull()")
         .drop_duplicates(subset=["parent_id", "identifiant_unique"])
     )
+    df_children = df_children[df_children["statut"] == constants.ACTEUR_ACTIF]
     df_children = pd.merge(
         df_children[["parent_id", "identifiant_unique"]],
         df_acteur_merged[["identifiant_unique", "source_id"]],
         on="identifiant_unique",
     )
+
     df_acteur_merged = df_acteur_merged[
         ~df_acteur_merged["identifiant_unique"].isin(
             df_children["identifiant_unique"].tolist()
         )
     ].copy()
+    df_acteur_merged = df_acteur_merged[
+        df_acteur_merged["statut"] == constants.ACTEUR_ACTIF
+    ]
 
     # Add a new column uuid to make the displayedacteur id without source name in id
     df_acteur_merged["uuid"] = df_acteur_merged["identifiant_unique"].apply(

--- a/dags/compute_acteurs/tasks/business_logic/db_data_write.py
+++ b/dags/compute_acteurs/tasks/business_logic/db_data_write.py
@@ -3,17 +3,44 @@ from shared.tasks.database_logic.db_manager import PostgresConnectionManager
 
 
 def db_data_write(
-    df_acteur_merged=pd.DataFrame,
-    df_labels_updated=pd.DataFrame,
-    df_acteur_services_updated=pd.DataFrame,
-    df_acteur_sources_updated=pd.DataFrame,
-    df_propositionservice_merged=pd.DataFrame,
-    df_propositionservice_sous_categories_merged=pd.DataFrame,
+    df_acteur_merged: pd.DataFrame,
+    df_labels_updated: pd.DataFrame,
+    df_acteur_services_updated: pd.DataFrame,
+    df_acteur_sources_updated: pd.DataFrame,
+    df_propositionservice_merged: pd.DataFrame,
+    df_propositionservice_sous_categories_merged: pd.DataFrame,
 ):
 
-    df_propositionservice_sous_categories_merged.rename(
-        columns={"propositionservice_id": "displayedpropositionservice_id"},
-        inplace=True,
+    df_labels_updated = df_labels_updated[
+        df_labels_updated["displayedacteur_id"].isin(
+            df_acteur_merged["identifiant_unique"]
+        )
+    ]
+
+    df_acteur_services_updated = df_acteur_services_updated[
+        df_acteur_services_updated["displayedacteur_id"].isin(
+            df_acteur_merged["identifiant_unique"]
+        )
+    ]
+
+    df_acteur_sources_updated = df_acteur_sources_updated[
+        df_acteur_sources_updated["displayedacteur_id"].isin(
+            df_acteur_merged["identifiant_unique"]
+        )
+    ]
+
+    df_propositionservice_merged = df_propositionservice_merged[
+        df_propositionservice_merged["acteur_id"].isin(
+            df_acteur_merged["identifiant_unique"]
+        )
+    ]
+
+    df_propositionservice_sous_categories_merged = (
+        df_propositionservice_sous_categories_merged[
+            df_propositionservice_sous_categories_merged[
+                "displayedpropositionservice_id"
+            ].isin(df_propositionservice_merged["id"])
+        ]
     )
 
     engine = PostgresConnectionManager().engine

--- a/dags/compute_acteurs/tasks/business_logic/deduplicate_propositionservices.py
+++ b/dags/compute_acteurs/tasks/business_logic/deduplicate_propositionservices.py
@@ -49,6 +49,10 @@ def deduplicate_propositionservices(
         [df_ps_sscat, df_parents_ps_sscat],
         ignore_index=True,
     )
+    df_ps_sscat.rename(
+        columns={"propositionservice_id": "displayedpropositionservice_id"},
+        inplace=True,
+    )
 
     # suppression des ps des enfants
     df_ps = df_ps[~df_ps["acteur_id"].isin(children_ids)]

--- a/dags_unit_tests/compute_acteurs/business_logic/test_apply_correction_acteur.py
+++ b/dags_unit_tests/compute_acteurs/business_logic/test_apply_correction_acteur.py
@@ -15,6 +15,7 @@ class TestApplyCorrections:
                 "cree_le": ["2022-01-01", "2022-01-02"],
                 "parent_id": [None, None],
                 "source_id": [1, 2],
+                "statut": ["ACTIF", "ACTIF"],
             }
         )
 
@@ -27,6 +28,7 @@ class TestApplyCorrections:
                 "cree_le": ["2022-01-03"],
                 "parent_id": [None],
                 "source_id": [1],
+                "statut": ["ACTIF"],
             }
         )
 
@@ -45,6 +47,7 @@ class TestApplyCorrections:
                 "cree_le": ["2022-01-01", "2022-01-02"],
                 "parent_id": [None, None],
                 "source_id": [1, 2],
+                "statut": ["ACTIF", "ACTIF"],
                 "uuid": ["Hogy2rqwtvgMUctiqUyYmH", "AS5wKPytvs9VjWEFQdqTwK"],
             }
         )
@@ -71,6 +74,7 @@ class TestApplyCorrections:
                 "cree_le": ["2022-01-01", "2022-01-02"],
                 "parent_id": [None, None],
                 "source_id": [1, 2],
+                "statut": ["ACTIF", "ACTIF"],
             }
         )
 
@@ -83,6 +87,7 @@ class TestApplyCorrections:
                 "cree_le": ["2022-01-03", "2022-01-03", "2022-01-03"],
                 "parent_id": ["actor3", "actor3", None],
                 "source_id": [1, 2, None],
+                "statut": ["ACTIF", "ACTIF", "ACTIF"],
             }
         )
 
@@ -103,6 +108,7 @@ class TestApplyCorrections:
                 "cree_le": ["2022-01-03"],
                 "parent_id": [None],
                 "source_id": [np.nan],
+                "statut": ["ACTIF"],
                 "uuid": ["Ad4fYCpSxc7rpzNvK8wCYr"],
             }
         )


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [⚠️Des fiches-acteurs INACTIF (ou Clusterisés) sont indexés sur Google](https://www.notion.so/accelerateur-transition-ecologique-ademe/Des-fiches-acteurs-INACTIF-ou-Clusteris-s-sont-index-s-sur-Google-1516523d57d78022bd99cb9fc0e06ce4?pvs=4)

Lors du calcul des acteurs à afficher, on ne prend que les acteurs actifs
Ainsi les acteurs supprimé ou inactif n'ont plus de fiches, elle ne seront pas disponible pour l'indexation
Les enfants inactif ne participent plus à l'affichage de leur parent

## Comment ?

Filtrer les acteurs non actif
Filtrer les models liés au acteur non actif
Filtrer les parents sans acteurs actif avant d'enregistrer dans displayedacteur

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
