### PR TITLE
Déplacement de la documentation relative à l'utilisation du français et de l'anglais

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,34 +450,6 @@ flowchart TB
     PropositionService --> DisplayedPropositionService
 ```
 
-## Conventions de code - Utilisation des langues françaises et anglaises
-
-Nous suivons les règles et standards de l'industrie que nous contrôlons à chaque commit et Pull Request grâce à des outils tel que `ruff` ou `eslint`.
-
-Cependant, ce projet est développé et propulsé par l'État français et doit être utilisable et administrable simplement par le plus grand nombre. Nous appliquons donc une règle spécifique quant à l'utilisation de la langue française versus la langue anglaise, nous avons donc défini les cas d'utilisation de ces 2 langues.
-
-### En Français
-
-A l'attention des administrés, administrations, administrateurs, et l'équipe Longue vie aux objets
-
-- Git/Github Les commits, les Pull Request
-- La documentation dans les markdowns
-- Les noms et les champs des tables en base de données
-
-### En Anglais
-
-Dans le code, à l'attention des équipes techniques
-
-- les fonctions
-- les noms de variables
-- les commentaires dans le code
-
-### Effets de bord acceptés
-
-Certaines variables combinant un nom d'objet et un suffixe ou préfixe peuvent être en franglais
-
-Ex :  `acteur_by_id`
-
 ## Data platform
 
 Longue vie aux objets est aussi une `data platform` dont la documentation est dans [README.airflow.md](./README.airflow.md)

--- a/docs/reference/902-utilisation-du-francais-et-de-l-anglais.md
+++ b/docs/reference/902-utilisation-du-francais-et-de-l-anglais.md
@@ -1,0 +1,28 @@
+# Conventions de code - Utilisation des langues françaises et anglaises
+
+Nous suivons les règles et standards de l'industrie que nous contrôlons à chaque commit et Pull Request grâce à des outils tel que `ruff` ou `eslint`.
+
+Cependant, ce projet est développé et propulsé par l'État français et doit être utilisable et administrable simplement par le plus grand nombre. Nous appliquons donc une règle spécifique quant à l'utilisation de la langue française versus la langue anglaise, nous avons donc défini les cas d'utilisation de ces 2 langues.
+
+## En Français
+
+A l'attention des administrés, administrations, administrateurs, et l'équipe Longue vie aux objets
+
+- Git/Github Les commits, les Pull Request
+- La documentation dans les markdowns
+- Les noms et les champs des tables en base de données
+
+## En Anglais
+
+Dans le code, à l'attention des équipes techniques
+
+- les fonctions
+- les noms de variables
+- les messages d'erreur des exceptions
+- les commentaires dans le code
+
+## Effets de bord acceptés
+
+Certaines variables combinant un nom d'objet et un suffixe ou préfixe peuvent être en franglais
+
+Ex :  `acteur_by_id`

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -8,4 +8,5 @@
 301-db-guidelines.md
 302-organisations-des-fichiers-data.md
 901-documentation-technique.md
+902-utilisation-du-francais-et-de-l-anglais.md
 ```


### PR DESCRIPTION
# Description succincte du problème résolu

Juste déplacer la documentation, ajouter le cas du message des exception

J'ai tester de faire cette PR à partir de l'interface github :)

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [ ] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [x] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
