### PR TITLE
Ordonner les acteurs parent selon la dernière date de modification dans le selecteur du formulaire Acteur de Django Admin

### DIFF
--- a/qfdmo/admin/acteur.py
+++ b/qfdmo/admin/acteur.py
@@ -361,6 +361,7 @@ class RevisionActeurParentAdmin(admin.ModelAdmin):
                     .distinct()
                 ),
             )
+            .order_by("-modifie_le")
         )
 
 


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [[Django Admin] Régression : le menu pour sélectionner un parent propose des enfants](https://www.notion.so/accelerateur-transition-ecologique-ademe/Django-Admin-R-gression-le-menu-pour-s-lectionner-un-parent-propose-des-enfants-1a06523d57d780ee8ad4d29a046700b8?pvs=4)

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Django Admin - modification d'un acteur corrigé

**💡 quoi**: La selection des parent n'est pas ordonnée

**🎯 pourquoi**: Pour faire gagnerdu temps à Christian, souvent Christian va selectionner un parent qu'il vient de modifier, du coup, c'est plus simple pour lui de le trouver en haut de la liste

**🤔 comment**: Simplement ajouter un `order_by` sur le queryset de`RevisionActeurParentAdmin`

## Exemple résultats / UI / Data

![CleanShot 2025-03-19 at 10 05 42](https://github.com/user-attachments/assets/17c29ae7-58d4-4620-8029-8e8dbec9b118)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
