### PR TITLE
Suppression de la dépendance à honcho dans le makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,10 @@ run-airflow:
 
 .PHONY: run-django
 run-django:
+	docker compose --profile lvao up -d
 	rm -rf .parcel-cache
-	honcho start -f Procfile.dev
+	$(DJANGO_ADMIN) runserver 0.0.0.0:8000
+	npm run watch
 
 run-all:
 	docker compose --profile airflow up -d


### PR DESCRIPTION
# Description succincte du problème résolu

Clean up du makefile pour ne pas dépedre de honcho et lancer la db quand on lance django

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [ ] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
