### PR TITLE
Correction du selecteur parent das l'admin revision acteur

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,14 +60,14 @@ run-airflow:
 
 .PHONY: run-django
 run-django:
+	docker compose --profile lvao up -d
 	rm -rf .parcel-cache
 	honcho start -f Procfile.dev
 
 run-all:
 	docker compose --profile airflow up -d
 	rm -rf .parcel-cache
-	$(DJANGO_ADMIN) runserver 0.0.0.0:8000
-	npm run watch
+	honcho start -f Procfile.dev
 
 # Local django operations
 .PHONY: migrate


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [[Django Admin] Régression : le menu pour sélectionner un parent propose des enfants](https://www.notion.so/accelerateur-transition-ecologique-ademe/Django-Admin-R-gression-le-menu-pour-s-lectionner-un-parent-propose-des-enfants-1a06523d57d780ee8ad4d29a046700b8?pvs=4)

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Django Admin

**💡 quoi**: le selecteur de parent sur RévisionActeur affiche tous les RévisionActeur alors que seul les RévisionActeur qui sont déjà des parents doivent apparaitre

**🎯 pourquoi**: Régression de l'implémentation de l'interdiction de créer ou supprimer le parent à partir du selecteur

**🤔 comment**: 

- Déplacement de la logique se selection sur l'objet PrantActeurAdmin précédemment implémenté au niveau du champ
- Suppression de l'icone d'édition à coté du selecteur
- Correction du redirect de l'icone `view`

## Exemple résultats / UI / Data

![CleanShot 2025-03-04 at 09 05 26@2x](https://github.com/user-attachments/assets/e352dd00-1893-473b-800e-35a4971c5f49)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [x] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

