### PR TITLE
prevent undefined variable error when clicking first item in results

### DIFF
--- a/static/to_compile/js/controllers/assistant/search.ts
+++ b/static/to_compile/js/controllers/assistant/search.ts
@@ -11,7 +11,7 @@ export default class extends Controller<HTMLFormElement> {
   submitFirstItem() {
     const firstResult = document.querySelector<HTMLAnchorElement>("#search-results > a")
     if (firstResult) {
-      result.click()
+      firstResult.click()
     }
   }
 


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [Saisie d’un objet, préselection du 1er objet dans la liste](https://www.notion.so/accelerateur-transition-ecologique-ademe/AST-1-Saisie-d-un-objet-pr-selection-du-1er-objet-dans-la-liste-17d6523d57d7809d951ec15e342687b5?pvs=4)


**🗺️ contexte**: La PR #1380 était incomplète, elle n'est pas fonctionnelle

**💡 quoi**: correction d'une variable indéfinie dans le js

**🎯 pourquoi**: pour faire marcher #1380 

**🤔 comment**: correction du nom de la variable utilisée

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
