### PR TITLE
forcer la mise en preprod et prod sur clevercloud

### DIFF
--- a/.github/workflows/cd_preprod.yml
+++ b/.github/workflows/cd_preprod.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: 47ng/actions-clever-cloud@v2.0.0
         with:
           alias: lvao-preprod-airflow-webserver
+          force: true
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
           CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
@@ -53,6 +54,7 @@ jobs:
       - uses: 47ng/actions-clever-cloud@v2.0.0
         with:
           alias: lvao-preprod-airflow-scheduler
+          force: true
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
           CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}

--- a/.github/workflows/cd_prod.yml
+++ b/.github/workflows/cd_prod.yml
@@ -47,6 +47,7 @@ jobs:
       - uses: 47ng/actions-clever-cloud@v2.0.0
         with:
           alias: lvao-prod-airflow-webserver
+          force: true
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
           CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
@@ -63,6 +64,7 @@ jobs:
       - uses: 47ng/actions-clever-cloud@v2.0.0
         with:
           alias: lvao-prod-airflow-scheduler
+          force: true
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
           CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}


### PR DESCRIPTION
# Description succincte du problème résolu

Tout est dans le titre, c'est pour réduire le bruit car quand on a poussé des version à la main sur les environnements clevercloud, alors les mise en (pre)prod plante

Ici, on force e push to (pre)prod pour etre plus robuste

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
