### PR TITLE
Permettre de créer un parent même quand une action principale est définie

### DIFF
--- a/qfdmo/models/acteur.py
+++ b/qfdmo/models/acteur.py
@@ -567,11 +567,13 @@ class BaseActeur(TimestampedModel, NomAsNaturalKeyModel):
             "proposition_services",
             "acteur_type",
             "acteur_services",
+            "action_principale",
             "source",
             "labels",
         ]
         acteur_dict = model_to_dict(self, exclude=excluded_fields)
         acteur_dict["acteur_type"] = self.acteur_type
+        acteur_dict["action_principale"] = self.action_principale
         return {k: v for k, v in acteur_dict.items() if v}
 
 


### PR DESCRIPTION
# Description succincte du problème résolu

Pb remonté par Christian dans le fichier de récap des problèmes rencontrés ces derniers jours

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Gestion des acteurs "parent" dans l'admin django

**💡 quoi**: Impossible de créer un parent pour un (revision)acteur qui a une action principale définie

**🎯 pourquoi**: Pb de clone des champs relationnels, la fonction `model_to_dict` retourne un id pour l'objet action_principale

**🤔 comment**:

- ne pas extraire action_principal dans la fonction model_to_dict et assigner cette valeur à partir de l'objet cloné
- ajout de tests plus exhaustif

## Exemple résultats / UI / Data

![CleanShot 2025-02-13 at 12 04 36@2x](https://github.com/user-attachments/assets/3d8b9769-88a1-4c2f-ad93-391923babf28)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)


## 📆 A faire (prochaine PR)

