### PR TITLE
Résolution du problème de logs Airflow introuveable sur le stockage s3

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -160,7 +160,7 @@
         "filename": "docker-compose.yml",
         "hashed_secret": "3cf2012487b086bba2adb3386d69c2ab67a268b6",
         "is_verified": false,
-        "line_number": 49
+        "line_number": 53
       }
     ],
     "iframe_without_js.html": [
@@ -207,5 +207,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-28T14:22:35Z"
+  "generated_at": "2025-01-29T15:10:44Z"
 }

--- a/core/airflow_settings.py
+++ b/core/airflow_settings.py
@@ -1,0 +1,5 @@
+from core.settings import *  # noqa: F403
+
+# Inactive the logging when Django is use in Airflow because it's not compatible
+# with the Airflow logging system when saving logs to s3 storage
+LOGGING_CONFIG = None

--- a/dags/tools/dags/airflow_logs.py
+++ b/dags/tools/dags/airflow_logs.py
@@ -1,0 +1,45 @@
+import logging
+from datetime import datetime
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from utils.django import django_setup_full
+
+# Load Django environement to test Django and saving airflow logs to s3 storage are
+# compatible
+django_setup_full()
+
+logger = logging.getLogger(__name__)
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2024, 2, 7),
+    "email_on_failure": False,
+    "email_on_retry": False,
+}
+
+
+def test_django_and_logs():
+    logger.info("Test Django and Logs")
+
+
+with DAG(
+    dag_id="test_logs_pushed_to_s3",
+    dag_display_name="[TEST] Les logs Airflow sont enregistrés sur s3",
+    tags=["dev tools"],
+    default_args=default_args,
+    description=(
+        """
+Lancer le DAG et vérifier que les logs sont disponibles sur s3
+La mention `Found logs in s3` doit apparaitre dans les logs de la tâche
+"""
+    ),
+    schedule=None,
+) as dag:
+    PythonOperator(
+        task_id="test_django_and_logs",
+        python_callable=test_django_and_logs,
+        op_kwargs={"table_name": "qfdmo_acteur"},
+        dag=dag,
+    )

--- a/dags/utils/django.py
+++ b/dags/utils/django.py
@@ -57,7 +57,7 @@ def django_setup_full() -> None:
 
     Voir airflow-scheduler.Dockerfile pour plus de détails"""
     django_add_to_sys_path()
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "core.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "core.airflow_settings")
     django.setup()
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,10 @@ x-airflow-common:
   env_file:
     - ./dags/.env
   volumes:
+    - ./core:/opt/airflow/core/
+    - ./qfdmo:/opt/airflow/qfdmo/
+    - ./qfdmd:/opt/airflow/qfdmd/
+    - ./data:/opt/airflow/data/
     - ./logs:/opt/airflow/logs
     - ./dags:/opt/airflow/dags
     - ./config:/opt/airflow/config


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [[Airflow] Impossible d’écrire les logs sur S3 - execution aveugle](https://www.notion.so/accelerateur-transition-ecologique-ademe/Airflow-Impossible-d-crire-les-logs-sur-S3-execution-aveugle-1866523d57d780c6947cd64089cb1b69?pvs=4)

* Désactivation du logging de Django quand l'application django est utilisé par la plateforme DATA
* Ajout d'un DAG de controle de type `dev tools`

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
