### PR TITLE
:eye: Airflow: expose DB docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,8 +55,6 @@ services:
       POSTGRES_DB: airflow
     volumes:
       - ./airflow-pgdata:/var/lib/postgresql/data
-    expose:
-      - 5432
     ports:
       - 7654:5432
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,10 @@ services:
       POSTGRES_DB: airflow
     volumes:
       - ./airflow-pgdata:/var/lib/postgresql/data
+    expose:
+      - 5432
+    ports:
+      - 7654:5432
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "airflow"]
       interval: 10s


### PR DESCRIPTION
# :eye: Airflow: expose DB docker

Carte Notion : [[Airflow] Exposer la DB interne Airflow docker localement](https://www.notion.so/accelerateur-transition-ecologique-ademe/Airflow-Exposer-la-DB-interne-Airflow-docker-localement-18b6523d57d780b48c37e81b2dae6df1?pvs=4)

 - **:bulb: quoi**: exposer la DB airflow docker en local
 - **:dart: pourquoi**:  pouvoir intéroger et mieux comprendre le comportement airflow
 - **:thinking: comment**: en modifiant `docker-compose.yml` et en exposant/mappant les ports (on utilise `7654` car `6543` est déjà utilisé pour exposer la DB produit)

## :framed_picture: Exemple

Pour voir si les `xcom` explosent

```
SELECT dag_id,
SUM(length(value))/COUNT(DISTINCT run_id)/1048576 AS avg_run_xcom_size_mb
FROM xcom
WHERE run_id IS NOT NULL
GROUP BY dag_id;
```

![image](https://github.com/user-attachments/assets/a3994cd7-7e9f-4f77-bca6-7552ae7aea21)
