### PR TITLE
Correction de DBT et affichage de proposition de service dans django admin

### DIFF
--- a/dbt/macros/table/macro_filtered_propositionservice.sql
+++ b/dbt/macros/table/macro_filtered_propositionservice.sql
@@ -16,6 +16,7 @@ nochild_propositionservice AS (
     FROM qfdmo_vuepropositionservice AS vps
     INNER JOIN {{ ref(ephemeral_filtered_acteur) }} AS cfa
         ON vps.acteur_id = cfa.identifiant_unique AND cfa.parent_id is null
+    GROUP BY 1,2,3
 )
 
 SELECT * FROM parent_propositionservice

--- a/dbt/macros/table/macro_propositionservice.sql
+++ b/dbt/macros/table/macro_propositionservice.sql
@@ -1,12 +1,12 @@
 {%- macro propositionservice(ephemeral_filtered_propositionservice, propositionservice_sous_categories ) -%}
 
 SELECT
-    MIN(ps.id) AS id,
+    ps.id,
     ps.acteur_id,
     ps.action_id
 FROM {{ ref(ephemeral_filtered_propositionservice) }} AS ps
 INNER JOIN {{ ref(propositionservice_sous_categories) }} AS pssscat
    ON ps.id = pssscat.propositionservice_id
-GROUP BY acteur_id, action_id
+GROUP BY ps.id, ps.acteur_id, ps.action_id
 
 {%- endmacro -%}

--- a/dbt/macros/table/macro_propositionservice_sous_categories.sql
+++ b/dbt/macros/table/macro_propositionservice_sous_categories.sql
@@ -5,7 +5,6 @@ with
     AS
     (
         SELECT
-            MIN(pssscat.id) AS id,
             CONCAT(pps.parent_id::text, '_', pps.action_id::text) AS propositionservice_id,
             pssscat.souscategorieobjet_id AS souscategorieobjet_id
         FROM {{ ref("int_propositionservice_sous_categories") }} AS pssscat
@@ -20,18 +19,26 @@ with
     AS
     (
         SELECT
-            pssscat.id AS id,
             pssscat.propositionservice_id AS propositionservice_id,
             pssscat.souscategorieobjet_id AS souscategorieobjet_id
         FROM {{ ref("int_propositionservice_sous_categories") }} AS pssscat
             INNER JOIN {{ ref(ephemeral_filtered_propositionservice) }} AS ps ON pssscat.propositionservice_id = ps.id
             INNER JOIN {{ ref(ephemeral_filtered_acteur) }} AS cfa ON ps.acteur_id = cfa.identifiant_unique AND cfa.parent_id is null
+        GROUP BY
+            pssscat.propositionservice_id,
+            pssscat.souscategorieobjet_id
+    ),
+    propositionservice_sous_categories
+    AS
+    (
+        SELECT *
+            FROM parent_propositionservice_sous_categories
+        UNION ALL
+        SELECT *
+            FROM nochild_propositionservice_sous_categories
     )
 
-SELECT *
-    FROM parent_propositionservice_sous_categories
-UNION ALL
-SELECT *
-    FROM nochild_propositionservice_sous_categories
+SELECT ROW_NUMBER() OVER (ORDER BY propositionservice_id, souscategorieobjet_id) AS id, *
+FROM propositionservice_sous_categories
 
 {%- endmacro -%}

--- a/dbt/models/exposure/carte/schema.yml
+++ b/dbt/models/exposure/carte/schema.yml
@@ -76,10 +76,6 @@ models:
         description: "La date de création de l'acteur"
       - name: statut
         description: "Le statut de l'acteur"
-      - name: revision_existe
-        description: "Le fait que l'acteur est une révision"
-        data_tests:
-          - not_null
     config:
       materialized: table
       indexes:

--- a/qfdmo/admin/acteur.py
+++ b/qfdmo/admin/acteur.py
@@ -541,6 +541,7 @@ class PropositionServiceAdmin(
         "acteur__siren",
     ]
     search_help_text = "Recherche sur le nom, le siret ou le siren de l'acteur"
+    autocomplete_fields = ["acteur"]
 
 
 class RevisionPropositionServiceResource(BasePropositionServiceResource):
@@ -567,6 +568,7 @@ class RevisionPropositionServiceAdmin(
         "acteur__siret",
     ]
     search_help_text = "Recherche sur le nom ou le siret de l'acteur"
+    autocomplete_fields = ["acteur"]
 
 
 class DisplayedActeurResource(ActeurResource):


### PR DESCRIPTION
# Description succincte du problème résolu

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: DBT

**💡 quoi**: DBT plante en preprod car il n'arrive pas à créer un index

```
Database Error in model marts_carte_propositionservice_sous_categories (models/marts/carte/marts_carte_propositionservice_sous_categories.sql)
  could not create unique index "9450cbf251279cdd02bec3eca2da2b31"
  DETAIL:  Key (propositionservice_id, souscategorieobjet_id)=(RPS_369655, 107) is duplicated.
  CONTEXT:  parallel worker
  compiled code at target/run/qfdmo/models/marts/carte/marts_carte_propositionservice_sous_categories.sql
```

**🎯 pourquoi**: mauvaise déduplication après un JOIN

**🤔 comment**: 

* grouper les propositionservice_sous_categories par propositionservice_id, souscategorieobjet_id pour eviter les duplicat
* en débugant, je me suis rendu compte qu'on ne pouvait pas afficher de proposition de service à cause du selecteur d'acteur, j'ai ajouté acteur en `autocomplete_fields`

## Exemple résultats / UI / Data

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
