### PR TITLE
🚨 hotfix airfow scheduler dockerfile

### DIFF
--- a/airflow-scheduler.Dockerfile
+++ b/airflow-scheduler.Dockerfile
@@ -2,38 +2,21 @@
 # --- --- --- ---
 FROM apache/airflow:2.10.4 AS python-builder
 
-#---------------------------------
-# Extra dependencies
-#---------------------------------
-# unzip = airflow DAGs to ingest zip files into DB
-# gdal = Django geo
+# system dependencies
 USER root
+
+# unzip for Airflow DAG
 RUN echo "deb http://deb.debian.org/debian stable main" > /etc/apt/sources.list
 RUN apt-get update
 RUN apt-get install -y unzip
 
-# python dependencies
 RUN apt-get install -y --no-install-recommends \
-    gdal-bin libgdal-dev && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    libpq-dev gcc python3-dev
 
-ENV CPLUS_INCLUDE_PATH=/usr/include/gdal
-ENV C_INCLUDE_PATH=/usr/include/gdal
-
-#---------------------------------
-# Rebascule sur l'utilisateur airflow
-#---------------------------------
-# On rebascule sur le dernier utilisateur fourni
-# dans l'image de base
-# https://hub.docker.com/layers/apache/airflow/2.10.4/images/sha256-94b74c8b65924179b961b8838e9eaff2406d72085c612e0f29b72f886df0677e
-USER 50000
-
-# Use user airflow
-RUN chown -R ${AIRFLOW_UID:-50000}:0 /opt/airflow
-USER ${AIRFLOW_UID:-50000}:0
+# python dependencies
 ARG POETRY_VERSION=2.0
 ENV POETRY_NO_INTERACTION=1
+USER ${AIRFLOW_UID:-50000}:0
 RUN pip install "poetry==${POETRY_VERSION}"
 WORKDIR /opt/airflow/
 COPY pyproject.toml poetry.lock ./


### PR DESCRIPTION
# 🚨 hotfix airfow scheduler dockerfile

**🗺️ contexte**: on a fait une session pair avec @kolok dans laquelle on a fait trop de chose en même temps (revue PR, discussion dbt, Django etc...), on a mergé https://github.com/incubateur-ademe/quefairedemesobjets/pull/1427 dans lequel on a pas bien résolu les conflit sur le dockerfile

**💡 quoi**: hotfix sur ce problème:

![image](https://github.com/user-attachments/assets/863683be-b6d5-4175-a748-a4e4b4e49008)

**🎯 pourquoi**: rendre `airflow-scheduler.Dockerfile` à nouveau fonctionnel

**🤔 comment**:
  - je suis **reparti** de [la version](https://github.com/incubateur-ademe/quefairedemesobjets/blob/4a6aa90bf826396a0bc7f4bd6ae576c8a25beac4/airflow-scheduler.Dockerfile) de https://github.com/incubateur-ademe/quefairedemesobjets/pull/1219
  - **ajout** de l'install unzip, requise pour https://github.com/incubateur-ademe/quefairedemesobjets/pull/1427
  - **suppression** d'un `apt-get update` qui devenait redondant
  

## :heavy_check_mark: Vérifications

 - Airflow fonctionne à nouveau (le docker peut être rebuild et 0 problème dans la UI)
 - Les tests passent