### PR TITLE
Désactiver les services workers hérités de gatsby

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "source": [
         "static/to_compile/entrypoints/qfdmo.css",
         "static/to_compile/entrypoints/qfdmo.ts",
+        "static/to_compile/entrypoints/sw.ts",
         "static/to_compile/entrypoints/assistant/script-to-iframe.ts",
         "static/to_compile/entrypoints/admin-categorie-widget.ts",
         "static/to_compile/entrypoints/qfdmd.ts",

--- a/qfdmd/urls.py
+++ b/qfdmd/urls.py
@@ -7,6 +7,7 @@ from qfdmd.views import (
     ContactFormView,
     SynonymeDetailView,
     get_assistant_script,
+    get_sw,
     search_view,
 )
 
@@ -32,4 +33,6 @@ urlpatterns = [
     # legacy behaviour.
     path("dechet/<slug:slug>/", SynonymeDetailView.as_view(), name="synonyme-detail"),
     path("iframe.js", get_assistant_script, name="script"),
+    path("sw.js", get_sw, name="script"),
+    path("service-worker.js", get_sw, name="script"),
 ]

--- a/qfdmd/urls.py
+++ b/qfdmd/urls.py
@@ -34,5 +34,4 @@ urlpatterns = [
     path("dechet/<slug:slug>/", SynonymeDetailView.as_view(), name="synonyme-detail"),
     path("iframe.js", get_assistant_script, name="script"),
     path("sw.js", get_sw, name="script"),
-    path("service-worker.js", get_sw, name="script"),
 ]

--- a/qfdmd/views.py
+++ b/qfdmd/views.py
@@ -23,6 +23,10 @@ def get_assistant_script(request):
     return static_file_content_from("assistant/script-to-iframe.js")
 
 
+def get_sw(request):
+    return static_file_content_from("sw.js")
+
+
 def generate_iframe_script(request) -> str:
     """Generates a <script> tag used to embed Assistant website."""
     script_parts = ["<script"]

--- a/static/to_compile/entrypoints/qfdmd.ts
+++ b/static/to_compile/entrypoints/qfdmd.ts
@@ -14,6 +14,36 @@ stimulus.register("blink", BlinkController)
 stimulus.register("copy", CopyController)
 stimulus.register("analytics", AnalyticsController)
 
+document.addEventListener("DOMContentLoaded", () => {
+
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.getRegistrations().then(function(registrations) {
+      registrations.forEach(function(registration) {
+        registration.unregister().then(function(success) {
+          if (success) {
+            console.log('Service worker unregistered successfully.');
+          } else {
+            console.log('Failed to unregister service worker.');
+          }
+        });
+      });
+    }).catch(function(error) {
+      console.error('Error while fetching service workers:', error);
+    });
+  }
+  if ('caches' in window) {
+    caches.keys().then(function(cacheNames) {
+      cacheNames.forEach(function(cacheName) {
+        caches.delete(cacheName).then(function(success) {
+          if (success) {
+            console.log('Cache deleted:', cacheName);
+          }
+        });
+      });
+    });
+  }
+})
+
 
 
 Turbo.session.drive = false;

--- a/static/to_compile/entrypoints/qfdmd.ts
+++ b/static/to_compile/entrypoints/qfdmd.ts
@@ -14,36 +14,4 @@ stimulus.register("blink", BlinkController)
 stimulus.register("copy", CopyController)
 stimulus.register("analytics", AnalyticsController)
 
-document.addEventListener("DOMContentLoaded", () => {
-
-  if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.getRegistrations().then(function(registrations) {
-      registrations.forEach(function(registration) {
-        registration.unregister().then(function(success) {
-          if (success) {
-            console.log('Service worker unregistered successfully.');
-          } else {
-            console.log('Failed to unregister service worker.');
-          }
-        });
-      });
-    }).catch(function(error) {
-      console.error('Error while fetching service workers:', error);
-    });
-  }
-  if ('caches' in window) {
-    caches.keys().then(function(cacheNames) {
-      cacheNames.forEach(function(cacheName) {
-        caches.delete(cacheName).then(function(success) {
-          if (success) {
-            console.log('Cache deleted:', cacheName);
-          }
-        });
-      });
-    });
-  }
-})
-
-
-
 Turbo.session.drive = false;

--- a/static/to_compile/entrypoints/sw.ts
+++ b/static/to_compile/entrypoints/sw.ts
@@ -1,0 +1,26 @@
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.getRegistrations().then(function(registrations) {
+    registrations.forEach(function(registration) {
+      registration.unregister().then(function(success) {
+        if (success) {
+          console.log('Service worker unregistered successfully.');
+        } else {
+          console.log('Failed to unregister service worker.');
+        }
+      });
+    });
+  }).catch(function(error) {
+    console.error('Error while fetching service workers:', error);
+  });
+}
+if ('caches' in window) {
+  caches.keys().then(function(cacheNames) {
+    cacheNames.forEach(function(cacheName) {
+      caches.delete(cacheName).then(function(success) {
+        if (success) {
+          console.log('Cache deleted:', cacheName);
+        }
+      });
+    });
+  });
+}

--- a/static/to_compile/entrypoints/sw.ts
+++ b/static/to_compile/entrypoints/sw.ts
@@ -13,14 +13,3 @@ if ('serviceWorker' in navigator) {
     console.error('Error while fetching service workers:', error);
   });
 }
-if ('caches' in window) {
-  caches.keys().then(function(cacheNames) {
-    cacheNames.forEach(function(cacheName) {
-      caches.delete(cacheName).then(function(success) {
-        if (success) {
-          console.log('Cache deleted:', cacheName);
-        }
-      });
-    });
-  });
-}


### PR DESCRIPTION
**Quoi** : forcer la désactivation des service workers tournant sur les machines des visiteurs récurrents pour le domaine quefairedemesdechets.ademe.fr

**Pourquoi** : On hérite d'un service worker dans quefairedemesdechets.ademe.fr qui est présent sur /sw.js.
Il semblerait que son absence dans la nouvelle version de l'assistant empêche sa mise à jour qui a normalement lieu toutes les 24 heures, cf https://answers.netlify.com/t/support-guide-understanding-unregistering-service-workers/145

**Comment** : le navigateur via gatbsy a pu enregistrer un service worker à l'url sur le chemin `/sw.js`. 
On charge donc un nouveau fichier .js qui permet de remplacer l'existant, normalement rafraichi par le navigateur au bout de 24h

**⚠️ tests** : j'ai déployé ce code en prod directement car c'est le seul endroit où on peut reproduire, ça a semble-t-il résolu le problème pour une bonne partie de l'équipe