### PR TITLE
Filtrer les parents qui n'ont pas d'enfants actifs

### DIFF
--- a/dags/compute_acteurs/tasks/business_logic/compute_acteur.py
+++ b/dags/compute_acteurs/tasks/business_logic/compute_acteur.py
@@ -10,7 +10,10 @@ from qfdmo.models.acteur import RevisionActeur  # noqa: E402
 
 def compute_acteur(df_acteur: pd.DataFrame, df_revisionacteur: pd.DataFrame):
 
-    revisionacteur_parent_ids = df_revisionacteur["parent_id"].unique()
+    # Collect parent_id among active revisionacteurs
+    revisionacteur_parent_ids = df_revisionacteur[
+        df_revisionacteur["statut"] == constants.ACTEUR_ACTIF
+    ]["parent_id"].unique()
 
     df_revisionacteur_parents = df_revisionacteur[
         df_revisionacteur["identifiant_unique"].isin(revisionacteur_parent_ids)


### PR DESCRIPTION
# Description succincte du problème résolu

Le rafraichissement des acteurs affichés est cassé à cause des parents qui n'ont que des enfants non actifs

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
