### PR TITLE
script de ratrappage par source des propositions de service

### DIFF
--- a/qfdmo/management/commands/enrich_revisionpropositionservice.py
+++ b/qfdmo/management/commands/enrich_revisionpropositionservice.py
@@ -1,0 +1,115 @@
+import argparse
+
+from django.core.management.base import BaseCommand
+from django.db.models import QuerySet
+
+from qfdmo.models.acteur import (
+    Acteur,
+    RevisionActeur,
+    RevisionPropositionService,
+    Source,
+)
+from qfdmo.models.action import Action
+
+
+def ps_by_action(propositionservices: QuerySet):
+    return {
+        p.action.code: [sscat for sscat in p.sous_categories.all()]
+        for p in propositionservices
+    }
+
+
+class Command(BaseCommand):
+    help = "Suppression des parents qui n'ont pas d'enfants"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            help="Run command without writing changes to the database",
+            action=argparse.BooleanOptionalAction,
+            default=False,
+        )
+        parser.add_argument(
+            "--source_code",
+            help="code de la source concernée",
+            type=str,
+            required=True,
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        source_code = options["source_code"]
+
+        try:
+            source = Source.objects.get(code=source_code)
+        except Source.DoesNotExist:
+            self.stdout.write(self.style.ERROR(f"Source {source_code} non trouvée"))
+
+        for acteur in Acteur.objects.filter(source=source):
+            try:
+                revision_acteur = RevisionActeur.objects.get(
+                    identifiant_unique=acteur.identifiant_unique
+                )
+            except RevisionActeur.DoesNotExist:
+                continue
+
+            ps_acteur_by_action = ps_by_action(acteur.proposition_services.all())
+            rps_acteur_by_action = ps_by_action(
+                revision_acteur.proposition_services.all()
+            )
+
+            pss_to_add = []
+            pss_to_update = []
+            for action_code, ps_acteur_sscats in ps_acteur_by_action.items():
+                if action_code not in rps_acteur_by_action:
+                    pss_to_add.append(
+                        {
+                            action_code: ps_acteur_sscats,
+                        }
+                    )
+                    continue
+
+                if sscat := set(ps_acteur_sscats) - set(
+                    rps_acteur_by_action[action_code]
+                ):
+                    pss_to_update.append(
+                        {
+                            action_code: sscat,
+                        }
+                    )
+
+            action_by_code = {a.code: a for a in Action.objects.all()}
+            if pss_to_add or pss_to_update:
+                message = f"Acteur {acteur.identifiant_unique}:\n"
+                if pss_to_add:
+                    displayed_ps = [
+                        {k: [s.code for s in v] for k, v in ps.items()}
+                        for ps in pss_to_add
+                    ]
+                    message += "Ajout des proposition de services\n"
+                    message += f"{displayed_ps}"
+                if pss_to_update:
+                    displayed_ps = [
+                        {k: [s.code for s in v] for k, v in ps.items()}
+                        for ps in pss_to_update
+                    ]
+                    message += "Mise à jour des proposition de services\n"
+                    message += f"{displayed_ps}"
+                self.stdout.write(self.style.WARNING(message))
+                if not dry_run:
+                    if pss_to_add:
+                        for ps_to_add in pss_to_add:
+                            for action_code, ps_acteur_sscats in ps_to_add.items():
+                                ps = RevisionPropositionService.objects.create(
+                                    action=action_by_code[action_code],
+                                    acteur=revision_acteur,
+                                )
+                                ps.sous_categories.add(*ps_acteur_sscats)
+                    if pss_to_update:
+                        for ps_to_update in pss_to_update:
+                            for action_code, ps_acteur_sscats in ps_to_update.items():
+                                ps = RevisionPropositionService.objects.get(
+                                    action=action_by_code[action_code],
+                                    acteur=revision_acteur,
+                                )
+                                ps.sous_categories.add(*ps_acteur_sscats)


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [MÀJ de Propositions de service ne sont pas prise en compte dès que l’acteur a été Corrigé - mais devraient l’être](https://www.notion.so/accelerateur-transition-ecologique-ademe/M-J-de-Propositions-de-service-ne-sont-pas-prise-en-compte-d-s-que-l-acteur-a-t-Corrig-mais-dev-19d6523d57d78081b342c3835e364005?pvs=4)

**🗺️ contexte**: Script (command django)

**💡 quoi**: Rattrapage des propositions de service

**🎯 pourquoi**: 

Dès lors qu'une source avait une révision, lors de l'ingestion d'une nouvelle version, les nouvelle propositions de services n'ont pas été prise en compte car les propositions de service de la révision supplante celle de la source

**🤔 comment**: 

Création d'un script qui va ajouter les propositions de services qui existe sur l'acteur mais pas sur la révision
lancement par source
option dry-run

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [x] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code

