### PR TITLE
🧹 DAG Airflow pour nettoyer Airflow

### DIFF
--- a/dags/shared/config/__init__.py
+++ b/dags/shared/config/__init__.py
@@ -1,0 +1,3 @@
+from .catchups import CATCHUPS  # noqa: F401
+from .schedules import SCHEDULES  # noqa: F401
+from .start_dates import START_DATES  # noqa: F401

--- a/dags/shared/config/catchups.py
+++ b/dags/shared/config/catchups.py
@@ -1,0 +1,9 @@
+"""To make explicit that for now none of our DAGS work
+on versionned data and there is no reason to use catchups."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CATCHUPS:
+    AWLAYS_FALSE: bool = False

--- a/dags/shared/config/schedules.py
+++ b/dags/shared/config/schedules.py
@@ -1,0 +1,8 @@
+"""Constants for configuring DAG schedules"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SCHEDULES:
+    DAILY: str = "0 0 * * *"

--- a/dags/shared/config/start_dates.py
+++ b/dags/shared/config/start_dates.py
@@ -1,0 +1,14 @@
+"""Constants for configuring DAG start dates.
+We have had issues on new DAGs with Airflow spamming
+the scheduler despite catchup=False, so as extra safety
+we configure start dates to be 1 interval in the past of schedule
+(past needed so Airflow isn't stuck waiting for a constantly
+present/future date) thus if there is catchup, it's only 1 run max."""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+
+@dataclass(frozen=True)
+class START_DATES:
+    FOR_SCHEDULE_DAILY: datetime = datetime.now() - timedelta(days=1)

--- a/dags/tools/dags/airflow_cleanup_db.py
+++ b/dags/tools/dags/airflow_cleanup_db.py
@@ -1,0 +1,149 @@
+"""A DB Cleanup DAG
+- Originally developped by Astronomer: https://www.astronomer.io/docs/learn/cleanup-dag-tutorial
+- Modified to fit our needs"""
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import List, Optional
+
+from airflow.cli.commands.db_command import all_tables
+from airflow.decorators import dag, task
+from airflow.models.param import Param
+from airflow.operators.bash import BashOperator
+from airflow.utils.db import reflect_tables
+from airflow.utils.db_cleanup import _effective_table_names
+from airflow.utils.session import NEW_SESSION, provide_session
+from shared.config import CATCHUPS, SCHEDULES, START_DATES
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+DAYS_TO_KEEP = 7
+
+
+@dag(
+    dag_id="airflow_cleanup_db",
+    dag_display_name="Maintenance - Airflow - Nettoyer la DB (XCOM, logs, etc.)",
+    schedule=SCHEDULES.DAILY,
+    start_date=START_DATES.FOR_SCHEDULE_DAILY,
+    catchup=CATCHUPS.AWLAYS_FALSE,
+    is_paused_upon_creation=False,
+    render_template_as_native_obj=True,
+    max_active_tasks=1,
+    tags=["airflow", "maintenance", "nettoyage", "xcom", "cleanup", "db", "logs"],
+    params={
+        "dry_run": Param(
+            # DAG is meant to run continuously hence the default is False
+            default=False,
+            type="boolean",
+            description="🚱 Si coché: on affiche de l'info mais pas de nettoyage",
+        ),
+        "clean_before_timestamp": Param(
+            default=str(datetime.now(tz=UTC) - timedelta(days=DAYS_TO_KEEP)),
+            type="string",
+            format="date-time",
+            description_md=f"""**📅 Date au delà de laquelle on supprime**: par défaut
+            = aujourd'hui - {DAYS_TO_KEEP} jours""",
+        ),
+        "tables": Param(
+            default=[],
+            type=["null", "array"],
+            examples=all_tables,
+            description_md="**📅 Tables à nettoyer**: par défaut = toutes",
+        ),
+        "batch_size_days": Param(
+            default=7,
+            type="integer",
+            description_md="""**📦 Taille du batch**: par défaut on supprime
+            {batch_size_days} jours à la fois""",
+        ),
+    },
+)
+def airflow_cleanup_db():
+
+    @provide_session
+    def get_oldest_timestamp(
+        tables,
+        session: Session = NEW_SESSION,
+    ) -> Optional[str]:
+        oldest_timestamp_list = []
+        existing_tables = reflect_tables(tables=None, session=session).tables
+        _, effective_config_dict = _effective_table_names(table_names=tables)
+        for table_name, table_config in effective_config_dict.items():
+            if table_name in existing_tables:  # type: ignore
+                orm_model = table_config.orm_model
+                recency_column = table_config.recency_column
+                oldest_execution_date = (
+                    session.query(func.min(recency_column))  # type: ignore
+                    .select_from(orm_model)
+                    .scalar()
+                )
+                if oldest_execution_date:
+                    oldest_timestamp_list.append(oldest_execution_date.isoformat())
+                else:
+                    logging.info(f"No data found for {table_name}, skipping...")
+            else:
+                logging.warning(f"Table {table_name} not found. Skipping.")
+
+        if oldest_timestamp_list:
+            return min(oldest_timestamp_list)
+
+    @task
+    def get_chunked_timestamps(**context) -> List:
+        batches = []
+        start_chunk_time = get_oldest_timestamp(context["params"]["tables"])
+        if start_chunk_time:
+            start_ts = datetime.fromisoformat(start_chunk_time)
+            end_ts = datetime.fromisoformat(context["params"]["clean_before_timestamp"])
+            batch_size_days = context["params"]["batch_size_days"]
+
+            while start_ts < end_ts:
+                batch_end = min(start_ts + timedelta(days=batch_size_days), end_ts)
+                batches.append({"BATCH_TS": batch_end.isoformat()})
+                start_ts += timedelta(days=batch_size_days)
+        logger.info("Number of batches: %s", len(batches))
+        return batches
+
+    # The "clean_archive_tables" task drops archived tables created by
+    # the previous "clean_db" task, in case that task fails due to an error or timeout.
+    db_archive_cleanup = BashOperator(
+        task_id="clean_archive_tables",
+        bash_command="""\
+            airflow db drop-archived \
+        {% if params.tables -%}
+             --tables {{ params.tables|join(',') }} \
+        {% endif -%}
+             --yes \
+        """,
+        do_xcom_push=False,
+        trigger_rule="all_done",
+    )
+
+    chunked_timestamps = get_chunked_timestamps()
+
+    # dry_run mode is directly integrated using the --dry-run flag
+    _ = (  # noqa: F841
+        BashOperator.partial(
+            task_id="db_cleanup",
+            bash_command="""\
+            airflow db clean \
+             --clean-before-timestamp $BATCH_TS \
+        {% if params.dry_run -%}
+             --dry-run \
+        {% endif -%}
+             --skip-archive \
+        {% if params.tables -%}
+             --tables '{{ params.tables|join(',') }}' \
+        {% endif -%}
+             --verbose \
+             --yes \
+        """,
+            append_env=True,
+            do_xcom_push=False,
+        ).expand(env=chunked_timestamps)
+        >> db_archive_cleanup
+    )
+
+
+airflow_cleanup_db()


### PR DESCRIPTION
# 🧹 DAG Airflow pour nettoyer Airflow

Carte Notion/Mattermost/Sentry : [Airflow XCOM: solution durable de nettoyage](https://www.notion.so/accelerateur-transition-ecologique-ademe/Airflow-XCOM-solution-durable-de-nettoyage-1a76523d57d7800aba7be56a495f1a34)

**🗺️ contexte**: on utilise les xcom pour échanger de la donnée (ce qu'on devrait éviter de faire, airflow étant un orchestrateur, pas un compute)

**💡 quoi**: DAG Airflow pour nettoyer la base Airflow

**🎯 pourquoi**: la DB Airflow se remplit et crash périodiquement

**🤔 comment**:
 - J'ai repris https://www.astronomer.io/docs/learn/cleanup-dag-tutorial avec très peux de modifs:
    - fix de `clean_before_timestamp` qui avait besoin d’un `str`
    - renommage à notre sauce
    - ajout d'explications en français
 - **introduction de `shared/config`**: j'ai une autre PR de stabilisation à venir ([Airflow: imposer un catchup=False à tous nos DAGs](https://www.notion.so/accelerateur-transition-ecologique-ademe/Airflow-imposer-un-catchup-False-tous-nos-DAGs-1a06523d57d7804cbeffc8f93307ad97), mais qui va nécessiter de changer tous les DAG, donc plus facile à faire pendant un de nos hackaton). Sachant que: **on a des problèmes de catchup** ET **ce DAG fait de la suppression en masse** je me suis dit que c'était le bon moment pour commencer à introduire cette config censée résoudre le problème de catchup

## 🚱 A propos du `dry_un`

Le `dry_run` est géré par le paramètre `--dry-run` de [la CLI](https://airflow.apache.org/docs/apache-airflow/stable/cli-and-env-variables-ref.html), qui est "noyé" dans la commande bash et donc pas très visible MAIS **il est bien là et marche correctement**:

![image](https://github.com/user-attachments/assets/7aead973-89c2-49c0-af6b-755dad88a8a3)

## :framed_picture: Exemple

### Avant le nettoyage

J'ai des tâches qui remontent au 2025-02-24

![image](https://github.com/user-attachments/assets/76f248e3-61dd-4578-b101-9743d0ed6a82)

### Lancement du DAG

![image](https://github.com/user-attachments/assets/3ab62c35-e448-46c9-921d-5e7e64f0e1b5)


### Après nettoyage


## 📆 A faire (prochaine PR)

- [ ] Etendre & répendre les configurations de `shared/config` à tous nos DAGs pour mieux en centraliser/controller le comportement
