### PR TITLE
Fix un pb de colonne lors de l'ingestion de SINOE

### DIFF
--- a/dags/sources/dags/source_sinoe.py
+++ b/dags/sources/dags/source_sinoe.py
@@ -1,4 +1,5 @@
 from airflow import DAG
+from sources.config import shared_constants as constants
 from sources.config.airflow_params import (
     get_mapping_config,
     source_sinoe_dechet_mapping_get,
@@ -82,6 +83,10 @@ with DAG(
             {
                 "column": "source_code",
                 "value": "ademesinoedecheteries",
+            },
+            {
+                "column": "statut",
+                "value": constants.ACTEUR_ACTIF,
             },
             # 4. Transformation du dataframe
             {

--- a/dags/sources/tasks/transform/transform_df.py
+++ b/dags/sources/tasks/transform/transform_df.py
@@ -32,6 +32,7 @@ MANDATORY_COLUMNS_AFTER_NORMALISATION = [
     "proposition_service_codes",
     "source_code",
     "acteur_type_code",
+    "statut",
 ]
 REGEX_BAN_SEPARATORS = r"\s,;"
 

--- a/dags/utils/django.py
+++ b/dags/utils/django.py
@@ -230,7 +230,7 @@ def get_model_fields(model, with_relationships=True, latlong=False):
         if field.is_relation and not with_relationships:
             continue
         if field.one_to_many or field.many_to_many:
-            fields.append(field.name[0:-1] + "_codes")
+            fields.append(field.name.rstrip("s") + "_codes")
         elif field.many_to_one:
             fields.append(field.name + "_code")
         else:

--- a/dags/utils/django.py
+++ b/dags/utils/django.py
@@ -222,3 +222,21 @@ def django_schema_create_and_check(schema_name: str, sql: str, dry_run=True) -> 
     if schema_name not in tables_all:
         raise SystemError(f"Table pas crée malgré execution SQL OK: {schema_name}")
     logger.info(f"Création schema pour {schema_name=}: succès 🟢")
+
+
+def get_model_fields(model, with_relationships=True, latlong=False):
+    fields = []
+    for field in model._meta.get_fields():
+        if field.is_relation and not with_relationships:
+            continue
+        if field.one_to_many or field.many_to_many:
+            fields.append(field.name[0:-1] + "_codes")
+        elif field.many_to_one:
+            fields.append(field.name + "_code")
+        else:
+            fields.append(field.name)
+    if latlong:
+        fields.extend(["latitude", "longitude"])
+        if "location" in fields:
+            fields.remove("location")
+    return fields

--- a/dags_unit_tests/conftest.py
+++ b/dags_unit_tests/conftest.py
@@ -145,6 +145,7 @@ def dag_config():
                     "proposition_service_codes",
                     "source_code",
                     "acteur_type_code",
+                    "statut",
                 ]
             ],
             "endpoint": "https://example.com/api",

--- a/dags_unit_tests/sources/tasks/business_logic/test_keep_acteur_changed.py
+++ b/dags_unit_tests/sources/tasks/business_logic/test_keep_acteur_changed.py
@@ -1051,6 +1051,7 @@ def test_keep_acteur_changed_same_acteur_but_different_identifiant_unique2(dag_c
             "acteur_type_code": [[], []],
             "acteur_service_codes": [[], []],
             "proposition_service_codes": [[], []],
+            "statut": ["actif", "actif"],
         }
     )
     df_acteur_from_db = pd.DataFrame(
@@ -1063,6 +1064,7 @@ def test_keep_acteur_changed_same_acteur_but_different_identifiant_unique2(dag_c
             "acteur_type_code": [[], []],
             "acteur_service_codes": [[], []],
             "proposition_service_codes": [[], []],
+            "statut": ["actif", "actif"],
         }
     )
     df_expected = pd.DataFrame(
@@ -1075,6 +1077,7 @@ def test_keep_acteur_changed_same_acteur_but_different_identifiant_unique2(dag_c
             "acteur_type_code": [[]],
             "acteur_service_codes": [[]],
             "proposition_service_codes": [[]],
+            "statut": ["actif"],
         }
     )
     df_expected_from_db = pd.DataFrame(
@@ -1087,6 +1090,7 @@ def test_keep_acteur_changed_same_acteur_but_different_identifiant_unique2(dag_c
             "acteur_type_code": [[]],
             "acteur_service_codes": [[]],
             "proposition_service_codes": [[]],
+            "statut": ["actif"],
         }
     )
 

--- a/dags_unit_tests/sources/tasks/business_logic/test_keep_acteur_changed.py
+++ b/dags_unit_tests/sources/tasks/business_logic/test_keep_acteur_changed.py
@@ -21,6 +21,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "acteur_type_code": [],
                     "acteur_service_codes": [],
                     "proposition_service_codes": [],
+                    "statut": [],
                 }
             ),
             pd.DataFrame(
@@ -33,6 +34,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "acteur_type_code": [],
                     "acteur_service_codes": [],
                     "proposition_service_codes": [],
+                    "statut": [],
                 }
             ),
             pd.DataFrame(
@@ -45,6 +47,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "acteur_type_code": [],
                     "acteur_service_codes": [],
                     "proposition_service_codes": [],
+                    "statut": [],
                 }
             ),
             pd.DataFrame(
@@ -57,6 +60,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "acteur_type_code": [],
                     "acteur_service_codes": [],
                     "proposition_service_codes": [],
+                    "statut": [],
                 }
             ),
             {},
@@ -93,6 +97,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             },
                         ],
                     ],
+                    "statut": ["actif", "actif"],
                 }
             ),
             pd.DataFrame(
@@ -125,6 +130,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             },
                         ],
                     ],
+                    "statut": ["actif", "actif"],
                 }
             ),
             pd.DataFrame(
@@ -137,6 +143,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "acteur_type_code": pd.Series([], dtype="object"),
                     "acteur_service_codes": pd.Series([], dtype="object"),
                     "proposition_service_codes": pd.Series([], dtype="object"),
+                    "statut": pd.Series([], dtype="object"),
                 }
             ),
             pd.DataFrame(
@@ -149,6 +156,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "acteur_type_code": pd.Series([], dtype="object"),
                     "acteur_service_codes": pd.Series([], dtype="object"),
                     "proposition_service_codes": pd.Series([], dtype="object"),
+                    "statut": pd.Series([], dtype="object"),
                 }
             ),
             {},
@@ -185,6 +193,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             },
                         ],
                     ],
+                    "statut": ["actif", "actif"],
                 }
             ),
             pd.DataFrame(
@@ -217,6 +226,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             },
                         ],
                     ],
+                    "statut": ["actif", "actif"],
                 }
             ),
             pd.DataFrame(
@@ -229,6 +239,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "acteur_type_code": pd.Series([], dtype="object"),
                     "acteur_service_codes": pd.Series([], dtype="object"),
                     "proposition_service_codes": pd.Series([], dtype="object"),
+                    "statut": pd.Series([], dtype="object"),
                 }
             ),
             pd.DataFrame(
@@ -241,6 +252,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "acteur_type_code": pd.Series([], dtype="object"),
                     "acteur_service_codes": pd.Series([], dtype="object"),
                     "proposition_service_codes": pd.Series([], dtype="object"),
+                    "statut": pd.Series([], dtype="object"),
                 }
             ),
             {},
@@ -266,6 +278,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             }
                         ],
                     ],
+                    "statut": ["actif"],
                 }
             ),
             pd.DataFrame(
@@ -287,6 +300,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             }
                         ],
                     ],
+                    "statut": ["actif"],
                 }
             ),
             pd.DataFrame(
@@ -308,6 +322,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             }
                         ],
                     ],
+                    "statut": ["actif"],
                 }
             ),
             pd.DataFrame(
@@ -329,6 +344,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             }
                         ],
                     ],
+                    "statut": ["actif"],
                 }
             ),
             {
@@ -359,6 +375,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             }
                         ],
                     ],
+                    "statut": ["actif"],
                 }
             ),
             pd.DataFrame(
@@ -380,6 +397,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             }
                         ],
                     ],
+                    "statut": ["actif"],
                 }
             ),
             pd.DataFrame(
@@ -401,6 +419,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             }
                         ],
                     ],
+                    "statut": ["actif"],
                 }
             ),
             pd.DataFrame(
@@ -422,6 +441,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             }
                         ],
                     ],
+                    "statut": ["actif"],
                 }
             ),
             {
@@ -452,6 +472,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             }
                         ],
                     ],
+                    "statut": ["actif"],
                 }
             ),
             pd.DataFrame(
@@ -473,6 +494,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             }
                         ],
                     ],
+                    "statut": ["actif"],
                 }
             ),
             pd.DataFrame(
@@ -494,6 +516,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             }
                         ],
                     ],
+                    "statut": ["actif"],
                 }
             ),
             pd.DataFrame(
@@ -515,6 +538,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             }
                         ],
                     ],
+                    "statut": ["actif"],
                 }
             ),
             {
@@ -545,6 +569,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             }
                         ],
                     ],
+                    "statut": ["actif"],
                 }
             ),
             pd.DataFrame(
@@ -566,6 +591,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             }
                         ],
                     ],
+                    "statut": ["actif"],
                 }
             ),
             pd.DataFrame(
@@ -587,6 +613,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             }
                         ],
                     ],
+                    "statut": ["actif"],
                 }
             ),
             pd.DataFrame(
@@ -608,6 +635,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             }
                         ],
                     ],
+                    "statut": ["actif"],
                 }
             ),
             {
@@ -629,6 +657,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "acteur_type_code": [],
                     "acteur_service_codes": [],
                     "proposition_service_codes": [],
+                    "statut": [],
                 }
             ),
             pd.DataFrame(
@@ -650,6 +679,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             }
                         ],
                     ],
+                    "statut": ["actif"],
                 }
             ),
             pd.DataFrame(
@@ -662,6 +692,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "acteur_type_code": [],
                     "acteur_service_codes": [],
                     "proposition_service_codes": [],
+                    "statut": [],
                 }
             ),
             pd.DataFrame(
@@ -683,6 +714,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             }
                         ],
                     ],
+                    "statut": ["actif"],
                 }
             ),
             {},
@@ -708,6 +740,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             }
                         ],
                     ],
+                    "statut": ["actif"],
                 }
             ),
             pd.DataFrame(
@@ -720,6 +753,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "acteur_type_code": [],
                     "acteur_service_codes": [],
                     "proposition_service_codes": [],
+                    "statut": [],
                 }
             ),
             pd.DataFrame(
@@ -741,6 +775,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             }
                         ],
                     ],
+                    "statut": ["actif"],
                 }
             ),
             pd.DataFrame(
@@ -753,6 +788,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "acteur_type_code": [],
                     "acteur_service_codes": [],
                     "proposition_service_codes": [],
+                    "statut": [],
                 }
             ),
             {},
@@ -778,6 +814,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             }
                         ],
                     ],
+                    "statut": ["actif"],
                 }
             ),
             pd.DataFrame(
@@ -792,6 +829,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                         ["service1", "service2"],
                     ],
                     "proposition_service_codes": [[]],
+                    "statut": ["actif"],
                 }
             ),
             pd.DataFrame(
@@ -813,6 +851,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             }
                         ],
                     ],
+                    "statut": ["actif"],
                 }
             ),
             pd.DataFrame(
@@ -827,6 +866,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                         ["service1", "service2"],
                     ],
                     "proposition_service_codes": [[]],
+                    "statut": ["actif"],
                 }
             ),
             {
@@ -852,6 +892,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                         ["service1", "service2"],
                     ],
                     "proposition_service_codes": [[]],
+                    "statut": ["actif"],
                 }
             ),
             pd.DataFrame(
@@ -873,6 +914,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             }
                         ],
                     ],
+                    "statut": ["actif"],
                 }
             ),
             pd.DataFrame(
@@ -887,6 +929,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                         ["service1", "service2"],
                     ],
                     "proposition_service_codes": [[]],
+                    "statut": ["actif"],
                 }
             ),
             pd.DataFrame(
@@ -908,6 +951,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                             }
                         ],
                     ],
+                    "statut": ["actif"],
                 }
             ),
             {

--- a/dags_unit_tests/sources/tasks/business_logic/test_keep_acteur_changed.py
+++ b/dags_unit_tests/sources/tasks/business_logic/test_keep_acteur_changed.py
@@ -999,6 +999,7 @@ def test_keep_acteur_changed_same_acteur_but_different_identifiant_unique(dag_co
             "acteur_type_code": [[]],
             "acteur_service_codes": [[]],
             "proposition_service_codes": [[]],
+            "statut": ["actif"],
         }
     )
     df_acteur_from_db = pd.DataFrame(
@@ -1011,6 +1012,7 @@ def test_keep_acteur_changed_same_acteur_but_different_identifiant_unique(dag_co
             "acteur_type_code": [[]],
             "acteur_service_codes": [[]],
             "proposition_service_codes": [[]],
+            "statut": ["actif"],
         }
     )
     df_expected = pd.DataFrame(
@@ -1023,6 +1025,7 @@ def test_keep_acteur_changed_same_acteur_but_different_identifiant_unique(dag_co
             "acteur_type_code": [],
             "acteur_service_codes": [],
             "proposition_service_codes": [],
+            "statut": [],
         }
     )
 

--- a/dags_unit_tests/utils/test_django.py
+++ b/dags_unit_tests/utils/test_django.py
@@ -138,6 +138,7 @@ def test_get_model_fields():
         "acteur_service_codes",
         "latitude",
         "longitude",
+        "siret_is_closed",
     }
 
     fields = get_model_fields(Acteur, with_relationships=False, latlong=False)
@@ -169,4 +170,5 @@ def test_get_model_fields():
         "exclusivite_de_reprisereparation",
         "uniquement_sur_rdv",
         "location",
+        "siret_is_closed",
     }

--- a/dags_unit_tests/utils/test_django.py
+++ b/dags_unit_tests/utils/test_django.py
@@ -6,6 +6,7 @@ from utils.django import (
     django_model_queryset_to_sql,
     django_model_to_pandas_schema,
     django_setup_full,
+    get_model_fields,
 )
 
 django_setup_full()
@@ -96,3 +97,76 @@ def test_django_model_to_pandas_schema():
     assert df["code_postal"].tolist() == ["01000", "53000", "75000"]
     assert df["source_id"].tolist() == [1, 2, 3]
     assert df["acteur_type_id"].tolist() == [1, 2, 3]
+
+
+def test_get_model_fields():
+    from qfdmo.models import Acteur
+
+    fields = get_model_fields(Acteur, with_relationships=True, latlong=True)
+    assert set(fields) == {
+        "proposition_service_codes",
+        "cree_le",
+        "modifie_le",
+        "nom",
+        "description",
+        "identifiant_unique",
+        "acteur_type_code",
+        "adresse",
+        "adresse_complement",
+        "code_postal",
+        "ville",
+        "url",
+        "email",
+        "telephone",
+        "nom_commercial",
+        "nom_officiel",
+        "siren",
+        "siret",
+        "source_code",
+        "identifiant_externe",
+        "statut",
+        "naf_principal",
+        "commentaires",
+        "horaires_osm",
+        "horaires_description",
+        "public_accueilli",
+        "reprise",
+        "exclusivite_de_reprisereparation",
+        "uniquement_sur_rdv",
+        "action_principale_code",
+        "label_codes",
+        "acteur_service_codes",
+        "latitude",
+        "longitude",
+    }
+
+    fields = get_model_fields(Acteur, with_relationships=False, latlong=False)
+    assert set(fields) == {
+        "cree_le",
+        "modifie_le",
+        "nom",
+        "description",
+        "identifiant_unique",
+        "adresse",
+        "adresse_complement",
+        "code_postal",
+        "ville",
+        "url",
+        "email",
+        "telephone",
+        "nom_commercial",
+        "nom_officiel",
+        "siren",
+        "siret",
+        "identifiant_externe",
+        "statut",
+        "naf_principal",
+        "commentaires",
+        "horaires_osm",
+        "horaires_description",
+        "public_accueilli",
+        "reprise",
+        "exclusivite_de_reprisereparation",
+        "uniquement_sur_rdv",
+        "location",
+    }

--- a/data/models/suggestion.py
+++ b/data/models/suggestion.py
@@ -236,7 +236,8 @@ class Suggestion(models.Model):
             updated_fields = {}
             unchanged_fields = {}
             for key, value in self.suggestion.items():
-                if key not in self.contexte:
+                # Ignore location because it is already displayed with lat / long fields
+                if key not in self.contexte or key == "location":
                     continue
                 if self.contexte.get(key) != value:
                     updated_fields[key] = {"new": value, "old": self.contexte.get(key)}


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [DAG SINOE bloqué - problème avec la colonne ANNÉE](https://www.notion.so/accelerateur-transition-ecologique-ademe/DAG-SINOE-bloqu-probl-me-avec-la-colonne-ANN-E-1ac6523d57d780d0ba7ef7ba1323ede3?pvs=4)

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Airflow - Source

**💡 quoi**: Le DAG d'ingestion des source SINOE ne fonctionne plus

**🎯 pourquoi**: La colonne ANNEE n'est pas ignoré lors de la récupération des acteurs en DB et de la comparaison des source SINOE avec la base de données

**🤔 comment**: 

- ajout de la colonne statut nécessaire à l'execution de l'ingestion
- limiter la récupération en base de données au champs disponible en DB
- limiter la comparaison aux champs de la base + les relations de l'objet Acteur

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [x] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code


## 📆 A faire (prochaine PR)

- [ ] Gestion des champs de la DB acteur et des relations de manière centralisé