### PR TITLE
Si il n'y a pas de query lors de l'appel à get_objet_list alors on retourne une liste vide d'objet

### DIFF
--- a/qfdmo/views/adresses.py
+++ b/qfdmo/views/adresses.py
@@ -587,11 +587,11 @@ def refresh_acteur_view(request):
 
 @require_GET
 def get_object_list(request):
-    q = request.GET.get("q")
-    if not q:
+    query = request.GET.get("q")
+    if not query:
         return JsonResponse([], safe=False)
 
-    query = unidecode.unidecode(request.GET.get("q"))
+    query = unidecode.unidecode(query)
     objets = (
         Objet.objects.annotate(
             libelle_unaccent=Unaccent(Lower("libelle")),

--- a/qfdmo/views/adresses.py
+++ b/qfdmo/views/adresses.py
@@ -587,6 +587,10 @@ def refresh_acteur_view(request):
 
 @require_GET
 def get_object_list(request):
+    q = request.GET.get("q")
+    if not q:
+        return JsonResponse([], safe=False)
+
     query = unidecode.unidecode(request.GET.get("q"))
     objets = (
         Objet.objects.annotate(

--- a/unit_tests/qfdmo/test_adresse_get_object_list.py
+++ b/unit_tests/qfdmo/test_adresse_get_object_list.py
@@ -21,6 +21,14 @@ def objet2(sous_categorie):
     return ObjetFactory(libelle="Test Object 2", sous_categorie=sous_categorie)
 
 
+def test_get_object_list_noquery(client):
+    url = reverse("qfdmo:get_object_list")
+    response = client.get(url)
+    assert response.status_code == 200
+    data = json.loads(response.content)
+    assert data == []
+
+
 @pytest.mark.django_db
 def test_get_object_list(client, objet1, objet2):
     url = reverse("qfdmo:get_object_list")


### PR DESCRIPTION
# Description succincte du problème résolu

But : éviter une erreur Sentry

Sentry : https://sentry.incubateur.net/organizations/betagouv/issues/149376/?alert_rule_id=74&alert_timestamp=1739284583204&alert_type=email&environment=production&notification_uuid=398e226e-9cc5-4a63-9b81-021aac5108b0&project=115&referrer=alert_email


<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
