### PR TITLE
Permettre d'autres séparateurs dans les adresses au format BAN

### DIFF
--- a/dags/sources/tasks/transform/transform_df.py
+++ b/dags/sources/tasks/transform/transform_df.py
@@ -334,7 +334,7 @@ def _address_details_extract(
     address = postal_code = city = None
 
     # Pattern pour capturer les codes postaux et les noms de ville optionnels
-    pattern1 = re.compile(r"(.*)\s+(\d{4,5})\s*(.*)")
+    pattern1 = re.compile(r"(.*)[\s\,\;]+(\d{4,5})[\s\,\;]*(.*)")
     # Pattern pour capturer les codes postaux sans adresse
     pattern2 = re.compile(r"(\d{4,5})\s*(.*)")
     if match := pattern1.search(address_str):

--- a/dags_unit_tests/sources/tasks/transform/test_transform_df.py
+++ b/dags_unit_tests/sources/tasks/transform/test_transform_df.py
@@ -312,6 +312,22 @@ class TestCleanAdresse:
                     "ville": "Paris",
                 },
             ),
+            (
+                "Rue des Balmes,38540,HEYRIEUX",
+                {
+                    "adresse": "Rue des Balmes",
+                    "code_postal": "38540",
+                    "ville": "Heyrieux",
+                },
+            ),
+            (
+                "Rue des Balmes;38540;HEYRIEUX",
+                {
+                    "adresse": "Rue des Balmes",
+                    "code_postal": "38540",
+                    "ville": "Heyrieux",
+                },
+            ),
         ],
     )
     def test_clean_adresse_without_ban(


### PR DESCRIPTION
# Description succincte du problème résolu

Mattermost : [On a un nouveau problème de parsing ou d'import](https://mattermost.incubateur.net/betagouv/pl/8da7tqej93dtudyf46qqptirsw)

Bug remonté par @chrischarousset , les adresses avec des séparateurs autre que l'espace entre adresse / code postal / ville ne sont pas pris en compte

J'ai ajouté `,` et `;`

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [x] Bug fix
- [x] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
