### PR TITLE
cluster acteurs: ajout parents acteur types

### DIFF
--- a/dags/cluster/tasks/business_logic/cluster_acteurs_selection_acteur_type_parents.py
+++ b/dags/cluster/tasks/business_logic/cluster_acteurs_selection_acteur_type_parents.py
@@ -1,0 +1,34 @@
+import pandas as pd
+from utils.django import django_model_queryset_to_df, django_setup_full
+
+django_setup_full()
+from qfdmo.models import ActeurType, DisplayedActeur  # noqa: E402
+from qfdmo.models.acteur import ActeurStatus  # noqa: E402
+
+
+def cluster_acteurs_selection_acteur_type_parents(
+    acteur_type_ids: list[int],
+    fields: list[str],
+) -> pd.DataFrame:
+    """Sélectionne tous les parents des acteurs types donnés,
+    pour pouvoir notamment permettre de clusteriser avec
+    ces parents existant indépendemment des critères de sélection
+    des autres acteurs qu'on cherche à clusteriser (ex: si on cherche
+    à clusteriser les acteurs commerce de source A MAIS en essayant
+    de rattacher au maximum avec tous les parents commerce existants)"""
+
+    # Petite validation (on ne fait pas confiance à l'appelant)
+    ids_in_db = list(ActeurType.objects.values_list("id", flat=True))
+    ids_invalid = set(acteur_type_ids) - set(ids_in_db)
+    if ids_invalid:
+        raise ValueError(f"acteur_type_ids {ids_invalid} pas trouvés en DB")
+
+    # On récupère les parents des acteurs types donnés
+    # qui sont censés être des acteurs sans source
+    parents = DisplayedActeur.objects.filter(
+        acteur_type__id__in=acteur_type_ids,
+        statut=ActeurStatus.ACTIF,
+        source__id__isnull=True,
+    )
+
+    return django_model_queryset_to_df(parents, fields)

--- a/dags_unit_tests/cluster/tasks/business_logic/test_cluster_acteurs_selection_acteur_type_parents.py
+++ b/dags_unit_tests/cluster/tasks/business_logic/test_cluster_acteurs_selection_acteur_type_parents.py
@@ -1,0 +1,126 @@
+"""
+Fichier de test pour la fonction cluster_acteurs_selection_acteur_type_parents
+"""
+
+import pandas as pd
+import pytest
+from cluster.tasks.business_logic import cluster_acteurs_selection_acteur_type_parents
+
+from qfdmo.models import DisplayedActeur
+from unit_tests.qfdmo.acteur_factory import ActeurTypeFactory, SourceFactory
+
+
+@pytest.mark.django_db()
+class TestClusterActeursSelectionActeurTypeParents:
+
+    @pytest.fixture
+    def db_testdata_write(self) -> dict:
+        print("db_testdata_write")
+        """Création des donnéees de test en DB"""
+        data = {}
+        data["at1"] = ActeurTypeFactory(code="at1")
+        data["at2"] = ActeurTypeFactory(code="at2")
+        data["at3"] = ActeurTypeFactory(code="at3")
+        data["at4"] = ActeurTypeFactory(code="at4")
+        data["s1"] = SourceFactory(code="s1")
+        data["id_at1_parent"] = "10000000-0000-0000-0000-000000000000"
+        # On fait exprès d'utiliser des UUIDs partout, y compris
+        # pour les non-parents, pour démontrer que la requête ne
+        # se base pas sur l'anatomie des IDs
+        data["id_at2_pas_parent"] = "20000000-0000-0000-0000-000000000000"
+        data["id_at2_parent_a"] = "20000000-0000-0000-0000-00000000000a"
+        data["id_at2_parent_b"] = "20000000-0000-0000-0000-00000000000b"
+        data["id_at3_pas_parent"] = "30000000-0000-0000-0000-000000000000"
+        data["id_at4_parent"] = "40000000-0000-0000-0000-000000000000"
+        data["id_at4_parent_inactif"] = "40000000-0000-0000-0000-00000inactif"
+
+        # at1
+        # Parent MAIS d'un acteur type non sélectionné (at1)
+        DisplayedActeur.objects.create(
+            acteur_type=data["at1"],
+            identifiant_unique=data["id_at1_parent"],
+        )
+        # at2
+        # On test le cas où il y a plusieurs parents
+        # Pas parent car avec une source
+        DisplayedActeur.objects.create(
+            acteur_type=data["at2"],
+            identifiant_unique=data["id_at2_pas_parent"],
+            source=data["s1"],
+        )
+        # Parents car sans source
+        DisplayedActeur.objects.create(
+            acteur_type=data["at2"],
+            identifiant_unique=data["id_at2_parent_a"],
+        )
+        DisplayedActeur.objects.create(
+            acteur_type=data["at2"],
+            identifiant_unique=data["id_at2_parent_b"],
+        )
+        # at3
+        # Pour at3 on test le cas où il n'y a pas de parent
+        DisplayedActeur.objects.create(
+            acteur_type=data["at3"],
+            identifiant_unique=data["id_at3_pas_parent"],
+            source=data["s1"],
+        )
+        # at4
+        # On test le cas où il y a 1 parent
+        DisplayedActeur.objects.create(
+            acteur_type=data["at4"],
+            identifiant_unique=data["id_at4_parent"],
+        )
+        # On test le cas où il y a 1 parent mais inactif
+        DisplayedActeur.objects.create(
+            acteur_type=data["at4"],
+            identifiant_unique=data["id_at4_parent_inactif"],
+            statut="INACTIF",
+        )
+
+        return data
+
+    @pytest.fixture
+    def df_working(self, db_testdata_write) -> pd.DataFrame:
+        """On génère et retourne la df pour les tests"""
+        data = db_testdata_write
+        acteur_type_ids = [data["at2"].id, data["at3"].id, data["at4"].id]
+        fields = ["identifiant_unique", "statut", "latitude"]
+        return cluster_acteurs_selection_acteur_type_parents(
+            acteur_type_ids=acteur_type_ids,
+            fields=fields,
+        )
+
+    def test_df_shape(self, df_working):
+        # 3 parents (2 parents pour at2 + 0 pour at3 + 1 pour at4)
+        # 3 champs
+        assert df_working.shape == (3, 3)
+
+    def test_df_columns(self, df_working):
+        # Seules les colonnes demandées sont retournées
+        assert sorted(df_working.columns.tolist()) == sorted(
+            [
+                "identifiant_unique",
+                "statut",
+                "latitude",
+            ]
+        )
+
+    def test_parents_are_valid(self, df_working, db_testdata_write):
+        # Seuls les parents des acteurs types demandés
+        # sont retournés
+        data = db_testdata_write
+        assert sorted(df_working["identifiant_unique"].tolist()) == sorted(
+            [
+                data["id_at2_parent_a"],
+                data["id_at2_parent_b"],
+                data["id_at4_parent"],
+            ]
+        )
+
+    def test_parents_not_actif_excluded(self, df_working, db_testdata_write):
+        # Les parents inactifs ne sont pas retournés
+        data = db_testdata_write
+        assert (
+            data["id_at4_parent_inactif"]
+            not in df_working["identifiant_unique"].tolist()
+        )


### PR DESCRIPTION
# :family: CLUSTERING: toujours ajouter parents existants des acteurs types

Carte Notion : [CLUSTERING: toujours ajouter parents existants des acteurs types](https://www.notion.so/accelerateur-transition-ecologique-ademe/CLUSTERING-toujours-prendre-les-parents-existants-des-acteurs-types-1846523d57d78012ab64ed99c152693c?pvs=4)

 - **:bulb: quoi**: **toujours ajouter** les parents des acteurs types sélectionnés pour le clustering (paramètre `include_acteur_type_codes`), **indépendemment de tous les autres critères de sélection des acteurs**, les parents en question étant combiné aux acteurs sélectionnés
![image](https://github.com/user-attachments/assets/acd04144-13d3-4b61-a912-7d188775424c)
 - **:dart: pourquoi**:  **toujours tenter de clusteriser au mieux** par rapport aux parents existants même si le métier ne définit pas la pipeline explicitement pour cela
 - **:thinking: comment**: 
   - `cluster_acteurs_selection_acteur_type_parents`: nouvelle fonction qui vient chercher les parents qui correspondent à `include_acteur_type_codes` (mais sur la base des IDs déjà validés par la config)
   - **Tâche de sélection airflow**: on va venir enrichir les acteurs candidats au clustering avec les parents issus de la fonction ci-dessus

## :information_source: Exemple

Le métier essaye de clusteriser 1 nouvelle source (`include_source_codes=["mysource"]`) sur le type commerce (`include_acteur_type_codes=["commerce"]`) avec potentiellement tout un tas de critère de sélections (filtre sur le nom, champs siret non-vides etc...):
 - on sélectionne tous les parents de type `"commerce"`
    - *tous les autres critères de sélection (inclusion/exclusion) sont ignorés pour ces parents*
 - on ajoute ces parents aux acteurs candidats de la source  `"mysource"` de type `"commerce"`
 - au moment du clustering, l'algo essayera donc de rattacher les acteurs `"mysource"` aux parents existant

## :pray: Be honest with yourself

**On peut tout à fait considérer cette PR comme un bugfix d'une idiotie de ma part**: par définition un parent n’ayant pas de source, donc on ne pouvait jamais en l'état clusteriser avec les parents existants...

## :arrow_right: A faire (dans cette PR)

 - [ ] Inclure la logique de `cluster_acteurs_selection_acteur_type_parents` dans la tâche de sélection des acteurs