### PR TITLE
Typo provoquant une erreur 500 sur les pages légales

### DIFF
--- a/templates/qfdmd/cmspage_detail.html
+++ b/templates/qfdmd/cmspage_detail.html
@@ -2,7 +2,7 @@
 
 {% block analytics_action %}produitPageView{% endblock %}
 
-% block title %}
+{% block title %}
 {{ object.seo_title }} | {{ block.super }}
 {% endblock title %}
 


### PR DESCRIPTION
# Description succincte du problème résolu

Il manquait une accolade dans un tmplate qui provoquait une erreur 500

cf. https://sentry.incubateur.net/organizations/betagouv/issues/146001/?alert_rule_id=74&alert_timestamp=1738177597651&alert_type=email&environment=production&notification_uuid=182c32d3-4c39-467f-8b3a-c42669c78f52&project=115&referrer=alert_email
 
<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [ ] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
