### PR TITLE
Suppression de l'enquête dans le footer

### DIFF
--- a/templates/components/footer/_standalone.html
+++ b/templates/components/footer/_standalone.html
@@ -42,16 +42,3 @@
     </a>.
     </p>
 </section>
-<section class="fr-container">
-    <h2>Comment contribuer au développement de cet outil ?</h2>
-    <p>
-        Vous pouvez répondre <a
-            href="{% url 'qfdmd:assistant-survey-form' %}"
-            title="Enquête, formulaire- Nouvelle fenêtre"
-            target="_blank"
-            rel="noreferrer"
-        >
-           à notre enquête
-        </a>. Votre participation est importante pour s'assurer que nous développons un outil pertinent et répondant à vos besoins.
-    </p>
-</section>


### PR DESCRIPTION
Suppression du lien vers l'enquête en bas du footer, tout passe par le formulaire de contact pour le support usager

# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [Support - Enlever le Tally recherche du footer de l’assistant](https://www.notion.so/accelerateur-transition-ecologique-ademe/Support-Enlever-le-Tally-recherche-du-footer-de-l-assistant-1a16523d57d780bfba1ef5fccb700025?pvs=4)

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: <!-- Quelle épic / opportinuté est concernée ? -->

**💡 quoi**: <!-- description de ce qu'on est en train de changer -->

**🎯 pourquoi**: <!-- pourquoi on fait ce changement -->
Un seul point de contact pour les usagers : formulaire de contact (via l'enveloppe)

**🤔 comment**: <!-- Descrire l'ensemble des tâches réalisées (bullet points) -->

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [X] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
