### PR TITLE
Corriger l'url de l'iframe affichée dans la modal d'intégration de l'assistant

### DIFF
--- a/qfdmd/views.py
+++ b/qfdmd/views.py
@@ -31,7 +31,7 @@ def generate_iframe_script(request) -> str:
         produit_slug = request.resolver_match.kwargs["slug"]
         script_parts.append(f'data-objet="{produit_slug}"')
 
-    script_parts.append(f'src="{settings.BASE_URL}/script.js"></script>')
+    script_parts.append(f'src="{settings.BASE_URL}{reverse("qfdmd:script")}"></script>')
     return " ".join(script_parts)
 
 


### PR DESCRIPTION
**Quoi :** tout est dans le titre !
**Pourquoi :** on affiche `script.js` au lieu de `iframe.js`
**Comment :** tant qu'à faire : on récupère l'url retournée par le routeur Django plutôt que de hardcoder cette URL 


## Images

<img width="751" alt="image" src="https://github.com/user-attachments/assets/6059d18b-3eb7-4f4d-831a-c2684a728c52" />
