### PR TITLE
Renommage de variables lors de processus d'ingestion de sources

### DIFF
--- a/dags/sources/config/airflow_params.py
+++ b/dags/sources/config/airflow_params.py
@@ -11,15 +11,15 @@ from sources.tasks.transform.transform_column import (
     clean_reprise,
     clean_siren,
     clean_siret,
-    clean_souscategorie_codes,
-    clean_souscategorie_codes_sinoe,
+    clean_sous_categorie_codes,
+    clean_sous_categorie_codes_sinoe,
     clean_url,
     convert_opening_hours,
     strip_lower_string,
     strip_string,
 )
 from sources.tasks.transform.transform_df import (
-    clean_acteurservice_codes,
+    clean_acteur_service_codes,
     clean_action_codes,
     clean_adresse,
     clean_identifiant_externe,
@@ -30,7 +30,7 @@ from sources.tasks.transform.transform_df import (
     clean_telephone,
     compute_location,
     get_latlng_from_geopoint,
-    merge_and_clean_souscategorie_codes,
+    merge_and_clean_sous_categorie_codes,
     merge_sous_categories_columns,
 )
 from utils.django import django_setup_full
@@ -52,8 +52,8 @@ TRANSFORM_COLUMN_MAPPING = {
     "clean_reprise": clean_reprise,
     "clean_siren": clean_siren,
     "clean_siret": clean_siret,
-    "clean_souscategorie_codes_sinoe": clean_souscategorie_codes_sinoe,
-    "clean_souscategorie_codes": clean_souscategorie_codes,
+    "clean_sous_categorie_codes_sinoe": clean_sous_categorie_codes_sinoe,
+    "clean_sous_categorie_codes": clean_sous_categorie_codes,
     "clean_url": clean_url,
     "convert_opening_hours": convert_opening_hours,
     "strip_lower_string": strip_lower_string,
@@ -61,7 +61,7 @@ TRANSFORM_COLUMN_MAPPING = {
 }
 
 TRANSFORM_DF_MAPPING = {
-    "clean_acteurservice_codes": clean_acteurservice_codes,
+    "clean_acteur_service_codes": clean_acteur_service_codes,
     "clean_action_codes": clean_action_codes,
     "clean_adresse": clean_adresse,
     "clean_identifiant_externe": clean_identifiant_externe,
@@ -72,7 +72,7 @@ TRANSFORM_DF_MAPPING = {
     "clean_telephone": clean_telephone,
     "compute_location": compute_location,
     "get_latlng_from_geopoint": get_latlng_from_geopoint,
-    "merge_and_clean_souscategorie_codes": merge_and_clean_souscategorie_codes,
+    "merge_and_clean_sous_categorie_codes": merge_and_clean_sous_categorie_codes,
     "merge_sous_categories_columns": merge_sous_categories_columns,
 }
 

--- a/dags/sources/dags/source_aliapur.py
+++ b/dags/sources/dags/source_aliapur.py
@@ -53,8 +53,8 @@ with DAG(
             },
             {
                 "origin": "produitsdechets_acceptes",
-                "transformation": "clean_souscategorie_codes",
-                "destination": "souscategorie_codes",
+                "transformation": "clean_sous_categorie_codes",
+                "destination": "sous_categorie_codes",
             },
             # 3. Ajout des colonnes avec une valeur par défaut
             {
@@ -107,8 +107,8 @@ with DAG(
                     "point_dapport_pour_reemploi",
                     "point_de_collecte_ou_de_reprise_des_dechets",
                 ],
-                "transformation": "clean_acteurservice_codes",
-                "destination": ["acteurservice_codes"],
+                "transformation": "clean_acteur_service_codes",
+                "destination": ["acteur_service_codes"],
             },
             {
                 "origin": [
@@ -121,9 +121,9 @@ with DAG(
                 "destination": ["action_codes"],
             },
             {
-                "origin": ["action_codes", "souscategorie_codes"],
+                "origin": ["action_codes", "sous_categorie_codes"],
                 "transformation": "clean_proposition_services",
-                "destination": ["proposition_services_codes"],
+                "destination": ["proposition_service_codes"],
             },
             # 5. Supression des colonnes
             {"remove": "_i"},

--- a/dags/sources/dags/source_citeo.py
+++ b/dags/sources/dags/source_citeo.py
@@ -49,8 +49,8 @@ with DAG(
             },
             {
                 "origin": "produitsdechets_acceptes",
-                "transformation": "clean_souscategorie_codes",
-                "destination": "souscategorie_codes",
+                "transformation": "clean_sous_categorie_codes",
+                "destination": "sous_categorie_codes",
             },
             # 3. Ajout des colonnes avec une valeur par défaut
             {
@@ -97,8 +97,8 @@ with DAG(
                     "point_dapport_pour_reemploi",
                     "point_de_collecte_ou_de_reprise_des_dechets",
                 ],
-                "transformation": "clean_acteurservice_codes",
-                "destination": ["acteurservice_codes"],
+                "transformation": "clean_acteur_service_codes",
+                "destination": ["acteur_service_codes"],
             },
             {
                 "origin": [
@@ -111,9 +111,9 @@ with DAG(
                 "destination": ["action_codes"],
             },
             {
-                "origin": ["action_codes", "souscategorie_codes"],
+                "origin": ["action_codes", "sous_categorie_codes"],
                 "transformation": "clean_proposition_services",
-                "destination": ["proposition_services_codes"],
+                "destination": ["proposition_service_codes"],
             },
             # 5. Supression des colonnes
             {"remove": "_i"},

--- a/dags/sources/dags/source_cma.py
+++ b/dags/sources/dags/source_cma.py
@@ -83,7 +83,7 @@ with DAG(
                 "value": "commerce",
             },
             {
-                "column": "acteurservice_codes",
+                "column": "acteur_service_codes",
                 "value": ["service_de_reparation"],
             },
             {
@@ -129,13 +129,13 @@ with DAG(
             },
             {
                 "origin": ["categorie", "categorie2", "categorie3"],
-                "transformation": "merge_and_clean_souscategorie_codes",
-                "destination": ["souscategorie_codes"],
+                "transformation": "merge_and_clean_sous_categorie_codes",
+                "destination": ["sous_categorie_codes"],
             },
             {
-                "origin": ["action_codes", "souscategorie_codes"],
+                "origin": ["action_codes", "sous_categorie_codes"],
                 "transformation": "clean_proposition_services",
-                "destination": ["proposition_services_codes"],
+                "destination": ["proposition_service_codes"],
             },
             # 5. Supression des colonnes
             {"remove": "activite"},

--- a/dags/sources/dags/source_corepile.py
+++ b/dags/sources/dags/source_corepile.py
@@ -53,8 +53,8 @@ with DAG(
             },
             {
                 "origin": "produitsdechets_acceptes",
-                "transformation": "clean_souscategorie_codes",
-                "destination": "souscategorie_codes",
+                "transformation": "clean_sous_categorie_codes",
+                "destination": "sous_categorie_codes",
             },
             # 3. Ajout des colonnes avec une valeur par défaut
             {
@@ -101,8 +101,8 @@ with DAG(
                     "point_dapport_pour_reemploi",
                     "point_de_collecte_ou_de_reprise_des_dechets",
                 ],
-                "transformation": "clean_acteurservice_codes",
-                "destination": ["acteurservice_codes"],
+                "transformation": "clean_acteur_service_codes",
+                "destination": ["acteur_service_codes"],
             },
             {
                 "origin": [
@@ -115,9 +115,9 @@ with DAG(
                 "destination": ["action_codes"],
             },
             {
-                "origin": ["action_codes", "souscategorie_codes"],
+                "origin": ["action_codes", "sous_categorie_codes"],
                 "transformation": "clean_proposition_services",
-                "destination": ["proposition_services_codes"],
+                "destination": ["proposition_service_codes"],
             },
             # 5. Supression des colonnes
             {"remove": "_i"},

--- a/dags/sources/dags/source_cyclevia.py
+++ b/dags/sources/dags/source_cyclevia.py
@@ -81,8 +81,8 @@ with DAG(
             },
             {
                 "origin": "produitsdechets_acceptes",
-                "transformation": "clean_souscategorie_codes",
-                "destination": "souscategorie_codes",
+                "transformation": "clean_sous_categorie_codes",
+                "destination": "sous_categorie_codes",
             },
             # 3. Ajout des colonnes avec une valeur par défaut
             {
@@ -130,8 +130,8 @@ with DAG(
                     "point_dapport_pour_reemploi",
                     "point_de_collecte_ou_de_reprise_des_dechets",
                 ],
-                "transformation": "clean_acteurservice_codes",
-                "destination": ["acteurservice_codes"],
+                "transformation": "clean_acteur_service_codes",
+                "destination": ["acteur_service_codes"],
             },
             {
                 "origin": [
@@ -144,9 +144,9 @@ with DAG(
                 "destination": ["action_codes"],
             },
             {
-                "origin": ["action_codes", "souscategorie_codes"],
+                "origin": ["action_codes", "sous_categorie_codes"],
                 "transformation": "clean_proposition_services",
-                "destination": ["proposition_services_codes"],
+                "destination": ["proposition_service_codes"],
             },
             # 5. Supression des colonnes
             {"remove": "_i"},

--- a/dags/sources/dags/source_ecodds.py
+++ b/dags/sources/dags/source_ecodds.py
@@ -63,8 +63,8 @@ with DAG(
             },
             {
                 "origin": "produitsdechets_acceptes",
-                "transformation": "clean_souscategorie_codes",
-                "destination": "souscategorie_codes",
+                "transformation": "clean_sous_categorie_codes",
+                "destination": "sous_categorie_codes",
             },
             # 3. Ajout des colonnes avec une valeur par défaut
             {
@@ -107,8 +107,8 @@ with DAG(
                     "point_dapport_pour_reemploi",
                     "point_de_collecte_ou_de_reprise_des_dechets",
                 ],
-                "transformation": "clean_acteurservice_codes",
-                "destination": ["acteurservice_codes"],
+                "transformation": "clean_acteur_service_codes",
+                "destination": ["acteur_service_codes"],
             },
             {
                 "origin": [
@@ -121,9 +121,9 @@ with DAG(
                 "destination": ["action_codes"],
             },
             {
-                "origin": ["action_codes", "souscategorie_codes"],
+                "origin": ["action_codes", "sous_categorie_codes"],
                 "transformation": "clean_proposition_services",
-                "destination": ["proposition_services_codes"],
+                "destination": ["proposition_service_codes"],
             },
             # 5. Supression des colonnes
             {"remove": "_i"},

--- a/dags/sources/dags/source_ecologic.py
+++ b/dags/sources/dags/source_ecologic.py
@@ -54,8 +54,8 @@ with DAG(
             },
             {
                 "origin": "produitsdechets_acceptes",
-                "transformation": "clean_souscategorie_codes",
-                "destination": "souscategorie_codes",
+                "transformation": "clean_sous_categorie_codes",
+                "destination": "sous_categorie_codes",
             },
             # 3. Ajout des colonnes avec une valeur par défaut
             {
@@ -97,8 +97,8 @@ with DAG(
                     "point_dapport_pour_reemploi",
                     "point_de_collecte_ou_de_reprise_des_dechets",
                 ],
-                "transformation": "clean_acteurservice_codes",
-                "destination": ["acteurservice_codes"],
+                "transformation": "clean_acteur_service_codes",
+                "destination": ["acteur_service_codes"],
             },
             {
                 "origin": [
@@ -111,9 +111,9 @@ with DAG(
                 "destination": ["action_codes"],
             },
             {
-                "origin": ["action_codes", "souscategorie_codes"],
+                "origin": ["action_codes", "sous_categorie_codes"],
                 "transformation": "clean_proposition_services",
-                "destination": ["proposition_services_codes"],
+                "destination": ["proposition_service_codes"],
             },
             # 5. Supression des colonnes
             {"remove": "_i"},

--- a/dags/sources/dags/source_ecomaison.py
+++ b/dags/sources/dags/source_ecomaison.py
@@ -63,8 +63,8 @@ with DAG(
             },
             {
                 "origin": "produitsdechets_acceptes",
-                "transformation": "clean_souscategorie_codes",
-                "destination": "souscategorie_codes",
+                "transformation": "clean_sous_categorie_codes",
+                "destination": "sous_categorie_codes",
             },
             # 3. Ajout des colonnes avec une valeur par défaut
             {
@@ -116,8 +116,8 @@ with DAG(
                     "point_dapport_pour_reemploi",
                     "point_de_collecte_ou_de_reprise_des_dechets",
                 ],
-                "transformation": "clean_acteurservice_codes",
-                "destination": ["acteurservice_codes"],
+                "transformation": "clean_acteur_service_codes",
+                "destination": ["acteur_service_codes"],
             },
             {
                 "origin": [
@@ -130,9 +130,9 @@ with DAG(
                 "destination": ["action_codes"],
             },
             {
-                "origin": ["action_codes", "souscategorie_codes"],
+                "origin": ["action_codes", "sous_categorie_codes"],
                 "transformation": "clean_proposition_services",
-                "destination": ["proposition_services_codes"],
+                "destination": ["proposition_service_codes"],
             },
             # 5. Supression des colonnes
             {"remove": "_i"},

--- a/dags/sources/dags/source_ecopae.py
+++ b/dags/sources/dags/source_ecopae.py
@@ -63,8 +63,8 @@ with DAG(
             },
             {
                 "origin": "produitsdechets_acceptes",
-                "transformation": "clean_souscategorie_codes",
-                "destination": "souscategorie_codes",
+                "transformation": "clean_sous_categorie_codes",
+                "destination": "sous_categorie_codes",
             },
             # 3. Ajout des colonnes avec une valeur par défaut
             {
@@ -111,8 +111,8 @@ with DAG(
                     "point_dapport_pour_reemploi",
                     "point_de_collecte_ou_de_reprise_des_dechets",
                 ],
-                "transformation": "clean_acteurservice_codes",
-                "destination": ["acteurservice_codes"],
+                "transformation": "clean_acteur_service_codes",
+                "destination": ["acteur_service_codes"],
             },
             {
                 "origin": [
@@ -125,9 +125,9 @@ with DAG(
                 "destination": ["action_codes"],
             },
             {
-                "origin": ["action_codes", "souscategorie_codes"],
+                "origin": ["action_codes", "sous_categorie_codes"],
                 "transformation": "clean_proposition_services",
-                "destination": ["proposition_services_codes"],
+                "destination": ["proposition_service_codes"],
             },
             # 5. Supression des colonnes
             {"remove": "_i"},

--- a/dags/sources/dags/source_ecosystem.py
+++ b/dags/sources/dags/source_ecosystem.py
@@ -53,8 +53,8 @@ with DAG(
             },
             {
                 "origin": "produitsdechets_acceptes",
-                "transformation": "clean_souscategorie_codes",
-                "destination": "souscategorie_codes",
+                "transformation": "clean_sous_categorie_codes",
+                "destination": "sous_categorie_codes",
             },
             # 3. Ajout des colonnes avec une valeur par défaut
             {
@@ -99,8 +99,8 @@ with DAG(
                     "point_dapport_pour_reemploi",
                     "point_de_collecte_ou_de_reprise_des_dechets",
                 ],
-                "transformation": "clean_acteurservice_codes",
-                "destination": ["acteurservice_codes"],
+                "transformation": "clean_acteur_service_codes",
+                "destination": ["acteur_service_codes"],
             },
             {
                 "origin": [
@@ -111,9 +111,9 @@ with DAG(
                 "destination": ["action_codes"],
             },
             {
-                "origin": ["action_codes", "souscategorie_codes"],
+                "origin": ["action_codes", "sous_categorie_codes"],
                 "transformation": "clean_proposition_services",
-                "destination": ["proposition_services_codes"],
+                "destination": ["proposition_service_codes"],
             },
             # 5. Supression des colonnes
             {"remove": "_i"},

--- a/dags/sources/dags/source_ocab.py
+++ b/dags/sources/dags/source_ocab.py
@@ -53,8 +53,8 @@ with DAG(
             },
             {
                 "origin": "produitsdechets_acceptes",
-                "transformation": "clean_souscategorie_codes",
-                "destination": "souscategorie_codes",
+                "transformation": "clean_sous_categorie_codes",
+                "destination": "sous_categorie_codes",
             },
             # 3. Ajout des colonnes avec une valeur par défaut
             {
@@ -101,8 +101,8 @@ with DAG(
                     "point_dapport_pour_reemploi",
                     "point_de_collecte_ou_de_reprise_des_dechets",
                 ],
-                "transformation": "clean_acteurservice_codes",
-                "destination": ["acteurservice_codes"],
+                "transformation": "clean_acteur_service_codes",
+                "destination": ["acteur_service_codes"],
             },
             {
                 "origin": [
@@ -115,9 +115,9 @@ with DAG(
                 "destination": ["action_codes"],
             },
             {
-                "origin": ["action_codes", "souscategorie_codes"],
+                "origin": ["action_codes", "sous_categorie_codes"],
                 "transformation": "clean_proposition_services",
-                "destination": ["proposition_services_codes"],
+                "destination": ["proposition_service_codes"],
             },
             # 5. Supression des colonnes
             {"remove": "_i"},

--- a/dags/sources/dags/source_ocad3e.py
+++ b/dags/sources/dags/source_ocad3e.py
@@ -58,8 +58,8 @@ with DAG(
             },
             {
                 "origin": "produitsdechets_acceptes",
-                "transformation": "clean_souscategorie_codes",
-                "destination": "souscategorie_codes",
+                "transformation": "clean_sous_categorie_codes",
+                "destination": "sous_categorie_codes",
             },
             # 3. Ajout des colonnes avec une valeur par défaut
             {
@@ -114,8 +114,8 @@ with DAG(
                     "point_dapport_de_service_reparation",
                     "point_de_reparation",
                 ],
-                "transformation": "clean_acteurservice_codes",
-                "destination": ["acteurservice_codes"],
+                "transformation": "clean_acteur_service_codes",
+                "destination": ["acteur_service_codes"],
             },
             {
                 "origin": [
@@ -126,9 +126,9 @@ with DAG(
                 "destination": ["action_codes"],
             },
             {
-                "origin": ["action_codes", "souscategorie_codes"],
+                "origin": ["action_codes", "sous_categorie_codes"],
                 "transformation": "clean_proposition_services",
-                "destination": ["proposition_services_codes"],
+                "destination": ["proposition_service_codes"],
             },
             # 5. Supression des colonnes
             {"remove": "_i"},

--- a/dags/sources/dags/source_pharmacies.py
+++ b/dags/sources/dags/source_pharmacies.py
@@ -56,7 +56,7 @@ with DAG(
                 "value": "non",
             },
             {
-                "column": "acteurservice_codes",
+                "column": "acteur_service_codes",
                 "value": ["structure_de_collecte"],
             },
             {
@@ -68,7 +68,7 @@ with DAG(
                 "value": [],
             },
             {
-                "column": "souscategorie_codes",
+                "column": "sous_categorie_codes",
                 "value": ["medicaments"],
             },
             {
@@ -99,9 +99,9 @@ with DAG(
                 "destination": ["identifiant_unique"],
             },
             {
-                "origin": ["action_codes", "souscategorie_codes"],
+                "origin": ["action_codes", "sous_categorie_codes"],
                 "transformation": "clean_proposition_services",
-                "destination": ["proposition_services_codes"],
+                "destination": ["proposition_service_codes"],
             },
             # 5. Supression des colonnes
             {"remove": "Téléphone"},

--- a/dags/sources/dags/source_pyreo.py
+++ b/dags/sources/dags/source_pyreo.py
@@ -73,8 +73,8 @@ with DAG(
             },
             {
                 "origin": "produitsdechets_acceptes",
-                "transformation": "clean_souscategorie_codes",
-                "destination": "souscategorie_codes",
+                "transformation": "clean_sous_categorie_codes",
+                "destination": "sous_categorie_codes",
             },
             # 3. Ajout des colonnes avec une valeur par défaut
             {
@@ -131,8 +131,8 @@ with DAG(
                     "point_dapport_pour_reemploi",
                     "point_de_collecte_ou_de_reprise_des_dechets",
                 ],
-                "transformation": "clean_acteurservice_codes",
-                "destination": ["acteurservice_codes"],
+                "transformation": "clean_acteur_service_codes",
+                "destination": ["acteur_service_codes"],
             },
             {
                 "origin": [
@@ -145,9 +145,9 @@ with DAG(
                 "destination": ["action_codes"],
             },
             {
-                "origin": ["action_codes", "souscategorie_codes"],
+                "origin": ["action_codes", "sous_categorie_codes"],
                 "transformation": "clean_proposition_services",
-                "destination": ["proposition_services_codes"],
+                "destination": ["proposition_service_codes"],
             },
             # 5. Supression des colonnes
             {"remove": "_i"},

--- a/dags/sources/dags/source_refashion.py
+++ b/dags/sources/dags/source_refashion.py
@@ -77,8 +77,8 @@ with DAG(
             },
             {
                 "origin": "produitsdechets_acceptes",
-                "transformation": "clean_souscategorie_codes",
-                "destination": "souscategorie_codes",
+                "transformation": "clean_sous_categorie_codes",
+                "destination": "sous_categorie_codes",
             },
             # 3. Ajout des colonnes avec une valeur par défaut
             {
@@ -131,8 +131,8 @@ with DAG(
                     "point_dapport_pour_reemploi",
                     "point_de_collecte_ou_de_reprise_des_dechets",
                 ],
-                "transformation": "clean_acteurservice_codes",
-                "destination": ["acteurservice_codes"],
+                "transformation": "clean_acteur_service_codes",
+                "destination": ["acteur_service_codes"],
             },
             {
                 "origin": [
@@ -145,9 +145,9 @@ with DAG(
                 "destination": ["action_codes"],
             },
             {
-                "origin": ["action_codes", "souscategorie_codes"],
+                "origin": ["action_codes", "sous_categorie_codes"],
                 "transformation": "clean_proposition_services",
-                "destination": ["proposition_services_codes"],
+                "destination": ["proposition_service_codes"],
             },
             # 5. Supression des colonnes
             {"remove": "_i"},

--- a/dags/sources/dags/source_s3.py
+++ b/dags/sources/dags/source_s3.py
@@ -30,9 +30,9 @@ with DAG(
             # 1. Renommage des colonnes
             # 2. Transformation des colonnes
             {
-                "origin": "souscategorie_codes",
-                "transformation": "clean_souscategorie_codes",
-                "destination": "souscategorie_codes",
+                "origin": "sous_categorie_codes",
+                "transformation": "clean_sous_categorie_codes",
+                "destination": "sous_categorie_codes",
             },
             {
                 "origin": "nom",
@@ -55,9 +55,9 @@ with DAG(
                 "destination": "source_code",
             },
             {
-                "origin": "acteurservice_codes",
+                "origin": "acteur_service_codes",
                 "transformation": "clean_code_list",
-                "destination": "acteurservice_codes",
+                "destination": "acteur_service_codes",
             },
             {
                 "origin": "action_codes",
@@ -135,9 +135,9 @@ with DAG(
                 "destination": ["telephone"],
             },
             {
-                "origin": ["action_codes", "souscategorie_codes"],
+                "origin": ["action_codes", "sous_categorie_codes"],
                 "transformation": "clean_proposition_services",
-                "destination": ["proposition_services_codes"],
+                "destination": ["proposition_service_codes"],
             },
             # 5. Supression des colonnes
             {"remove": "action_principale"},

--- a/dags/sources/dags/source_screlec.py
+++ b/dags/sources/dags/source_screlec.py
@@ -73,8 +73,8 @@ with DAG(
             },
             {
                 "origin": "produitsdechets_acceptes",
-                "transformation": "clean_souscategorie_codes",
-                "destination": "souscategorie_codes",
+                "transformation": "clean_sous_categorie_codes",
+                "destination": "sous_categorie_codes",
             },
             # 3. Ajout des colonnes avec une valeur par défaut
             {
@@ -122,8 +122,8 @@ with DAG(
                     "point_dapport_pour_reemploi",
                     "point_de_collecte_ou_de_reprise_des_dechets",
                 ],
-                "transformation": "clean_acteurservice_codes",
-                "destination": ["acteurservice_codes"],
+                "transformation": "clean_acteur_service_codes",
+                "destination": ["acteur_service_codes"],
             },
             {
                 "origin": [
@@ -136,9 +136,9 @@ with DAG(
                 "destination": ["action_codes"],
             },
             {
-                "origin": ["action_codes", "souscategorie_codes"],
+                "origin": ["action_codes", "sous_categorie_codes"],
                 "transformation": "clean_proposition_services",
-                "destination": ["proposition_services_codes"],
+                "destination": ["proposition_service_codes"],
             },
             # 5. Supression des colonnes
             {"remove": "_i"},

--- a/dags/sources/dags/source_sinoe.py
+++ b/dags/sources/dags/source_sinoe.py
@@ -54,8 +54,8 @@ with DAG(
             },
             {
                 "origin": "LST_TYPE_DECHET",
-                "transformation": "clean_souscategorie_codes_sinoe",
-                "destination": "souscategorie_codes",
+                "transformation": "clean_sous_categorie_codes_sinoe",
+                "destination": "sous_categorie_codes",
             },
             {
                 "origin": "ORIGINE_DECHET_ACC",
@@ -72,7 +72,7 @@ with DAG(
                 "value": [],
             },
             {
-                "column": "acteurservice_codes",
+                "column": "acteur_service_codes",
                 "value": ["structure_de_collecte"],
             },
             {
@@ -113,9 +113,9 @@ with DAG(
                 "destination": ["identifiant_unique"],
             },
             {
-                "origin": ["action_codes", "souscategorie_codes"],
+                "origin": ["action_codes", "sous_categorie_codes"],
                 "transformation": "clean_proposition_services",
-                "destination": ["proposition_services_codes"],
+                "destination": ["proposition_service_codes"],
             },
             # 5. Supression des colonnes
             {"remove": "_geopoint"},

--- a/dags/sources/dags/source_soren.py
+++ b/dags/sources/dags/source_soren.py
@@ -69,8 +69,8 @@ with DAG(
             },
             {
                 "origin": "produitsdechets_acceptes",
-                "transformation": "clean_souscategorie_codes",
-                "destination": "souscategorie_codes",
+                "transformation": "clean_sous_categorie_codes",
+                "destination": "sous_categorie_codes",
             },
             # 3. Ajout des colonnes avec une valeur par défaut
             {
@@ -113,8 +113,8 @@ with DAG(
                     "point_dapport_pour_reemploi",
                     "point_de_collecte_ou_de_reprise_des_dechets",
                 ],
-                "transformation": "clean_acteurservice_codes",
-                "destination": ["acteurservice_codes"],
+                "transformation": "clean_acteur_service_codes",
+                "destination": ["acteur_service_codes"],
             },
             {
                 "origin": [
@@ -127,9 +127,9 @@ with DAG(
                 "destination": ["action_codes"],
             },
             {
-                "origin": ["action_codes", "souscategorie_codes"],
+                "origin": ["action_codes", "sous_categorie_codes"],
                 "transformation": "clean_proposition_services",
-                "destination": ["proposition_services_codes"],
+                "destination": ["proposition_service_codes"],
             },
             # 5. Supression des colonnes
             {"remove": "_i"},

--- a/dags/sources/dags/source_valdelia.py
+++ b/dags/sources/dags/source_valdelia.py
@@ -68,8 +68,8 @@ with DAG(
             },
             {
                 "origin": "produitsdechets_acceptes",
-                "transformation": "clean_souscategorie_codes",
-                "destination": "souscategorie_codes",
+                "transformation": "clean_sous_categorie_codes",
+                "destination": "sous_categorie_codes",
             },
             # 3. Ajout des colonnes avec une valeur par défaut
             {
@@ -122,8 +122,8 @@ with DAG(
                     "point_dapport_pour_reemploi",
                     "point_de_collecte_ou_de_reprise_des_dechets",
                 ],
-                "transformation": "clean_acteurservice_codes",
-                "destination": ["acteurservice_codes"],
+                "transformation": "clean_acteur_service_codes",
+                "destination": ["acteur_service_codes"],
             },
             {
                 "origin": [
@@ -136,9 +136,9 @@ with DAG(
                 "destination": ["action_codes"],
             },
             {
-                "origin": ["action_codes", "souscategorie_codes"],
+                "origin": ["action_codes", "sous_categorie_codes"],
                 "transformation": "clean_proposition_services",
-                "destination": ["proposition_services_codes"],
+                "destination": ["proposition_service_codes"],
             },
             # 5. Supression des colonnes
             {"remove": "_i"},

--- a/dags/sources/tasks/business_logic/db_data_prepare.py
+++ b/dags/sources/tasks/business_logic/db_data_prepare.py
@@ -49,7 +49,7 @@ def db_data_prepare(
     # FIXME : à faire avant dans la normalisation des données
     # Inactivate acteur if propositions_services is empty
     df_acteur.loc[
-        df_acteur["proposition_services_codes"].apply(lambda x: x == []), "statut"
+        df_acteur["proposition_service_codes"].apply(lambda x: x == []), "statut"
     ] = "INACTIF"
 
     df_acteur["suggestion"] = df_acteur.apply(

--- a/dags/sources/tasks/business_logic/db_read_acteur.py
+++ b/dags/sources/tasks/business_logic/db_read_acteur.py
@@ -39,11 +39,11 @@ def db_read_acteur(df_normalized: pd.DataFrame, dag_config: DAGConfig):
     acteurs_list = []
     expected_columns = dag_config.get_expected_columns() - {
         "location",
-        "souscategorie_codes",
+        "sous_categorie_codes",
         "label_codes",
-        "acteurservice_codes",
+        "acteur_service_codes",
         "action_codes",
-        "proposition_services_codes",
+        "proposition_service_codes",
         "source_code",
         "acteur_type_code",
     } | {"cree_le"}
@@ -52,10 +52,10 @@ def db_read_acteur(df_normalized: pd.DataFrame, dag_config: DAGConfig):
         acteur_dict["source_code"] = acteur.source.code
         acteur_dict["acteur_type_code"] = acteur.acteur_type.code
         acteur_dict["label_codes"] = [label.code for label in acteur.labels.all()]
-        acteur_dict["acteurservice_codes"] = [
+        acteur_dict["acteur_service_codes"] = [
             acteur_service.code for acteur_service in acteur.acteur_services.all()
         ]
-        acteur_dict["proposition_services_codes"] = [
+        acteur_dict["proposition_service_codes"] = [
             {
                 "action": proposition_service.action.code,
                 "sous_categories": [

--- a/dags/sources/tasks/business_logic/keep_acteur_changed.py
+++ b/dags/sources/tasks/business_logic/keep_acteur_changed.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 def is_identique_row(row_source, row_db, columns_to_compare):
     is_identique = True
     for column in columns_to_compare - {"identifiant_unique"}:
-        if column == "proposition_services_codes":
+        if column == "proposition_service_codes":
             # on trie la list de dict par la clé action
             row_source[column] = sorted(row_source[column], key=lambda x: x["action"])
             row_db[column] = sorted(row_db[column], key=lambda x: x["action"])
@@ -45,7 +45,7 @@ def keep_acteur_changed(
         dag_config.get_expected_columns()
         - {
             "location",
-            "souscategorie_codes",
+            "sous_categorie_codes",
             "action_codes",
         }
         - {"cree_le"}

--- a/dags/sources/tasks/business_logic/source_data_normalize.py
+++ b/dags/sources/tasks/business_logic/source_data_normalize.py
@@ -125,15 +125,15 @@ def _remove_undesired_lines(df: pd.DataFrame, dag_config: DAGConfig) -> pd.DataF
         column in df.columns
         for column in [
             "label_codes",
-            "acteurservice_codes",
-            "proposition_services_codes",
+            "acteur_service_codes",
+            "proposition_service_codes",
         ]
     ):
         df = merge_duplicates(
             df,
             group_column="identifiant_unique",
-            merge_as_list_columns=["label_codes", "acteurservice_codes"],
-            merge_as_proposition_service_columns=["proposition_services_codes"],
+            merge_as_list_columns=["label_codes", "acteur_service_codes"],
+            merge_as_proposition_service_columns=["proposition_service_codes"],
         )
 
     # Remove acteurs which propose only service à domicile
@@ -145,10 +145,10 @@ def _remove_undesired_lines(df: pd.DataFrame, dag_config: DAGConfig) -> pd.DataF
     if "public_accueilli" in df.columns:
         df = df[df["public_accueilli"] != constants.PUBLIC_PRO]
 
-    # Remove acteurs which have no souscategorie_codes
-    if "souscategorie_codes" in df.columns:
-        df = df[df["souscategorie_codes"].notnull()]
-        df = df[df["souscategorie_codes"].apply(len) > 0]
+    # Remove acteurs which have no sous_categorie_codes
+    if "sous_categorie_codes" in df.columns:
+        df = df[df["sous_categorie_codes"].notnull()]
+        df = df[df["sous_categorie_codes"].apply(len) > 0]
 
     # Find duplicates for logging
     dups = df[df["identifiant_unique"].duplicated(keep=False)]

--- a/dags/sources/tasks/business_logic/source_data_validate.py
+++ b/dags/sources/tasks/business_logic/source_data_validate.py
@@ -84,16 +84,16 @@ def source_data_validate(df: pd.DataFrame, dag_config: DAGConfig) -> None:
     # vérification des codes des acteurservices
     df_acteurservice_code = set(
         chain.from_iterable(
-            x if isinstance(x, list) else [x] for x in df["acteurservice_codes"]
+            x if isinstance(x, list) else [x] for x in df["acteur_service_codes"]
         )
     )
     db_acteurservice_code = set(
         db_tasks.read_data_from_postgres(table_name="qfdmo_acteurservice")["code"]
     )
-    invalid_acteurservice_codes = df_acteurservice_code - db_acteurservice_code
-    if invalid_acteurservice_codes:
+    invalid_acteur_service_codes = df_acteurservice_code - db_acteurservice_code
+    if invalid_acteur_service_codes:
         raise ValueError(
-            f"acteurservice_codes: codes pas dans DB: {invalid_acteurservice_codes}"
+            f"acteur_service_codes: codes pas dans DB: {invalid_acteur_service_codes}"
         )
 
     # ------------------------------------
@@ -114,7 +114,7 @@ def source_data_validate(df: pd.DataFrame, dag_config: DAGConfig) -> None:
     # vérification des codes des labels
     df_sscat_code = set(
         chain.from_iterable(
-            x if isinstance(x, list) else [x] for x in df["souscategorie_codes"]
+            x if isinstance(x, list) else [x] for x in df["sous_categorie_codes"]
         )
     )
     db_sscat_code = set(

--- a/dags/sources/tasks/transform/transform_column.py
+++ b/dags/sources/tasks/transform/transform_column.py
@@ -172,13 +172,13 @@ def clean_code_list(codes: str | None, _) -> list[str]:
     return [code.strip().lower() for code in codes.split("|") if code.strip().lower()]
 
 
-def clean_souscategorie_codes(
+def clean_sous_categorie_codes(
     sscat_list: str | None, dag_config: DAGConfig
 ) -> list[str]:
-    souscategorie_codes = []
+    sous_categorie_codes = []
 
     if not sscat_list:
-        return souscategorie_codes
+        return sous_categorie_codes
 
     product_mapping = dag_config.product_mapping
     for sscat in sscat_list.split("|"):
@@ -187,16 +187,16 @@ def clean_souscategorie_codes(
             continue
         sscat = product_mapping[sscat]
         if isinstance(sscat, str):
-            souscategorie_codes.append(sscat)
+            sous_categorie_codes.append(sscat)
         elif isinstance(sscat, list):
-            souscategorie_codes.extend(sscat)
+            sous_categorie_codes.extend(sscat)
         else:
             raise ValueError(f"Type {type(sscat)} not supported in product_mapping")
 
-    return list(set(souscategorie_codes))
+    return list(set(sous_categorie_codes))
 
 
-def clean_souscategorie_codes_sinoe(
+def clean_sous_categorie_codes_sinoe(
     sscats: str | None, dag_config: DAGConfig
 ) -> list[str]:
 
@@ -221,4 +221,4 @@ def clean_souscategorie_codes_sinoe(
         if dechet_mapping[v].lower() in product_mapping
     ]
 
-    return clean_souscategorie_codes("|".join(sscat_list), dag_config)
+    return clean_sous_categorie_codes("|".join(sscat_list), dag_config)

--- a/dags/sources/tasks/transform/transform_df.py
+++ b/dags/sources/tasks/transform/transform_df.py
@@ -26,9 +26,9 @@ MANDATORY_COLUMNS_AFTER_NORMALISATION = [
     "identifiant_unique",
     "identifiant_externe",
     "nom",
-    "acteurservice_codes",
+    "acteur_service_codes",
     "label_codes",
-    "proposition_services_codes",
+    "proposition_service_codes",
     "source_code",
     "acteur_type_code",
 ]
@@ -189,16 +189,16 @@ def clean_adresse(row, dag_config):
     return row[["adresse", "code_postal", "ville"]]
 
 
-def clean_acteurservice_codes(row, _):
-    acteurservice_codes = []
+def clean_acteur_service_codes(row, _):
+    acteur_service_codes = []
     if row.get("point_dapport_de_service_reparation") or row.get("point_de_reparation"):
-        acteurservice_codes.append("service_de_reparation")
+        acteur_service_codes.append("service_de_reparation")
     if row.get("point_dapport_pour_reemploi") or row.get(
         "point_de_collecte_ou_de_reprise_des_dechets"
     ):
-        acteurservice_codes.append("structure_de_collecte")
-    row["acteurservice_codes"] = acteurservice_codes
-    return row[["acteurservice_codes"]]
+        acteur_service_codes.append("structure_de_collecte")
+    row["acteur_service_codes"] = acteur_service_codes
+    return row[["acteur_service_codes"]]
 
 
 def clean_action_codes(row, _):
@@ -239,25 +239,25 @@ def clean_label_codes(row, dag_config):
     return row[["label_codes"]]
 
 
-def merge_and_clean_souscategorie_codes(
+def merge_and_clean_sous_categorie_codes(
     row: pd.Series, dag_config: DAGConfig
 ) -> pd.Series:
     categories = [row[col] for col in row.keys() if pd.notna(row[col]) and row[col]]
-    souscategorie_codes = []
+    sous_categorie_codes = []
     product_mapping = dag_config.product_mapping
     for sscat in categories:
         sscat = sscat.strip().lower()
         sscat = product_mapping[sscat]
         if isinstance(sscat, str):
-            souscategorie_codes.append(sscat)
+            sous_categorie_codes.append(sscat)
         elif isinstance(sscat, list):
-            souscategorie_codes.extend(sscat)
+            sous_categorie_codes.extend(sscat)
         else:
             raise ValueError(
-                f"Type {type(sscat)} not supported for souscategorie_codes"
+                f"Type {type(sscat)} not supported for sous_categorie_codes"
             )
-    row["souscategorie_codes"] = list(set(souscategorie_codes))
-    return row[["souscategorie_codes"]]
+    row["sous_categorie_codes"] = list(set(sous_categorie_codes))
+    return row[["sous_categorie_codes"]]
 
 
 def get_latlng_from_geopoint(row: pd.Series, _) -> pd.Series:
@@ -281,21 +281,21 @@ def compute_location(row: pd.Series, _):
 def clean_proposition_services(row, _):
 
     # formater les propositions de service selon les colonnes
-    # action_codes and souscategorie_codes
+    # action_codes and sous_categorie_codes
     #
     # [{'action': 'CODE_ACTION','sous_categories': ['CODE_SSCAT']}] ou []
-    if row["souscategorie_codes"]:
-        row["proposition_services_codes"] = [
+    if row["sous_categorie_codes"]:
+        row["proposition_service_codes"] = [
             {
                 "action": action,
-                "sous_categories": row["souscategorie_codes"],
+                "sous_categories": row["sous_categorie_codes"],
             }
             for action in row["action_codes"]
         ]
     else:
-        row["proposition_services_codes"] = []
+        row["proposition_service_codes"] = []
 
-    return row[["proposition_services_codes"]]
+    return row[["proposition_service_codes"]]
 
 
 ### Fonctions de résolution de l'adresse au format BAN et avec vérification via l'API

--- a/dags_unit_tests/conftest.py
+++ b/dags_unit_tests/conftest.py
@@ -140,9 +140,9 @@ def dag_config():
                     "identifiant_unique",
                     "identifiant_externe",
                     "nom",
-                    "acteurservice_codes",
+                    "acteur_service_codes",
                     "label_codes",
-                    "proposition_services_codes",
+                    "proposition_service_codes",
                     "source_code",
                     "acteur_type_code",
                 ]

--- a/dags_unit_tests/sources/tasks/business_logic/test_db_data_prepare.py
+++ b/dags_unit_tests/sources/tasks/business_logic/test_db_data_prepare.py
@@ -13,7 +13,7 @@ from dags.sources.tasks.business_logic.db_data_prepare import db_data_prepare
                     "identifiant_unique": ["2", "3"],
                     "statut": ["ACTIF", "ACTIF"],
                     "cree_le": ["2021-01-01", "2021-01-01"],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [{"prop2": "val2"}],
                         [{"prop3": "val3"}],
                     ],
@@ -32,11 +32,11 @@ from dags.sources.tasks.business_logic.db_data_prepare import db_data_prepare
                         "identifiant_unique": ["3"],
                         "statut": ["ACTIF"],
                         "cree_le": ["2021-01-01"],
-                        "proposition_services_codes": [[{"prop3": "val3"}]],
+                        "proposition_service_codes": [[{"prop3": "val3"}]],
                         "suggestion": [
                             '{"identifiant_unique": "3", "statut": "ACTIF",'
                             ' "cree_le": "2021-01-01",'
-                            ' "proposition_services_codes": [{"prop3": "val3"}]}'
+                            ' "proposition_service_codes": [{"prop3": "val3"}]}'
                         ],
                         "contexte": None,
                     }
@@ -46,11 +46,11 @@ from dags.sources.tasks.business_logic.db_data_prepare import db_data_prepare
                         "identifiant_unique": ["2"],
                         "statut": ["ACTIF"],
                         "cree_le": ["2021-01-01"],
-                        "proposition_services_codes": [[{"prop2": "val2"}]],
+                        "proposition_service_codes": [[{"prop2": "val2"}]],
                         "suggestion": [
                             '{"identifiant_unique": "2", "statut": "ACTIF",'
                             ' "cree_le": "2021-01-01",'
-                            ' "proposition_services_codes": [{"prop2": "val2"}]}'
+                            ' "proposition_service_codes": [{"prop2": "val2"}]}'
                         ],
                         "contexte": [
                             '{"identifiant_unique": "2", "statut": "ACTIF",'

--- a/dags_unit_tests/sources/tasks/business_logic/test_keep_acteur_changed.py
+++ b/dags_unit_tests/sources/tasks/business_logic/test_keep_acteur_changed.py
@@ -18,8 +18,8 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": [],
                     "identifiant_externe": [],
                     "acteur_type_code": [],
-                    "acteurservice_codes": [],
-                    "proposition_services_codes": [],
+                    "acteur_service_codes": [],
+                    "proposition_service_codes": [],
                 }
             ),
             pd.DataFrame(
@@ -30,8 +30,8 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": [],
                     "identifiant_externe": [],
                     "acteur_type_code": [],
-                    "acteurservice_codes": [],
-                    "proposition_services_codes": [],
+                    "acteur_service_codes": [],
+                    "proposition_service_codes": [],
                 }
             ),
             pd.DataFrame(
@@ -42,8 +42,8 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": [],
                     "identifiant_externe": [],
                     "acteur_type_code": [],
-                    "acteurservice_codes": [],
-                    "proposition_services_codes": [],
+                    "acteur_service_codes": [],
+                    "proposition_service_codes": [],
                 }
             ),
             pd.DataFrame(
@@ -54,8 +54,8 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": [],
                     "identifiant_externe": [],
                     "acteur_type_code": [],
-                    "acteurservice_codes": [],
-                    "proposition_services_codes": [],
+                    "acteur_service_codes": [],
+                    "proposition_service_codes": [],
                 }
             ),
         ),
@@ -69,11 +69,11 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": ["source1", "source2"],
                     "identifiant_externe": ["id1", "id2"],
                     "acteur_type_code": ["commerce", "ess"],
-                    "acteurservice_codes": [
+                    "acteur_service_codes": [
                         ["service1", "service2"],
                         ["service2", "service1"],
                     ],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [
                             {
                                 "action": "action1",
@@ -101,11 +101,11 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": ["source1", "source2"],
                     "identifiant_externe": ["id1", "id2"],
                     "acteur_type_code": ["commerce", "ess"],
-                    "acteurservice_codes": [
+                    "acteur_service_codes": [
                         ["service1", "service2"],
                         ["service2", "service1"],
                     ],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [
                             {
                                 "action": "action1",
@@ -133,8 +133,8 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": pd.Series([], dtype="object"),
                     "identifiant_externe": pd.Series([], dtype="object"),
                     "acteur_type_code": pd.Series([], dtype="object"),
-                    "acteurservice_codes": pd.Series([], dtype="object"),
-                    "proposition_services_codes": pd.Series([], dtype="object"),
+                    "acteur_service_codes": pd.Series([], dtype="object"),
+                    "proposition_service_codes": pd.Series([], dtype="object"),
                 }
             ),
             pd.DataFrame(
@@ -145,8 +145,8 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": pd.Series([], dtype="object"),
                     "identifiant_externe": pd.Series([], dtype="object"),
                     "acteur_type_code": pd.Series([], dtype="object"),
-                    "acteurservice_codes": pd.Series([], dtype="object"),
-                    "proposition_services_codes": pd.Series([], dtype="object"),
+                    "acteur_service_codes": pd.Series([], dtype="object"),
+                    "proposition_service_codes": pd.Series([], dtype="object"),
                 }
             ),
         ),
@@ -160,11 +160,11 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": ["source1", "source2"],
                     "identifiant_externe": ["id1", "id2"],
                     "acteur_type_code": ["commerce", "ess"],
-                    "acteurservice_codes": [
+                    "acteur_service_codes": [
                         ["service1", "service2"],
                         ["service2", "service1"],
                     ],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [
                             {
                                 "action": "action1",
@@ -192,11 +192,11 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": ["source1", "source2"],
                     "identifiant_externe": ["id1", "id2"],
                     "acteur_type_code": ["commerce", "ess"],
-                    "acteurservice_codes": [
+                    "acteur_service_codes": [
                         ["service1", "service2"],
                         ["service1", "service2"],
                     ],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [
                             {
                                 "action": "action1",
@@ -224,8 +224,8 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": pd.Series([], dtype="object"),
                     "identifiant_externe": pd.Series([], dtype="object"),
                     "acteur_type_code": pd.Series([], dtype="object"),
-                    "acteurservice_codes": pd.Series([], dtype="object"),
-                    "proposition_services_codes": pd.Series([], dtype="object"),
+                    "acteur_service_codes": pd.Series([], dtype="object"),
+                    "proposition_service_codes": pd.Series([], dtype="object"),
                 }
             ),
             pd.DataFrame(
@@ -236,8 +236,8 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": pd.Series([], dtype="object"),
                     "identifiant_externe": pd.Series([], dtype="object"),
                     "acteur_type_code": pd.Series([], dtype="object"),
-                    "acteurservice_codes": pd.Series([], dtype="object"),
-                    "proposition_services_codes": pd.Series([], dtype="object"),
+                    "acteur_service_codes": pd.Series([], dtype="object"),
+                    "proposition_service_codes": pd.Series([], dtype="object"),
                 }
             ),
         ),
@@ -251,10 +251,10 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": ["source1"],
                     "identifiant_externe": ["id1"],
                     "acteur_type_code": ["commerce"],
-                    "acteurservice_codes": [
+                    "acteur_service_codes": [
                         ["service1", "service2"],
                     ],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [
                             {
                                 "action": "action1",
@@ -272,10 +272,10 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": ["source1"],
                     "identifiant_externe": ["id1"],
                     "acteur_type_code": ["commerce"],
-                    "acteurservice_codes": [
+                    "acteur_service_codes": [
                         ["service1", "service2"],
                     ],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [
                             {
                                 "action": "action1",
@@ -293,10 +293,10 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": ["source1"],
                     "identifiant_externe": ["id1"],
                     "acteur_type_code": ["commerce"],
-                    "acteurservice_codes": [
+                    "acteur_service_codes": [
                         ["service1", "service2"],
                     ],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [
                             {
                                 "action": "action1",
@@ -314,10 +314,10 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": ["source1"],
                     "identifiant_externe": ["id1"],
                     "acteur_type_code": ["commerce"],
-                    "acteurservice_codes": [
+                    "acteur_service_codes": [
                         ["service1", "service2"],
                     ],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [
                             {
                                 "action": "action1",
@@ -328,7 +328,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                 }
             ),
         ),
-        # 5. LIST (acteurservice_codes) updated
+        # 5. LIST (acteur_service_codes) updated
         (
             pd.DataFrame(
                 {
@@ -338,10 +338,10 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": ["source1"],
                     "identifiant_externe": ["id1"],
                     "acteur_type_code": ["commerce"],
-                    "acteurservice_codes": [
+                    "acteur_service_codes": [
                         ["service1", "service2"],
                     ],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [
                             {
                                 "action": "action1",
@@ -359,10 +359,10 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": ["source1"],
                     "identifiant_externe": ["id1"],
                     "acteur_type_code": ["commerce"],
-                    "acteurservice_codes": [
+                    "acteur_service_codes": [
                         ["service1", "service3"],
                     ],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [
                             {
                                 "action": "action1",
@@ -380,10 +380,10 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": ["source1"],
                     "identifiant_externe": ["id1"],
                     "acteur_type_code": ["commerce"],
-                    "acteurservice_codes": [
+                    "acteur_service_codes": [
                         ["service1", "service2"],
                     ],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [
                             {
                                 "action": "action1",
@@ -401,10 +401,10 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": ["source1"],
                     "identifiant_externe": ["id1"],
                     "acteur_type_code": ["commerce"],
-                    "acteurservice_codes": [
+                    "acteur_service_codes": [
                         ["service1", "service3"],
                     ],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [
                             {
                                 "action": "action1",
@@ -415,7 +415,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                 }
             ),
         ),
-        # 6. LIST length (acteurservice_codes) updated
+        # 6. LIST length (acteur_service_codes) updated
         (
             pd.DataFrame(
                 {
@@ -425,10 +425,10 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": ["source1"],
                     "identifiant_externe": ["id1"],
                     "acteur_type_code": ["commerce"],
-                    "acteurservice_codes": [
+                    "acteur_service_codes": [
                         ["service1", "service2"],
                     ],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [
                             {
                                 "action": "action1",
@@ -446,10 +446,10 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": ["source1"],
                     "identifiant_externe": ["id1"],
                     "acteur_type_code": ["commerce"],
-                    "acteurservice_codes": [
+                    "acteur_service_codes": [
                         ["service1"],
                     ],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [
                             {
                                 "action": "action1",
@@ -467,10 +467,10 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": ["source1"],
                     "identifiant_externe": ["id1"],
                     "acteur_type_code": ["commerce"],
-                    "acteurservice_codes": [
+                    "acteur_service_codes": [
                         ["service1", "service2"],
                     ],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [
                             {
                                 "action": "action1",
@@ -488,10 +488,10 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": ["source1"],
                     "identifiant_externe": ["id1"],
                     "acteur_type_code": ["commerce"],
-                    "acteurservice_codes": [
+                    "acteur_service_codes": [
                         ["service1"],
                     ],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [
                             {
                                 "action": "action1",
@@ -502,7 +502,7 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                 }
             ),
         ),
-        # 7. DICT (proposition_services_codes) updated
+        # 7. DICT (proposition_service_codes) updated
         (
             pd.DataFrame(
                 {
@@ -512,10 +512,10 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": ["source1"],
                     "identifiant_externe": ["id1"],
                     "acteur_type_code": ["commerce"],
-                    "acteurservice_codes": [
+                    "acteur_service_codes": [
                         ["service1", "service2"],
                     ],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [
                             {
                                 "action": "action1",
@@ -533,10 +533,10 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": ["source1"],
                     "identifiant_externe": ["id1"],
                     "acteur_type_code": ["commerce"],
-                    "acteurservice_codes": [
+                    "acteur_service_codes": [
                         ["service1", "service2"],
                     ],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [
                             {
                                 "action": "action1",
@@ -554,10 +554,10 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": ["source1"],
                     "identifiant_externe": ["id1"],
                     "acteur_type_code": ["commerce"],
-                    "acteurservice_codes": [
+                    "acteur_service_codes": [
                         ["service1", "service2"],
                     ],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [
                             {
                                 "action": "action1",
@@ -575,10 +575,10 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": ["source1"],
                     "identifiant_externe": ["id1"],
                     "acteur_type_code": ["commerce"],
-                    "acteurservice_codes": [
+                    "acteur_service_codes": [
                         ["service1", "service2"],
                     ],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [
                             {
                                 "action": "action1",
@@ -599,8 +599,8 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": [],
                     "identifiant_externe": [],
                     "acteur_type_code": [],
-                    "acteurservice_codes": [],
-                    "proposition_services_codes": [],
+                    "acteur_service_codes": [],
+                    "proposition_service_codes": [],
                 }
             ),
             pd.DataFrame(
@@ -611,10 +611,10 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": ["source1"],
                     "identifiant_externe": ["id1"],
                     "acteur_type_code": ["commerce"],
-                    "acteurservice_codes": [
+                    "acteur_service_codes": [
                         ["service1", "service2"],
                     ],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [
                             {
                                 "action": "action1",
@@ -632,8 +632,8 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": [],
                     "identifiant_externe": [],
                     "acteur_type_code": [],
-                    "acteurservice_codes": [],
-                    "proposition_services_codes": [],
+                    "acteur_service_codes": [],
+                    "proposition_service_codes": [],
                 }
             ),
             pd.DataFrame(
@@ -644,10 +644,10 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": ["source1"],
                     "identifiant_externe": ["id1"],
                     "acteur_type_code": ["commerce"],
-                    "acteurservice_codes": [
+                    "acteur_service_codes": [
                         ["service1", "service2"],
                     ],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [
                             {
                                 "action": "action1",
@@ -668,10 +668,10 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": ["source1"],
                     "identifiant_externe": ["id1"],
                     "acteur_type_code": ["commerce"],
-                    "acteurservice_codes": [
+                    "acteur_service_codes": [
                         ["service1", "service2"],
                     ],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [
                             {
                                 "action": "action1",
@@ -689,8 +689,8 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": [],
                     "identifiant_externe": [],
                     "acteur_type_code": [],
-                    "acteurservice_codes": [],
-                    "proposition_services_codes": [],
+                    "acteur_service_codes": [],
+                    "proposition_service_codes": [],
                 }
             ),
             pd.DataFrame(
@@ -701,10 +701,10 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": ["source1"],
                     "identifiant_externe": ["id1"],
                     "acteur_type_code": ["commerce"],
-                    "acteurservice_codes": [
+                    "acteur_service_codes": [
                         ["service1", "service2"],
                     ],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [
                             {
                                 "action": "action1",
@@ -722,8 +722,8 @@ from dags.sources.tasks.business_logic.keep_acteur_changed import keep_acteur_ch
                     "source_code": [],
                     "identifiant_externe": [],
                     "acteur_type_code": [],
-                    "acteurservice_codes": [],
-                    "proposition_services_codes": [],
+                    "acteur_service_codes": [],
+                    "proposition_service_codes": [],
                 }
             ),
         ),

--- a/dags_unit_tests/sources/tasks/business_logic/test_source_data_normalize.py
+++ b/dags_unit_tests/sources/tasks/business_logic/test_source_data_normalize.py
@@ -342,7 +342,7 @@ class TestRemoveUndesiredLines:
                             "Particuliers",
                             "Particuliers",
                         ],
-                        "souscategorie_codes": [["code1"], ["code2"], ["code3"]],
+                        "sous_categorie_codes": [["code1"], ["code2"], ["code3"]],
                     }
                 ),
                 pd.DataFrame(
@@ -350,7 +350,7 @@ class TestRemoveUndesiredLines:
                         "identifiant_unique": ["id1"],
                         "service_a_domicile": ["non"],
                         "public_accueilli": ["Particuliers"],
-                        "souscategorie_codes": [["code1"]],
+                        "sous_categorie_codes": [["code1"]],
                     }
                 ),
             ),
@@ -366,7 +366,7 @@ class TestRemoveUndesiredLines:
                             "Professionnels",
                             "Aucun",
                         ],
-                        "souscategorie_codes": [
+                        "sous_categorie_codes": [
                             ["code1"],
                             ["code2"],
                             ["code3"],
@@ -383,7 +383,7 @@ class TestRemoveUndesiredLines:
                             "Particuliers et professionnels",
                             "Aucun",
                         ],
-                        "souscategorie_codes": [["code1"], ["code2"], ["code4"]],
+                        "sous_categorie_codes": [["code1"], ["code2"], ["code4"]],
                     }
                 ),
             ),
@@ -398,7 +398,7 @@ class TestRemoveUndesiredLines:
                             "Particuliers",
                             "Particuliers",
                         ],
-                        "souscategorie_codes": [["code1"], [], ["code3"]],
+                        "sous_categorie_codes": [["code1"], [], ["code3"]],
                     }
                 ),
                 pd.DataFrame(
@@ -406,7 +406,7 @@ class TestRemoveUndesiredLines:
                         "identifiant_unique": ["id1", "id3"],
                         "service_a_domicile": ["non", "non"],
                         "public_accueilli": ["Particuliers", "Particuliers"],
-                        "souscategorie_codes": [["code1"], ["code3"]],
+                        "sous_categorie_codes": [["code1"], ["code3"]],
                     }
                 ),
             ),
@@ -432,12 +432,12 @@ class TestRemoveUndesiredLines:
                         "Particuliers",
                     ],
                     "label_codes": [["label1"], ["label2"], ["label3"]],
-                    "acteurservice_codes": [
+                    "acteur_service_codes": [
                         ["acteurservice1"],
                         ["acteurservice2"],
                         ["acteurservice3"],
                     ],
-                    "proposition_services_codes": [
+                    "proposition_service_codes": [
                         [
                             {
                                 "action": "action1",
@@ -464,11 +464,11 @@ class TestRemoveUndesiredLines:
                 "service_a_domicile": ["non", "non"],
                 "public_accueilli": ["Particuliers", "Particuliers"],
                 "label_codes": [["label1", "label2"], ["label3"]],
-                "acteurservice_codes": [
+                "acteur_service_codes": [
                     ["acteurservice1", "acteurservice2"],
                     ["acteurservice3"],
                 ],
-                "proposition_services_codes": [
+                "proposition_service_codes": [
                     [
                         {"action": "action1", "sous_categories": ["sscat1", "sscat3"]},
                         {"action": "action2", "sous_categories": ["sscat1", "sscat2"]},

--- a/dags_unit_tests/sources/tasks/transform/test_transform_column.py
+++ b/dags_unit_tests/sources/tasks/transform/test_transform_column.py
@@ -11,8 +11,8 @@ from sources.tasks.transform.transform_column import (
     clean_reprise,
     clean_siren,
     clean_siret,
-    clean_souscategorie_codes,
-    clean_souscategorie_codes_sinoe,
+    clean_sous_categorie_codes,
+    clean_sous_categorie_codes_sinoe,
     clean_url,
     convert_opening_hours,
     strip_lower_string,
@@ -320,17 +320,17 @@ class TestCleanSousCategorieCodes:
             ),
         ],
     )
-    def test_clean_souscategorie_codes(
+    def test_clean_sous_categorie_codes(
         self, sscat_list, product_mapping, expected_output, dag_config
     ):
         dag_config.product_mapping = product_mapping
-        result = clean_souscategorie_codes(sscat_list, dag_config)
+        result = clean_sous_categorie_codes(sscat_list, dag_config)
         assert sorted(result) == sorted(expected_output)
 
-    def test_clean_souscategorie_codes_raise(self, dag_config):
+    def test_clean_sous_categorie_codes_raise(self, dag_config):
         dag_config.product_mapping = {"sscat1": 1.0}
         with pytest.raises(ValueError):
-            clean_souscategorie_codes("sscat1", dag_config)
+            clean_sous_categorie_codes("sscat1", dag_config)
 
 
 class TestCleanSouscategorieCodesSinoe:
@@ -390,14 +390,14 @@ class TestCleanSouscategorieCodesSinoe:
             ),
         ],
     )
-    def test_clean_souscategorie_codes_sinoe(
+    def test_clean_sous_categorie_codes_sinoe(
         self, sscats, dechet_mapping, product_mapping, expected_output, dag_config
     ):
         # Mock the DAGConfig
         dag_config.dechet_mapping = dechet_mapping
         dag_config.product_mapping = product_mapping
 
-        result = clean_souscategorie_codes_sinoe(sscats, dag_config)
+        result = clean_sous_categorie_codes_sinoe(sscats, dag_config)
         assert sorted(result) == sorted(expected_output)
 
 

--- a/dags_unit_tests/sources/tasks/transform/test_transform_df.py
+++ b/dags_unit_tests/sources/tasks/transform/test_transform_df.py
@@ -10,7 +10,7 @@ from sources.tasks.transform.transform_df import (
     clean_telephone,
     compute_location,
     get_latlng_from_geopoint,
-    merge_and_clean_souscategorie_codes,
+    merge_and_clean_sous_categorie_codes,
     merge_duplicates,
     merge_sous_categories_columns,
 )
@@ -150,13 +150,13 @@ class TestMergeDuplicates:
                 pd.DataFrame(
                     {
                         "identifiant_unique": [1, 1],
-                        "proposition_services_codes": [[], []],
+                        "proposition_service_codes": [[], []],
                     }
                 ),
                 pd.DataFrame(
                     {
                         "identifiant_unique": [1],
-                        "proposition_services_codes": [[]],
+                        "proposition_service_codes": [[]],
                     }
                 ),
             ),
@@ -164,7 +164,7 @@ class TestMergeDuplicates:
                 pd.DataFrame(
                     {
                         "identifiant_unique": [1, 1],
-                        "proposition_services_codes": [
+                        "proposition_service_codes": [
                             [
                                 {
                                     "action": "action1",
@@ -178,7 +178,7 @@ class TestMergeDuplicates:
                 pd.DataFrame(
                     {
                         "identifiant_unique": [1],
-                        "proposition_services_codes": [
+                        "proposition_service_codes": [
                             [
                                 {
                                     "action": "action1",
@@ -193,7 +193,7 @@ class TestMergeDuplicates:
                 pd.DataFrame(
                     {
                         "identifiant_unique": [1, 1],
-                        "proposition_services_codes": [
+                        "proposition_service_codes": [
                             [
                                 {
                                     "action": "action1",
@@ -212,7 +212,7 @@ class TestMergeDuplicates:
                 pd.DataFrame(
                     {
                         "identifiant_unique": [1],
-                        "proposition_services_codes": [
+                        "proposition_service_codes": [
                             [
                                 {
                                     "action": "action1",
@@ -227,7 +227,7 @@ class TestMergeDuplicates:
                 pd.DataFrame(
                     {
                         "identifiant_unique": [1, 1],
-                        "proposition_services_codes": [
+                        "proposition_service_codes": [
                             [
                                 {
                                     "action": "action1",
@@ -246,7 +246,7 @@ class TestMergeDuplicates:
                 pd.DataFrame(
                     {
                         "identifiant_unique": [1],
-                        "proposition_services_codes": [
+                        "proposition_service_codes": [
                             [
                                 {
                                     "action": "action1",
@@ -261,7 +261,7 @@ class TestMergeDuplicates:
                 pd.DataFrame(
                     {
                         "identifiant_unique": [1, 1],
-                        "proposition_services_codes": [
+                        "proposition_service_codes": [
                             [
                                 {
                                     "action": "action1",
@@ -280,7 +280,7 @@ class TestMergeDuplicates:
                 pd.DataFrame(
                     {
                         "identifiant_unique": [1],
-                        "proposition_services_codes": [
+                        "proposition_service_codes": [
                             [
                                 {
                                     "action": "action1",
@@ -303,7 +303,7 @@ class TestMergeDuplicates:
             df,
             group_column="identifiant_unique",
             merge_as_list_columns=[],
-            merge_as_proposition_service_columns=["proposition_services_codes"],
+            merge_as_proposition_service_columns=["proposition_service_codes"],
         )
 
         result_df = result_df.sort_values(by="identifiant_unique").reset_index(
@@ -532,7 +532,7 @@ class TestCleanAdresse:
 
 class TestCleanActeurserviceCodes:
     @pytest.mark.parametrize(
-        "row_columns, expected_acteurservice_codes",
+        "row_columns, expected_acteur_service_codes",
         [
             ({}, []),
             ({"point_dapport_de_service_reparation": True}, ["service_de_reparation"]),
@@ -553,7 +553,7 @@ class TestCleanActeurserviceCodes:
             ),
         ],
     )
-    def clean_acteurservice_codes(self, row_columns, expected_action_codes):
+    def clean_acteur_service_codes(self, row_columns, expected_action_codes):
         result = clean_action_codes(pd.Series(row_columns), None)
         assert result["action_codes"] == expected_action_codes
 
@@ -627,14 +627,14 @@ class TestMergeAndCleanSouscategorieCodes:
             ({"col1": None, "col2": None}, []),
         ],
     )
-    def test_merge_and_clean_souscategorie_codes(
+    def test_merge_and_clean_sous_categorie_codes(
         self, row_data, expected_output, dag_config
     ):
         dag_config.product_mapping = {"sscat1": "mapped1", "sscat2": "mapped2"}
 
         row = pd.Series(row_data)
-        result = merge_and_clean_souscategorie_codes(row, dag_config)
-        assert sorted(result["souscategorie_codes"]) == sorted(expected_output)
+        result = merge_and_clean_sous_categorie_codes(row, dag_config)
+        assert sorted(result["sous_categorie_codes"]) == sorted(expected_output)
 
 
 class TestGetLatLngFromGeopoint:

--- a/data/models/suggestion.py
+++ b/data/models/suggestion.py
@@ -230,7 +230,7 @@ class Suggestion(models.Model):
     # FIXME: this acteur management will be reviewed with PYDANTIC classes which will
     # be used to handle all specificities of self.suggestions
     def _create_acteur_linked_objects(self, acteur):
-        for proposition_service_code in self.suggestion["proposition_services_codes"]:
+        for proposition_service_code in self.suggestion["proposition_service_codes"]:
             proposition_service = PropositionService.objects.create(
                 action=Action.objects.get(code=proposition_service_code["action"]),
                 acteur=acteur,
@@ -243,7 +243,7 @@ class Suggestion(models.Model):
             label = LabelQualite.objects.get(code=label_code)
             acteur.labels.add(label.id)
 
-        for acteurservice_code in self.suggestion["acteurservice_codes"]:
+        for acteurservice_code in self.suggestion["acteur_service_codes"]:
             acteur_service = ActeurService.objects.get(code=acteurservice_code)
             acteur.acteur_services.add(acteur_service.id)
 


### PR DESCRIPTION
# Description succincte du problème résolu

⚠️ Invalide les suggestions non-validées
⚠️ Modifie le template des source depuis s3

[discussion Mattermost](https://mattermost.incubateur.net/betagouv/pl/onooe88g4pbipq87bm6jy4z4jc)

**🗺️ contexte**: Airflow

**💡 quoi**: Unifier le nommage des variable faisant référence à des code

**🎯 pourquoi**: meilleur compréhension

**🤔 comment**: Renommage

- acteurservice_codes -> acteur_service_codes
- proposition_services_codes -> proposition_service_codes
- souscategorie_codes -> sous_categorie_codes

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [x] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code
