### PR TITLE
Suite : Les Picto ne s'affichent plus sur la page d'accueil de QFDMO

### DIFF
--- a/qfdmd/templatetags/qfdmd_tags.py
+++ b/qfdmd/templatetags/qfdmd_tags.py
@@ -9,6 +9,8 @@ from django.utils.safestring import mark_safe
 
 register = template.Library()
 
+logger = logging.getLogger(__name__)
+
 
 @register.inclusion_tag("components/patchwork/patchwork.html")
 def patchwork() -> dict:
@@ -34,7 +36,7 @@ def render_file_content(file_field: FileField) -> str:
             with file_field.storage.open(file_field.name) as f:
                 return mark_safe(f.read().decode("utf-8"))  # noqa: S308
         except FileNotFoundError as e:
-            logging.error(f"file not found {file_field.name=}, original error : {e}")
+            logger.error(f"file not found {file_field.name=}, original error : {e}")
             return ""
 
     return cast(


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Mattermost : [hello ! ptit bug sur la prod, la home n'affiche plus les illustrations 🙊](https://mattermost.incubateur.net/betagouv/pl/ymmro5zbiff85cqkogazc57axh)

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Page d'accueil de QFDMD

**💡 quoi**: Les picto ne s'affichent pas

**🎯 pourquoi**: le comportement du FileField.stockage est diférent entre un stockage local et un stockage S3 via CleverCloud

**🤔 comment**: 

- Gestion de l'existance de fichier avec un try except

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
