### PR TITLE
🔇CLUSTERING: exclure les enfants existants du contexte

### DIFF
--- a/dags/cluster/tasks/business_logic/cluster_acteurs_suggestions/contexte.py
+++ b/dags/cluster/tasks/business_logic/cluster_acteurs_suggestions/contexte.py
@@ -1,6 +1,7 @@
 """Generates the data stored in Suggestion.contexte field"""
 
 import pandas as pd
+from cluster.config.constants import COL_PARENT_ID_BEFORE
 
 
 def suggestion_contexte_generate(
@@ -23,6 +24,15 @@ def suggestion_contexte_generate(
     df_cluster = df_cluster[
         df_cluster[COL_CHANGE_MODEL_NAME] != ChangeActeurCreateAsParent.name()
     ]
+    # We exclude existing children because these were are as-is
+    # purely based on their previous parent_id. Right now if we include
+    # them here they can break the exacts.groups.keys() == 1 check because:
+    # - they might be missing data (Revisions only have changes)
+    # - we didn't do ANY normalization on them since they are re-attached as-is
+    # Once we introduce the feature to re-cluster children:
+    # - the issue will naturally go away (beacuse we will be forced to process them)
+    # - TODO: we will need to make the below exclusion conditional on above feature
+    df_cluster = df_cluster[df_cluster[COL_PARENT_ID_BEFORE].isnull()]
 
     # Ensuring we have 1 exact group:
     # - intentionally NOT dropping NAs (we shouldn't have any)


### PR DESCRIPTION
# 🔇CLUSTERING: exclure les enfants existants du contexte

Carte Notion: [🔇CLUSTERING: exclure les enfants existants du contexte](https://www.notion.so/accelerateur-transition-ecologique-ademe/CLUSTERING-exclure-les-enfants-existants-du-contexte-1a06523d57d780d2a4bcf4d338d1e683)

**🗺️ contexte**: clustering des acteurs

**💡 quoi**: exclure les enfants existants du contexte

**🎯 pourquoi**: ils peuvent créer des **false-positives** au niveau des checks de suggestions parce que:
   - on vérifie que toutes les données des champs `cluster_fields_exact` sont identiques
   - or les enfants peuvent diverger puisque rattachés tels-quels (on a pas encore fait [CLUSTERING & DEDUP: re-clusteriser les enfants existants](https://www.notion.so/accelerateur-transition-ecologique-ademe/CLUSTERING-DEDUP-re-clusteriser-les-enfants-existants-1956523d57d7801abe3bc132ec7e33b0) donc 0 norma/traitement sur enfants d'où divergences)

**🤔 comment**:
 - on exclue les enfants dans la fonction `suggestion_contexte_generate`
 - ajout d'un test dans `test_cluster_acteurs_suggestions_contexte_generate` pour empêcher régression

## :arrow_down: Conséquences

Vu à l'instant avec @chrischarousset qui est OK avec le compromis
 - on va **perdre de la donnée de contexte sur les enfants existants**: c'est OK vu que les enfants sont uniquement rattachés, mais cela aurait pu nous aider à déceler des clusters existants mauvais
 - on fera une **prochaine PR pour améliorer** la façon dont on génère le contexte
