### PR TITLE
Suppression d'un reverse en trop

### DIFF
--- a/qfdmo/admin/acteur.py
+++ b/qfdmo/admin/acteur.py
@@ -11,7 +11,6 @@ from django.db.models import Subquery
 from django.db.models.functions import Lower
 from django.forms import CharField
 from django.http import HttpRequest, HttpResponseRedirect
-from django.urls import reverse
 from django.utils.html import format_html
 from import_export import admin as import_export_admin
 from import_export import fields, resources, widgets
@@ -388,7 +387,7 @@ class RevisionActeurAdmin(import_export_admin.ImportExportMixin, BaseActeurAdmin
             if not revision_acteur.parent:
                 revision_acteur.create_parent()
             revision_acteur = revision_acteur.duplicate()
-            return HttpResponseRedirect(reverse(revision_acteur.change_url))
+            return HttpResponseRedirect(revision_acteur.change_url)
 
         return super().response_change(request, revision_acteur)
 


### PR DESCRIPTION
# Description succincte du problème résolu

Suite de la PR #1349
Sentry : https://sentry.incubateur.net/organizations/betagouv/issues/151409/?alert_rule_id=74&alert_timestamp=1740024262374&alert_type=email&environment=staging&notification_uuid=5dea7311-6cea-4471-a023-97040683674e&project=115&referrer=alert_email

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: django admin

**💡 quoi**: le lien dupliqué est cassé

**🎯 pourquoi**: un reverse en trop

**🤔 comment**: suppression du reverse

## Exemple résultats / UI / Data

![CleanShot 2025-02-20 at 05 26 54](https://github.com/user-attachments/assets/8b0be858-2021-4d49-bee6-f67ec3fba6a3)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [x] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
