### PR TITLE
Parfois les xlsx envoient des lignes vides, elle doivent être ignorées

### DIFF
--- a/qfdmo/admin/acteur.py
+++ b/qfdmo/admin/acteur.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any, List
 
 import orjson
@@ -41,6 +42,8 @@ from qfdmo.models.acteur import (
 )
 from qfdmo.models.categorie_objet import CategorieObjet
 from qfdmo.widgets import CustomOSMWidget
+
+logger = logging.getLogger(__name__)
 
 
 class ActeurLabelQualiteInline(admin.StackedInline):
@@ -256,6 +259,13 @@ class ActeurResource(resources.ModelResource):
             return super().get_queryset()[: self.limit]
         return super().get_queryset()
 
+    def skip_row(self, instance, original, row, import_validation_errors=None):
+        if all(value is None for value in row.values()):
+            return True
+        return super().skip_row(
+            instance, original, row, import_validation_errors=import_validation_errors
+        )
+
     class Meta:
         model = Acteur
         import_id_fields = ["identifiant_unique"]
@@ -281,6 +291,7 @@ class ActeurAdmin(import_export_admin.ExportMixin, BaseActeurAdmin):
 
 
 class RevisionActeurResource(ActeurResource):
+
     class Meta:
         model = RevisionActeur
 


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [DjangoAdmin : Impossible d’uploader un fichier (import)](https://www.notion.so/accelerateur-transition-ecologique-ademe/DjangoAdmin-Impossible-d-uploader-un-fichier-import-1b16523d57d780258dfdcaf9fa457d94?pvs=4)

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Django Admin - import

**💡 quoi**: Parfois des lignes avec toutes les valeurs à nulles sont affichées après un import

**🎯 pourquoi**: je suppose que xlsx garde des colonnes nulles dans son format xml et django-import-export ne les ignore pas

**🤔 comment**: ingorer les lignes à importer quand toutes les valeurs sont nulles

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

