### PR TITLE
Fusionner les duplicats des sources

### DIFF
--- a/dags/sources/dags/source_aliapur.py
+++ b/dags/sources/dags/source_aliapur.py
@@ -142,7 +142,6 @@ with DAG(
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-aliapur/lines?size=10000"
         ),
-        "ignore_duplicates": False,
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config(),
     },

--- a/dags/sources/dags/source_citeo.py
+++ b/dags/sources/dags/source_citeo.py
@@ -129,7 +129,6 @@ with DAG(
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-citeo/lines?size=10000"
         ),
-        "ignore_duplicates": False,
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config(),
     },

--- a/dags/sources/dags/source_cma.py
+++ b/dags/sources/dags/source_cma.py
@@ -171,7 +171,6 @@ with DAG(
         "endpoint": (
             "https://data.artisanat.fr/api/explore/v2.1/catalog/datasets/reparacteurs/records"
         ),
-        "ignore_duplicates": False,
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config(mapping_key="sous_categories_cma"),
     },

--- a/dags/sources/dags/source_corepile.py
+++ b/dags/sources/dags/source_corepile.py
@@ -134,7 +134,6 @@ with DAG(
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-corepile/lines?size=10000"
         ),
-        "ignore_duplicates": False,
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config(),
     },

--- a/dags/sources/dags/source_cyclevia.py
+++ b/dags/sources/dags/source_cyclevia.py
@@ -166,7 +166,6 @@ with DAG(
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-cyclevia/lines?size=10000"
         ),
-        "ignore_duplicates": False,
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config(),
     },

--- a/dags/sources/dags/source_ecodds.py
+++ b/dags/sources/dags/source_ecodds.py
@@ -141,7 +141,6 @@ with DAG(
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-ecodds/lines?size=10000"
         ),
-        "ignore_duplicates": False,
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config(),
     },

--- a/dags/sources/dags/source_ecologic.py
+++ b/dags/sources/dags/source_ecologic.py
@@ -130,7 +130,6 @@ with DAG(
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-ecologic/lines?size=10000"
         ),
-        "ignore_duplicates": False,
         "validate_address_with_ban": False,
         "merge_duplicated_acteurs": True,  # In case of multi ecoorganisme or filiere
         "product_mapping": get_mapping_config(mapping_key="sous_categories_3eee"),

--- a/dags/sources/dags/source_ecologic.py
+++ b/dags/sources/dags/source_ecologic.py
@@ -131,7 +131,6 @@ with DAG(
             "donnees-eo-ecologic/lines?size=10000"
         ),
         "validate_address_with_ban": False,
-        "merge_duplicated_acteurs": True,  # In case of multi ecoorganisme or filiere
         "product_mapping": get_mapping_config(mapping_key="sous_categories_3eee"),
     },
     schedule=None,

--- a/dags/sources/dags/source_ecomaison.py
+++ b/dags/sources/dags/source_ecomaison.py
@@ -151,7 +151,6 @@ with DAG(
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-ecomaison/lines?size=10000"
         ),
-        "ignore_duplicates": False,
         "validate_address_with_ban": False,
         "merge_duplicated_acteurs": True,
         "product_mapping": get_mapping_config(),

--- a/dags/sources/dags/source_ecomaison.py
+++ b/dags/sources/dags/source_ecomaison.py
@@ -152,7 +152,6 @@ with DAG(
             "donnees-eo-ecomaison/lines?size=10000"
         ),
         "validate_address_with_ban": False,
-        "merge_duplicated_acteurs": True,
         "product_mapping": get_mapping_config(),
     },
     schedule=None,

--- a/dags/sources/dags/source_ecopae.py
+++ b/dags/sources/dags/source_ecopae.py
@@ -143,7 +143,6 @@ with DAG(
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-ecopae/lines?size=10000"
         ),
-        "ignore_duplicates": False,
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config(),
     },

--- a/dags/sources/dags/source_ecosystem.py
+++ b/dags/sources/dags/source_ecosystem.py
@@ -130,7 +130,6 @@ with DAG(
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-ecosystem/lines?size=10000"
         ),
-        "ignore_duplicates": False,
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config(mapping_key="sous_categories_3eee"),
     },

--- a/dags/sources/dags/source_ocab.py
+++ b/dags/sources/dags/source_ocab.py
@@ -132,7 +132,6 @@ with DAG(
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-ocab/lines?size=10000"
         ),
-        "ignore_duplicates": False,
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config(),
     },

--- a/dags/sources/dags/source_ocad3e.py
+++ b/dags/sources/dags/source_ocad3e.py
@@ -147,7 +147,6 @@ with DAG(
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-ocad3e/lines?size=10000"
         ),
-        "ignore_duplicates": False,
         "validate_address_with_ban": False,
         "label_bonus_reparation": "qualirepar",
         "product_mapping": get_mapping_config(mapping_key="sous_categories_qualirepar"),

--- a/dags/sources/dags/source_pyreo.py
+++ b/dags/sources/dags/source_pyreo.py
@@ -165,7 +165,6 @@ with DAG(
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-pyreo/lines?size=10000"
         ),
-        "ignore_duplicates": False,
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config(),
     },

--- a/dags/sources/dags/source_refashion.py
+++ b/dags/sources/dags/source_refashion.py
@@ -168,7 +168,6 @@ with DAG(
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-refashion/lines?size=10000"
         ),
-        "ignore_duplicates": False,
         "validate_address_with_ban": False,
         "label_bonus_reparation": "refashion",
         "product_mapping": get_mapping_config(),

--- a/dags/sources/dags/source_screlec.py
+++ b/dags/sources/dags/source_screlec.py
@@ -153,7 +153,6 @@ with DAG(
             {"remove": "accessible"},
             # 6. Colonnes à garder (rien à faire, utilisé pour le controle)
         ],
-        "ignore_duplicates": False,
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config("sous_categories"),
     },

--- a/dags/sources/dags/source_sinoe.py
+++ b/dags/sources/dags/source_sinoe.py
@@ -149,7 +149,6 @@ with DAG(
             {"keep": "ANNEE"},
         ],
         "dechet_mapping": source_sinoe_dechet_mapping_get(),
-        "ignore_duplicates": False,
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config("sous_categories_sinoe"),
     },

--- a/dags/sources/dags/source_soren.py
+++ b/dags/sources/dags/source_soren.py
@@ -148,7 +148,6 @@ with DAG(
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-soren/lines?size=10000"
         ),
-        "ignore_duplicates": False,
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config(),
     },

--- a/dags/sources/dags/source_valdelia.py
+++ b/dags/sources/dags/source_valdelia.py
@@ -156,7 +156,6 @@ with DAG(
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-valdelia/lines?size=10000"
         ),
-        "ignore_duplicates": False,
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config(),
     },

--- a/dags/sources/tasks/airflow_logic/config_management.py
+++ b/dags/sources/tasks/airflow_logic/config_management.py
@@ -56,7 +56,6 @@ class DAGConfig(BaseModel):
     combine_columns_categories: list[str] = []
     dechet_mapping: dict = {}
     endpoint: HttpUrl
-    ignore_duplicates: bool = False
     label_bonus_reparation: Optional[str] = None
     merge_duplicated_acteurs: bool = False
     product_mapping: dict

--- a/dags/sources/tasks/airflow_logic/config_management.py
+++ b/dags/sources/tasks/airflow_logic/config_management.py
@@ -57,7 +57,6 @@ class DAGConfig(BaseModel):
     dechet_mapping: dict = {}
     endpoint: HttpUrl
     label_bonus_reparation: Optional[str] = None
-    merge_duplicated_acteurs: bool = False
     product_mapping: dict
     source_code: Optional[str] = None
     validate_address_with_ban: bool = False

--- a/dags/sources/tasks/business_logic/source_data_normalize.py
+++ b/dags/sources/tasks/business_logic/source_data_normalize.py
@@ -120,11 +120,20 @@ def _remove_columns(df: pd.DataFrame, dag_config: DAGConfig) -> pd.DataFrame:
 
 
 def _remove_undesired_lines(df: pd.DataFrame, dag_config: DAGConfig) -> pd.DataFrame:
-    if dag_config.merge_duplicated_acteurs:
+
+    if all(
+        column in df.columns
+        for column in [
+            "label_codes",
+            "acteurservice_codes",
+            "proposition_services_codes",
+        ]
+    ):
         df = merge_duplicates(
             df,
             group_column="identifiant_unique",
-            merge_column="souscategorie_codes",
+            merge_as_list_columns=["label_codes", "acteurservice_codes"],
+            merge_as_proposition_service_columns=["proposition_services_codes"],
         )
 
     # Remove acteurs which propose only service à domicile
@@ -148,11 +157,6 @@ def _remove_undesired_lines(df: pd.DataFrame, dag_config: DAGConfig) -> pd.DataF
             f"==== DOUBLONS SUR LES IDENTIFIANTS UNIQUES {len(dups)/2} ====="
         )
         log.preview("Doublons sur identifiant_unique", dups)
-    if dag_config.ignore_duplicates:
-        # FIXME: dedupliquer en mergeant proposition_services_codes ?
-        # TODO: Attention aux lignes dupliquées à cause de de service en ligne
-        #  + physique
-        df = df.drop_duplicates(subset=["identifiant_unique"], keep="first")
 
     return df
 

--- a/dags/sources/tasks/transform/transform_df.py
+++ b/dags/sources/tasks/transform/transform_df.py
@@ -11,6 +11,7 @@ from sources.tasks.transform.transform_column import (
     clean_siren,
     clean_siret,
 )
+from utils import logging_utils as log
 from utils.base_utils import transform_location
 from utils.formatter import format_libelle_to_code
 from utils.mapping_utils import parse_float
@@ -34,39 +35,84 @@ MANDATORY_COLUMNS_AFTER_NORMALISATION = [
 REGEX_BAN_SEPARATORS = r"\s,;"
 
 
+# TODO: return some metadata about the duplicates
 def merge_duplicates(
-    df, group_column="identifiant_unique", merge_column="souscategorie_codes"
-):
+    df: pd.DataFrame,
+    group_column: str = "identifiant_unique",
+    merge_as_list_columns: list = [],
+    merge_as_proposition_service_columns: list = [],
+) -> pd.DataFrame:
+
+    for col in merge_as_list_columns + merge_as_proposition_service_columns:
+        if col not in df.columns:
+            raise ValueError(f"Column {col} not found in DataFrame")
 
     df_duplicates = df[df.duplicated(group_column, keep=False)]
+    if df_duplicates.empty:
+        logger.warning("No duplicate found")
+        return df
+    logger.warning(f"{len(df_duplicates)/2} duplicates found")
+    log.preview("df_duplicates", df_duplicates)
+
     df_non_duplicates = df[~df.duplicated(group_column, keep=False)]
 
+    merge_as_first_columns = [
+        col
+        for col in df.columns
+        if col
+        not in merge_as_list_columns
+        + merge_as_proposition_service_columns
+        + [group_column]
+    ]
     df_merged_duplicates = (
         df_duplicates.groupby(group_column)
         .agg(
             {
+                **{col: "first" for col in merge_as_first_columns},
+                **{col: _merge_list_columns for col in merge_as_list_columns},
                 **{
-                    col: "first"
-                    for col in df.columns
-                    if col != merge_column and col != group_column
+                    col: _merge_proposition_service_columns
+                    for col in merge_as_proposition_service_columns
                 },
-                merge_column: _merge_columns_of_accepted_products,
             }
         )
         .reset_index()
     )
 
-    # Concatenate the non-duplicates and merged duplicates
     df_final = pd.concat([df_non_duplicates, df_merged_duplicates], ignore_index=True)
 
     return df_final
 
 
-def _merge_columns_of_accepted_products(group):
-    produits_sets = set()
-    for produits in group:
-        produits_sets.update(produits)
-    return sorted(produits_sets)
+# FIXME: remove logs
+def _merge_list_columns(group):
+    result_sets = set()
+    logger.warning(f"=== {group=}")
+    for result in group:
+        result_sets.update(result)
+    logger.warning(f"=== {result_sets=}")
+    return sorted(list(result_sets))
+
+
+# FIXME: remove logs
+def _merge_proposition_service_columns(group):
+    sscat_by_action = {}
+    logger.warning(f"=== {group=}")
+    for pss in group:
+        logger.warning(f"=== {pss=}")
+        for ps in pss:
+            logger.warning(f"=== {ps=}")
+            if ps["action"] not in sscat_by_action:
+                sscat_by_action[ps["action"]] = []
+            sscat_by_action[ps["action"]].extend(ps["sous_categories"])
+
+    return [
+        {
+            "action": action,
+            "sous_categories": sorted(list(set(sscat))),
+        }
+        for action, sscat in sscat_by_action.items()
+    ]
 
 
 def clean_telephone(row: pd.Series, _):

--- a/dags/sources/tasks/transform/transform_df.py
+++ b/dags/sources/tasks/transform/transform_df.py
@@ -35,12 +35,11 @@ MANDATORY_COLUMNS_AFTER_NORMALISATION = [
 REGEX_BAN_SEPARATORS = r"\s,;"
 
 
-# TODO: return some metadata about the duplicates
 def merge_duplicates(
     df: pd.DataFrame,
-    group_column: str = "identifiant_unique",
-    merge_as_list_columns: list = [],
-    merge_as_proposition_service_columns: list = [],
+    group_column: str,
+    merge_as_list_columns: list,
+    merge_as_proposition_service_columns: list,
 ) -> pd.DataFrame:
 
     for col in merge_as_list_columns + merge_as_proposition_service_columns:
@@ -51,8 +50,7 @@ def merge_duplicates(
     if df_duplicates.empty:
         logger.warning("No duplicate found")
         return df
-    logger.warning(f"{len(df_duplicates)/2} duplicates found")
-    log.preview("df_duplicates", df_duplicates)
+    log.preview(f"{len(df_duplicates)/2} duplicates found", df_duplicates)
 
     df_non_duplicates = df[~df.duplicated(group_column, keep=False)]
 
@@ -84,24 +82,17 @@ def merge_duplicates(
     return df_final
 
 
-# FIXME: remove logs
 def _merge_list_columns(group):
     result_sets = set()
-    logger.warning(f"=== {group=}")
     for result in group:
         result_sets.update(result)
-    logger.warning(f"=== {result_sets=}")
     return sorted(list(result_sets))
 
 
-# FIXME: remove logs
 def _merge_proposition_service_columns(group):
     sscat_by_action = {}
-    logger.warning(f"=== {group=}")
     for pss in group:
-        logger.warning(f"=== {pss=}")
         for ps in pss:
-            logger.warning(f"=== {ps=}")
             if ps["action"] not in sscat_by_action:
                 sscat_by_action[ps["action"]] = []
             sscat_by_action[ps["action"]].extend(ps["sous_categories"])

--- a/dags_unit_tests/sources/tasks/airflow_logic/test_config_management.py
+++ b/dags_unit_tests/sources/tasks/airflow_logic/test_config_management.py
@@ -64,7 +64,6 @@ class TestDAGConfig:
         assert dag_config.combine_columns_categories == []
         assert dag_config.dechet_mapping == {}
         assert dag_config.label_bonus_reparation is None
-        assert dag_config.merge_duplicated_acteurs is False
         assert dag_config.product_mapping == {}
         assert dag_config.source_code is None
         assert dag_config.validate_address_with_ban is False

--- a/dags_unit_tests/sources/tasks/airflow_logic/test_config_management.py
+++ b/dags_unit_tests/sources/tasks/airflow_logic/test_config_management.py
@@ -63,7 +63,6 @@ class TestDAGConfig:
         assert dag_config.normalization_rules == []
         assert dag_config.combine_columns_categories == []
         assert dag_config.dechet_mapping == {}
-        assert dag_config.ignore_duplicates is False
         assert dag_config.label_bonus_reparation is None
         assert dag_config.merge_duplicated_acteurs is False
         assert dag_config.product_mapping == {}

--- a/dags_unit_tests/sources/tasks/business_logic/test_source_data_normalize.py
+++ b/dags_unit_tests/sources/tasks/business_logic/test_source_data_normalize.py
@@ -417,8 +417,7 @@ class TestRemoveUndesiredLines:
             result_df.reset_index(drop=True), expected_df.reset_index(drop=True)
         )
 
-    def test_merge_duplicated_acteurs(self, dag_config):
-        dag_config.merge_duplicated_acteurs = True
+    def test_merge_duplicated(self, dag_config):
         result = _remove_undesired_lines(
             pd.DataFrame(
                 {

--- a/dags_unit_tests/sources/tasks/business_logic/test_source_data_normalize.py
+++ b/dags_unit_tests/sources/tasks/business_logic/test_source_data_normalize.py
@@ -429,39 +429,26 @@ class TestRemoveUndesiredLines:
                         "Particuliers",
                         "Particuliers",
                     ],
-                    "souscategorie_codes": [["code1"], ["code2"], ["code3"]],
-                }
-            ),
-            dag_config,
-        )
-        result = result.sort_values("identifiant_unique")
-        result = result.reset_index(drop=True)
-
-        expected_df = pd.DataFrame(
-            {
-                "identifiant_unique": ["id1", "id2"],
-                "service_a_domicile": ["non", "non"],
-                "public_accueilli": ["Particuliers", "Particuliers"],
-                "souscategorie_codes": [["code1", "code2"], ["code3"]],
-            }
-        )
-        expected_df.reset_index(drop=True)
-
-        pd.testing.assert_frame_equal(result, expected_df)
-
-    def test_ignore_duplicates(self, dag_config):
-        dag_config.ignore_duplicates = True
-        result = _remove_undesired_lines(
-            pd.DataFrame(
-                {
-                    "identifiant_unique": ["id1", "id1", "id2"],
-                    "service_a_domicile": ["non", "non", "non"],
-                    "public_accueilli": [
-                        "Particuliers",
-                        "Particuliers",
-                        "Particuliers",
+                    "label_codes": [["label1"], ["label2"], ["label3"]],
+                    "acteurservice_codes": [
+                        ["acteurservice1"],
+                        ["acteurservice2"],
+                        ["acteurservice3"],
                     ],
-                    "souscategorie_codes": [["code1"], ["code2"], ["code3"]],
+                    "proposition_services_codes": [
+                        [
+                            {
+                                "action": "action1",
+                                "sous_categories": ["sscat1", "sscat3"],
+                            },
+                            {"action": "action2", "sous_categories": ["sscat1"]},
+                        ],
+                        [
+                            {"action": "action2", "sous_categories": ["sscat2"]},
+                            {"action": "action3", "sous_categories": ["sscat3"]},
+                        ],
+                        [{"action": "action3", "sous_categories": ["sscat3"]}],
+                    ],
                 }
             ),
             dag_config,
@@ -474,7 +461,19 @@ class TestRemoveUndesiredLines:
                 "identifiant_unique": ["id1", "id2"],
                 "service_a_domicile": ["non", "non"],
                 "public_accueilli": ["Particuliers", "Particuliers"],
-                "souscategorie_codes": [["code1"], ["code3"]],
+                "label_codes": [["label1", "label2"], ["label3"]],
+                "acteurservice_codes": [
+                    ["acteurservice1", "acteurservice2"],
+                    ["acteurservice3"],
+                ],
+                "proposition_services_codes": [
+                    [
+                        {"action": "action1", "sous_categories": ["sscat1", "sscat3"]},
+                        {"action": "action2", "sous_categories": ["sscat1", "sscat2"]},
+                        {"action": "action3", "sous_categories": ["sscat3"]},
+                    ],
+                    [{"action": "action3", "sous_categories": ["sscat3"]}],
+                ],
             }
         )
         expected_df.reset_index(drop=True)

--- a/dags_unit_tests/sources/tasks/transform/test_transform_df.py
+++ b/dags_unit_tests/sources/tasks/transform/test_transform_df.py
@@ -131,6 +131,7 @@ class TestMergeDuplicates:
             df,
             group_column="identifiant_unique",
             merge_as_list_columns=["label_codes"],
+            merge_as_proposition_service_columns=[],
         )
 
         result_df = result_df.sort_values(by="identifiant_unique").reset_index(
@@ -301,6 +302,7 @@ class TestMergeDuplicates:
         result_df = merge_duplicates(
             df,
             group_column="identifiant_unique",
+            merge_as_list_columns=[],
             merge_as_proposition_service_columns=["proposition_services_codes"],
         )
 

--- a/dags_unit_tests/sources/tasks/transform/test_transform_df.py
+++ b/dags_unit_tests/sources/tasks/transform/test_transform_df.py
@@ -25,7 +25,7 @@ class TestMergeDuplicates:
                 pd.DataFrame(
                     {
                         "identifiant_unique": [1, 1],
-                        "souscategorie_codes": [
+                        "label_codes": [
                             ["Plastic Box", "Metal", "Aàèë l'test"],
                             ["Plastic Box", "Metal", "Aàèë l'test"],
                         ],
@@ -35,9 +35,7 @@ class TestMergeDuplicates:
                 pd.DataFrame(
                     {
                         "identifiant_unique": [1],
-                        "souscategorie_codes": [
-                            ["Aàèë l'test", "Metal", "Plastic Box"]
-                        ],
+                        "label_codes": [["Aàèë l'test", "Metal", "Plastic Box"]],
                         "other_column": ["A"],
                     }
                 ),
@@ -46,7 +44,7 @@ class TestMergeDuplicates:
                 pd.DataFrame(
                     {
                         "identifiant_unique": [1, 2, 3],
-                        "souscategorie_codes": [
+                        "label_codes": [
                             ["Plastic", "Metal"],
                             ["Metal", "Glass"],
                             ["Paper"],
@@ -61,7 +59,7 @@ class TestMergeDuplicates:
                 pd.DataFrame(
                     {
                         "identifiant_unique": [1, 2, 3],
-                        "souscategorie_codes": [
+                        "label_codes": [
                             ["Plastic", "Metal"],
                             ["Metal", "Glass"],
                             ["Paper"],
@@ -78,7 +76,7 @@ class TestMergeDuplicates:
                 pd.DataFrame(
                     {
                         "identifiant_unique": [1, 1, 1],
-                        "souscategorie_codes": [
+                        "label_codes": [
                             ["Plastic", "Metal"],
                             ["Metal", "Glass"],
                             ["Paper"],
@@ -93,7 +91,7 @@ class TestMergeDuplicates:
                 pd.DataFrame(
                     {
                         "identifiant_unique": [1],
-                        "souscategorie_codes": [["Glass", "Metal", "Paper", "Plastic"]],
+                        "label_codes": [["Glass", "Metal", "Paper", "Plastic"]],
                         "other_column": ["A"],
                     }
                 ),
@@ -102,7 +100,7 @@ class TestMergeDuplicates:
                 pd.DataFrame(
                     {
                         "identifiant_unique": [1, 1, 2, 3, 3, 3],
-                        "souscategorie_codes": [
+                        "label_codes": [
                             ["Plastic", "Metal"],
                             ["Metal", "Glass"],
                             ["Paper"],
@@ -116,7 +114,7 @@ class TestMergeDuplicates:
                 pd.DataFrame(
                     {
                         "identifiant_unique": [1, 2, 3],
-                        "souscategorie_codes": [
+                        "label_codes": [
                             ["Glass", "Metal", "Plastic"],
                             ["Paper"],
                             ["Glass", "Metal", "Plastic"],
@@ -127,9 +125,184 @@ class TestMergeDuplicates:
             ),
         ],
     )
-    def test_merge_duplicates(self, df, expected_df):
+    def test_merge_duplicates_list(self, df, expected_df):
 
-        result_df = merge_duplicates(df)
+        result_df = merge_duplicates(
+            df,
+            group_column="identifiant_unique",
+            merge_as_list_columns=["label_codes"],
+        )
+
+        result_df = result_df.sort_values(by="identifiant_unique").reset_index(
+            drop=True
+        )
+        expected_df = expected_df.sort_values(by="identifiant_unique").reset_index(
+            drop=True
+        )
+
+        pd.testing.assert_frame_equal(result_df, expected_df)
+
+    @pytest.mark.parametrize(
+        "df, expected_df",
+        [
+            (
+                pd.DataFrame(
+                    {
+                        "identifiant_unique": [1, 1],
+                        "proposition_services_codes": [[], []],
+                    }
+                ),
+                pd.DataFrame(
+                    {
+                        "identifiant_unique": [1],
+                        "proposition_services_codes": [[]],
+                    }
+                ),
+            ),
+            (
+                pd.DataFrame(
+                    {
+                        "identifiant_unique": [1, 1],
+                        "proposition_services_codes": [
+                            [
+                                {
+                                    "action": "action1",
+                                    "sous_categories": ["sscat1", "sscat2"],
+                                }
+                            ],
+                            [],
+                        ],
+                    }
+                ),
+                pd.DataFrame(
+                    {
+                        "identifiant_unique": [1],
+                        "proposition_services_codes": [
+                            [
+                                {
+                                    "action": "action1",
+                                    "sous_categories": ["sscat1", "sscat2"],
+                                }
+                            ]
+                        ],
+                    }
+                ),
+            ),
+            (
+                pd.DataFrame(
+                    {
+                        "identifiant_unique": [1, 1],
+                        "proposition_services_codes": [
+                            [
+                                {
+                                    "action": "action1",
+                                    "sous_categories": ["sscat1", "sscat2"],
+                                }
+                            ],
+                            [
+                                {
+                                    "action": "action1",
+                                    "sous_categories": ["sscat1", "sscat2"],
+                                }
+                            ],
+                        ],
+                    }
+                ),
+                pd.DataFrame(
+                    {
+                        "identifiant_unique": [1],
+                        "proposition_services_codes": [
+                            [
+                                {
+                                    "action": "action1",
+                                    "sous_categories": ["sscat1", "sscat2"],
+                                }
+                            ]
+                        ],
+                    }
+                ),
+            ),
+            (
+                pd.DataFrame(
+                    {
+                        "identifiant_unique": [1, 1],
+                        "proposition_services_codes": [
+                            [
+                                {
+                                    "action": "action1",
+                                    "sous_categories": ["sscat2"],
+                                }
+                            ],
+                            [
+                                {
+                                    "action": "action1",
+                                    "sous_categories": ["sscat1"],
+                                }
+                            ],
+                        ],
+                    }
+                ),
+                pd.DataFrame(
+                    {
+                        "identifiant_unique": [1],
+                        "proposition_services_codes": [
+                            [
+                                {
+                                    "action": "action1",
+                                    "sous_categories": ["sscat1", "sscat2"],
+                                }
+                            ]
+                        ],
+                    }
+                ),
+            ),
+            (
+                pd.DataFrame(
+                    {
+                        "identifiant_unique": [1, 1],
+                        "proposition_services_codes": [
+                            [
+                                {
+                                    "action": "action1",
+                                    "sous_categories": ["sscat1", "sscat2"],
+                                }
+                            ],
+                            [
+                                {
+                                    "action": "action2",
+                                    "sous_categories": ["sscat1"],
+                                }
+                            ],
+                        ],
+                    }
+                ),
+                pd.DataFrame(
+                    {
+                        "identifiant_unique": [1],
+                        "proposition_services_codes": [
+                            [
+                                {
+                                    "action": "action1",
+                                    "sous_categories": ["sscat1", "sscat2"],
+                                },
+                                {
+                                    "action": "action2",
+                                    "sous_categories": ["sscat1"],
+                                },
+                            ],
+                        ],
+                    }
+                ),
+            ),
+        ],
+    )
+    def test_merge_duplicates_ps_dict(self, df, expected_df):
+
+        result_df = merge_duplicates(
+            df,
+            group_column="identifiant_unique",
+            merge_as_proposition_service_columns=["proposition_services_codes"],
+        )
 
         result_df = result_df.sort_values(by="identifiant_unique").reset_index(
             drop=True


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [[EOs] ignore_duplicate devrait être merge_duplicate ?](https://www.notion.so/accelerateur-transition-ecologique-ademe/EOs-ignore_duplicate-devrait-tre-merge_duplicate-1926523d57d7800087a3ccbd8b18d522?pvs=4)

**🗺️ contexte**: Ingestion de source via airflow

**💡 quoi**: Fusionner les duplicat en gardant les labels, acteur_services et proposition_services de toutes les versions de l'acteur dans le fichier source

**🎯 pourquoi**: ECODDS envoie une ligne par couple acteur/filiaire, il est aussi possible qu'il y ait plusieur ligne si un acteur répare un type d'objet et trie un autre type

**🤔 comment**: 

- Merge des duplicats -> prendre le premier enregistrement pour chaque champ (excepté pour les objets liés)
- Labels et acteur_services -> on cumule et déduplique les listes
- Proposition de service, on merge par action et déduplique les sous-categories pour chaque action
- Ajout de tests
- Suppression des options : `merge_duplicate` et `merge_duplicated_acteurs` qui deviennent caduques

## Exemple résultats / UI / Data

![CleanShot 2025-02-19 at 11 55 15](https://github.com/user-attachments/assets/1f625c66-a3d2-4b50-889c-eb30a0be4b1d)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [x] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] Ajout d'information sur les duplicats dans les metadata de la cohorte