### PR TITLE
🔍 Ajout de champs d'autocomplétion sur les produits / liens et synonymes

### DIFF
--- a/qfdmd/admin.py
+++ b/qfdmd/admin.py
@@ -101,6 +101,7 @@ class LienInline(admin.StackedInline):
 
 class ProduitInline(admin.StackedInline):
     model = Produit.liens.through
+    autocomplete_fields = ["produit"]
     extra = 0
 
 
@@ -156,6 +157,7 @@ class SynonymeAdmin(
     readonly_fields = ["slug"]
     list_display = ("nom", "produit", "slug", "modifie_le")
     list_filter = ["pin_on_homepage"]
+    autocomplete_fields = ["produit"]
     fields_to_display_in_first_position = ["nom", "produit"]
 
 


### PR DESCRIPTION
# Description succincte du problème résolu

[Améliorer la liste des produits pour les liens ](https://www.notion.so/accelerateur-transition-ecologique-ademe/ADMIN-Am-liorer-la-liste-des-produits-pour-les-liens-18f6523d57d78042bf6bcc4ab78f3af4?pvs=4)


**🗺️ contexte**:
Amélioration de l'administration django 

**💡 quoi**:
Autocomplétion dans les champs produits 

**🎯 pourquoi**: 
Pour améliorer la vie de Camille Christian et Delphine :) 

**🤔 comment**:
En utilisant la fonctionnalité [autocomplete fields](https://docs.djangoproject.com/en/5.1/ref/contrib/admin/#django.contrib.admin.ModelAdmin.autocomplete_fields) de Django 

## Exemple résultats / UI / Data

<img width="1612" alt="image" src="https://github.com/user-attachments/assets/300eae7d-9aeb-4ad0-8308-f43be2ca9116" />
<img width="1612" alt="image" src="https://github.com/user-attachments/assets/8ff9e9ea-e2e3-4955-8b3c-b7f4da5951cd" />


## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
