### PR TITLE
Forcer le domaine des vues de l'assistant

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -34,9 +34,9 @@ CMS_BASE_URL = decouple.config(
 DEBUG = decouple.config("DEBUG", default=False, cast=bool)
 STIMULUS_DEBUG = decouple.config("STIMULUS_DEBUG", default=False, cast=bool)
 POSTHOG_DEBUG = decouple.config("POSTHOG_DEBUG", default=False, cast=bool)
-ALLOWED_HOSTS = decouple.config("ALLOWED_HOSTS", default="localhost", cast=str).split(
-    ","
-)
+ALLOWED_HOSTS = decouple.config(
+    "ALLOWED_HOSTS", default="127.0.0.1,localhost", cast=str
+).split(",")
 
 # Application definition
 

--- a/qfdmd/views.py
+++ b/qfdmd/views.py
@@ -3,8 +3,8 @@ from typing import Any
 
 from django.conf import settings
 from django.http import HttpResponse
-from django.shortcuts import render
-from django.urls import reverse_lazy
+from django.shortcuts import redirect, render
+from django.urls import reverse, reverse_lazy
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_control
 from django.views.decorators.vary import vary_on_headers
@@ -80,6 +80,11 @@ class BaseView:
             iframe_script=generate_iframe_script(self.request),
         )
         return context
+
+    def dispatch(self, request, *args, **kwargs):
+        if request.META.get("HTTP_HOST") not in settings.ASSISTANT["HOSTS"]:
+            return redirect(reverse("home"))
+        return super().dispatch(request, *args, **kwargs)
 
 
 @method_decorator(cache_control(max_age=60 * 15), name="dispatch")

--- a/qfdmd/views.py
+++ b/qfdmd/views.py
@@ -69,6 +69,10 @@ class ContactFormView(FormView):
 
 class BaseView:
     """Base view that provides templates used on all pages.
+    It needs to be used by all views of the Assistant as it
+    provides some routing rules based on the domain and provide
+    some context to templates.
+
     TODO: this could be moved to a context processor"""
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:

--- a/qfdmd/views.py
+++ b/qfdmd/views.py
@@ -67,7 +67,7 @@ class ContactFormView(FormView):
         return super().form_valid(form)
 
 
-class BaseView:
+class AssistantBaseView:
     """Base view that provides templates used on all pages.
     It needs to be used by all views of the Assistant as it
     provides some routing rules based on the domain and provide
@@ -93,7 +93,7 @@ class BaseView:
 
 @method_decorator(cache_control(max_age=60 * 15), name="dispatch")
 @method_decorator(vary_on_headers("logged-in", "iframe"), name="dispatch")
-class HomeView(BaseView, ListView):
+class HomeView(AssistantBaseView, ListView):
     template_name = "qfdmd/home.html"
     model = Suggestion
 
@@ -116,9 +116,9 @@ class HomeView(BaseView, ListView):
         return context
 
 
-class SynonymeDetailView(BaseView, DetailView):
+class SynonymeDetailView(AssistantBaseView, DetailView):
     model = Synonyme
 
 
-class CMSPageDetailView(BaseView, DetailView):
+class CMSPageDetailView(AssistantBaseView, DetailView):
     model = CMSPage


### PR DESCRIPTION
# Forcer le domaine des vues de l'assistant

**Quoi** on s'assure que les vues de l'assistant ne sont visible que pour un domaine choisi 

**Pourquoi** : éviter par exemple que https://lvao.ademe.fr/dechet/chaussons ne soit utilisable à la place de https://quefairedemesdechets.ademe.fr

**Comment** lorsque la requête vers une vue de l'assistant ne provient pas d'un domaine connu, on redirige vers la home du projet.  
On applique cela à la classe parente de toutes les vues de l'assistant

