### PR TITLE
Augmenter ne nombre de valeurs accepté dans la requête 1000 -> 10000

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -30,3 +30,4 @@ ASSISTANT_HOSTS=localhost:8000
 ASSISTANT_BASE_URL=http://localhost:8000
 NOTION_TOKEN=
 NOTION_CONTACT_FORM_DATABASE_ID=17c6523d57d78140b87f000cd3ecef4b # Correspond à https://www.notion.so/accelerateur-transition-ecologique-ademe/17c6523d57d7808b8cc5f5ccae264f7c?v=17c6523d57d78140b87f000cd3ecef4b&pvs=4
+DATA_UPLOAD_MAX_NUMBER_FIELDS=10000

--- a/core/settings.py
+++ b/core/settings.py
@@ -399,3 +399,7 @@ NOTION = {
         "NOTION_CONTACT_FORM_DATABASE_ID", default=""
     ),
 }
+
+DATA_UPLOAD_MAX_NUMBER_FIELDS = decouple.config(
+    "DATA_UPLOAD_MAX_NUMBER_FIELDS", default=10000, cast=int
+)


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [Les opérations sur les suggestions génèrent des erreurs serveur](https://www.notion.so/accelerateur-transition-ecologique-ademe/Les-op-rations-sur-les-suggestions-g-n-rent-des-erreurs-serveur-1926523d57d7809ea214cf53ef8f8ec1?pvs=4)

**🗺️ contexte**: Django Admin

**💡 quoi**: Augmenté le nombre de suggestion selectionnable

**🎯 pourquoi**: Defaut de Django est trop faible pour les opérations de gestion de data

**🤔 comment**: Modification de la valeur DATA_UPLOAD_MAX_NUMBER_FIELDS à 10000

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [x] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code

## 📆 A faire (prochaine PR)

- [ ] Je n'ai pas réussi à capter cette limite avant que ça pête une erreur -> A voir si c'est possible
