### PR TITLE
Les Picto ne s'affichent plus sur la page d'accueil de QFDMO

### DIFF
--- a/qfdmd/templatetags/qfdmd_tags.py
+++ b/qfdmd/templatetags/qfdmd_tags.py
@@ -26,16 +26,18 @@ def render_file_content(file_field: FileField) -> str:
     """Renders the content of a Filefield as a safe HTML string
     and caches the result."""
 
-    return ""
-
     def get_file_content() -> str:
-        with file_field.open() as f:
+        if not file_field or not file_field.storage.exists(file_field.name):
+            return ""
+        with file_field.storage.open(file_field.name) as f:
             return mark_safe(f.read().decode("utf-8"))  # noqa: S308
 
     return cast(
         str,
         cache.get_or_set(
-            f"filefield-{file_field.name}-{file_field.size}", get_file_content
+            f"filefield-{file_field.name}-"
+            f"{file_field.size if hasattr(file_field, 'size') else 0}",
+            get_file_content,
         ),
     )
 


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Mattermost : [hello ! ptit bug sur la prod, la home n'affiche plus les illustrations 🙊](https://mattermost.incubateur.net/betagouv/pl/ymmro5zbiff85cqkogazc57axh)

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Page d'accueil de QFDMD

**💡 quoi**: Les picto ne s'affichent pas

**🎯 pourquoi**: il y a un `return ""` suspect

**🤔 comment**: 

- suppression du `return ""`
- gérer si le fichier n'existe pas

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [x] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## 📆 A faire (prochaine PR)

- [ ] Vérifier avec @fabienheureux si cette correction est correcte ?
