### PR TITLE
🔀 Ajouter le comportement de plusieurs sélections de catégories / sous catégories à chaque proposition de service (plutôt que la première)

### DIFF
--- a/static/to_compile/js/controllers/admin/categorie_widget_controller.ts
+++ b/static/to_compile/js/controllers/admin/categorie_widget_controller.ts
@@ -6,7 +6,7 @@ export default class extends Controller<HTMLFormElement> {
 
   syncSousCategorie(event) {
     const sousCategories: HTMLSelectElement = this.element
-      .closest("fieldset")
+      .closest("tr")
       .querySelector(`select[multiple]:not(#${this.element.id})`)!
 
     const categoriesSelected = [...event.target.options]


### PR DESCRIPTION
# Description succincte du problème résolu

[Nouveau combo-select par catégorie dans Django Admin : fonctionne sur le 1er bloc mais pas le 2ème](https://www.notion.so/accelerateur-transition-ecologique-ademe/Nouveau-combo-select-par-cat-gorie-dans-Django-Admin-fonctionne-sur-le-1er-bloc-mais-pas-le-2-me-1526523d57d780cfa94bcd1b81978797?pvs=4)

**🗺️ contexte**: 
Administration django

**💡 quoi**: 
Méthode de sélection des sous catégories d'une proposition de service d'un acteur corrigé

**🎯 pourquoi**:
Pour corriger un dysfonctionnement 

**🤔 comment**:
Plutôt que de cibler le `fieldset` parent on s'intéresse à la ligne du tableau. 
En effet, dans django admin on a l'arborescence suivante pour ce type de formulaires : 
```
fieldset
- table 
- - table row
- - - colonne formulaire catégories
- - - colonne formulaire sous catégories
```

jusque là on _écoutait_ (via un event listener) la modification d'une catégorie pour "remonter" (via un appel à querySelector) au `fieldset` parent et sélectionner les sous-catégories associées dans le `select`, sauf que le `fieldset` étant commun à toutes
les propositions de services affichées dans la UI, ça ne fonctionne qu'avec une seule proposition de service dans la liste. 

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

