### PR TITLE
par défaut, le start_date des dag est hier : cela évite les rattrapages inutiles

### DIFF
--- a/dags/acteurs/dags/compute_acteur_views.py
+++ b/dags/acteurs/dags/compute_acteur_views.py
@@ -1,13 +1,14 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from airflow import DAG
 from airflow.operators.bash import BashOperator
+from airflow.utils.dates import days_ago
 from shared.config.schedules import SCHEDULES
 
 default_args = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": datetime(2025, 2, 14),
+    "start_date": days_ago(1),
     "email_on_failure": False,
     "email_on_retry": False,
     "retries": 3,

--- a/dags/acteurs/dags/compute_acteur_views.py
+++ b/dags/acteurs/dags/compute_acteur_views.py
@@ -1,14 +1,14 @@
 from datetime import timedelta
 
+import pendulum
 from airflow import DAG
 from airflow.operators.bash import BashOperator
-from airflow.utils.dates import days_ago
 from shared.config.schedules import SCHEDULES
 
 default_args = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": days_ago(1),
+    "start_date": pendulum.today("UTC").add(days=-1),
     "email_on_failure": False,
     "email_on_retry": False,
     "retries": 3,

--- a/dags/acteurs/dags/export_opendata.py
+++ b/dags/acteurs/dags/export_opendata.py
@@ -1,15 +1,16 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from acteurs.tasks.airflow_logic.export_opendata_csv_to_s3_task import (
     export_opendata_csv_to_s3_task,
 )
 from airflow import DAG
+from airflow.utils.dates import days_ago
 from shared.config.schedules import SCHEDULES
 
 default_args = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": datetime(2025, 2, 14),
+    "start_date": days_ago(1),
     "email_on_failure": False,
     "email_on_retry": False,
     "retries": 3,

--- a/dags/acteurs/dags/export_opendata.py
+++ b/dags/acteurs/dags/export_opendata.py
@@ -1,16 +1,16 @@
 from datetime import timedelta
 
+import pendulum
 from acteurs.tasks.airflow_logic.export_opendata_csv_to_s3_task import (
     export_opendata_csv_to_s3_task,
 )
 from airflow import DAG
-from airflow.utils.dates import days_ago
 from shared.config.schedules import SCHEDULES
 
 default_args = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": days_ago(1),
+    "start_date": pendulum.today("UTC").add(days=-1),
     "email_on_failure": False,
     "email_on_retry": False,
     "retries": 3,

--- a/dags/clone/dags/clone_ae_annuaire_entreprise.py
+++ b/dags/clone/dags/clone_ae_annuaire_entreprise.py
@@ -4,11 +4,10 @@ DAG to clone the Annuaire Entreprise in our DB.
 running into DB table name length limits.
 """
 
-from datetime import datetime
-
 from airflow import DAG
 from airflow.models.baseoperator import chain
 from airflow.models.param import Param
+from airflow.utils.dates import days_ago
 from clone.tasks.airflow_logic.clone_ae_table_create_etab_task import (
     clone_ea_table_create_etab_task,
 )
@@ -37,7 +36,7 @@ with DAG(
     default_args={
         "owner": "airflow",
         "depends_on_past": False,
-        "start_date": datetime(2025, 3, 5),
+        "start_date": days_ago(1),
         "catchup": False,
         "email_on_failure": False,
         "email_on_retry": False,

--- a/dags/clone/dags/clone_ae_annuaire_entreprise.py
+++ b/dags/clone/dags/clone_ae_annuaire_entreprise.py
@@ -4,10 +4,10 @@ DAG to clone the Annuaire Entreprise in our DB.
 running into DB table name length limits.
 """
 
+import pendulum
 from airflow import DAG
 from airflow.models.baseoperator import chain
 from airflow.models.param import Param
-from airflow.utils.dates import days_ago
 from clone.tasks.airflow_logic.clone_ae_table_create_etab_task import (
     clone_ea_table_create_etab_task,
 )
@@ -36,7 +36,7 @@ with DAG(
     default_args={
         "owner": "airflow",
         "depends_on_past": False,
-        "start_date": days_ago(1),
+        "start_date": pendulum.today("UTC").add(days=-1),
         "catchup": False,
         "email_on_failure": False,
         "email_on_retry": False,

--- a/dags/cluster/dags/cluster_acteur_suggestions.py
+++ b/dags/cluster/dags/cluster_acteur_suggestions.py
@@ -6,11 +6,10 @@ Le traitement des suggestions est géré hors de ce DAG par
 l'app django data_management
 """
 
-from datetime import datetime
-
 from airflow import DAG
 from airflow.models.baseoperator import chain
 from airflow.models.param import Param
+from airflow.utils.dates import days_ago
 from cluster.config.constants import FIELDS_PARENT_DATA_EXCLUDED
 from cluster.config.model import ClusterConfig
 from cluster.tasks.airflow_logic.cluster_acteurs_clusters_display_task import (
@@ -325,7 +324,7 @@ with DAG(
         # Une date bidon dans le passée pour
         # par que Airflow "attende" que la date
         # soit atteinte
-        "start_date": datetime(2025, 1, 1),
+        "start_date": days_ago(1),
         # Notre donnée n'étant pas versionnée dans le temps,
         # faire du catchup n'a pas de sense
         "catchup": False,

--- a/dags/cluster/dags/cluster_acteur_suggestions.py
+++ b/dags/cluster/dags/cluster_acteur_suggestions.py
@@ -6,10 +6,11 @@ Le traitement des suggestions est géré hors de ce DAG par
 l'app django data_management
 """
 
+from datetime import datetime
+
 from airflow import DAG
 from airflow.models.baseoperator import chain
 from airflow.models.param import Param
-from airflow.utils.dates import days_ago
 from cluster.config.constants import FIELDS_PARENT_DATA_EXCLUDED
 from cluster.config.model import ClusterConfig
 from cluster.tasks.airflow_logic.cluster_acteurs_clusters_display_task import (
@@ -324,7 +325,7 @@ with DAG(
         # Une date bidon dans le passée pour
         # par que Airflow "attende" que la date
         # soit atteinte
-        "start_date": days_ago(1),
+        "start_date": datetime(2025, 1, 1),
         # Notre donnée n'étant pas versionnée dans le temps,
         # faire du catchup n'a pas de sense
         "catchup": False,

--- a/dags/compute_acteurs/dags/create_final_actors.py
+++ b/dags/compute_acteurs/dags/create_final_actors.py
@@ -1,7 +1,8 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from airflow import DAG
 from airflow.operators.python import PythonOperator
+from airflow.utils.dates import days_ago
 from compute_acteurs.tasks.airflow_logic import (
     compute_acteur_services_task,
     compute_acteur_task,
@@ -18,7 +19,7 @@ from shared.tasks.database_logic.db_tasks import read_data_from_postgres
 default_args = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": datetime(2024, 2, 7),
+    "start_date": days_ago(1),
     "email_on_failure": False,
     "email_on_retry": False,
     "retries": 1,

--- a/dags/compute_acteurs/dags/create_final_actors.py
+++ b/dags/compute_acteurs/dags/create_final_actors.py
@@ -1,8 +1,8 @@
 from datetime import timedelta
 
+import pendulum
 from airflow import DAG
 from airflow.operators.python import PythonOperator
-from airflow.utils.dates import days_ago
 from compute_acteurs.tasks.airflow_logic import (
     compute_acteur_services_task,
     compute_acteur_task,
@@ -19,7 +19,7 @@ from shared.tasks.database_logic.db_tasks import read_data_from_postgres
 default_args = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": days_ago(1),
+    "start_date": pendulum.today("UTC").add(days=-1),
     "email_on_failure": False,
     "email_on_retry": False,
     "retries": 1,

--- a/dags/crawl/dags/crawl_urls.py
+++ b/dags/crawl/dags/crawl_urls.py
@@ -1,7 +1,6 @@
-from datetime import datetime, timedelta
-
 from airflow import DAG
 from airflow.models.param import Param
+from airflow.utils.dates import days_ago
 from crawl.tasks.airflow_logic.crawl_urls_check_crawl_task import (
     crawl_urls_check_crawl_task,
 )
@@ -43,7 +42,7 @@ with DAG(
     default_args={
         "owner": "airflow",
         "depends_on_past": False,
-        "start_date": datetime(2025, 1, 1) - timedelta(days=1),
+        "start_date": days_ago(1),
         "email_on_failure": False,
         "email_on_retry": False,
         "retries": 0,

--- a/dags/crawl/dags/crawl_urls.py
+++ b/dags/crawl/dags/crawl_urls.py
@@ -1,6 +1,6 @@
+import pendulum
 from airflow import DAG
 from airflow.models.param import Param
-from airflow.utils.dates import days_ago
 from crawl.tasks.airflow_logic.crawl_urls_check_crawl_task import (
     crawl_urls_check_crawl_task,
 )
@@ -42,7 +42,7 @@ with DAG(
     default_args={
         "owner": "airflow",
         "depends_on_past": False,
-        "start_date": days_ago(1),
+        "start_date": pendulum.today("UTC").add(days=-1),
         "email_on_failure": False,
         "email_on_retry": False,
         "retries": 0,

--- a/dags/sources/tasks/airflow_logic/operators.py
+++ b/dags/sources/tasks/airflow_logic/operators.py
@@ -1,6 +1,6 @@
+import pendulum
 from airflow import DAG
 from airflow.models.baseoperator import chain
-from airflow.utils.dates import days_ago
 from sources.tasks.airflow_logic.db_data_prepare_task import db_data_prepare_task
 from sources.tasks.airflow_logic.db_read_acteur_task import db_read_acteur_task
 from sources.tasks.airflow_logic.db_write_type_action_suggestions_task import (
@@ -25,7 +25,7 @@ from sources.tasks.airflow_logic.source_data_validate_task import (
 default_args = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": days_ago(1),
+    "start_date": pendulum.today("UTC").add(days=-1),
     "email_on_failure": False,
     "email_on_retry": False,
     "retries": 1,

--- a/dags/sources/tasks/airflow_logic/operators.py
+++ b/dags/sources/tasks/airflow_logic/operators.py
@@ -1,7 +1,6 @@
-from datetime import datetime
-
 from airflow import DAG
 from airflow.models.baseoperator import chain
+from airflow.utils.dates import days_ago
 from sources.tasks.airflow_logic.db_data_prepare_task import db_data_prepare_task
 from sources.tasks.airflow_logic.db_read_acteur_task import db_read_acteur_task
 from sources.tasks.airflow_logic.db_write_type_action_suggestions_task import (
@@ -26,7 +25,7 @@ from sources.tasks.airflow_logic.source_data_validate_task import (
 default_args = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": datetime(2024, 3, 23),
+    "start_date": days_ago(1),
     "email_on_failure": False,
     "email_on_retry": False,
     "retries": 1,

--- a/dags/suggestions/dags/apply_suggestions.py
+++ b/dags/suggestions/dags/apply_suggestions.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
+import pendulum
 from airflow.models import DAG
-from airflow.utils.dates import days_ago
 from suggestions.tasks.airflow_logic import (
     db_apply_suggestion_task,
     db_check_suggestion_to_process_task,
@@ -11,7 +11,7 @@ from suggestions.tasks.airflow_logic import (
 default_args = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": days_ago(1),
+    "start_date": pendulum.today("UTC").add(days=-1),
     "retries": 1,
     "retry_delay": timedelta(minutes=5),
 }

--- a/dags/tools/dags/airflow_logs.py
+++ b/dags/tools/dags/airflow_logs.py
@@ -1,8 +1,8 @@
 import logging
 
+import pendulum
 from airflow import DAG
 from airflow.operators.python import PythonOperator
-from airflow.utils.dates import days_ago
 from utils.django import django_setup_full
 
 # Load Django environement to test Django and saving airflow logs to s3 storage are
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 default_args = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": days_ago(1),
+    "start_date": pendulum.today("UTC").add(days=-1),
     "email_on_failure": False,
     "email_on_retry": False,
 }

--- a/dags/tools/dags/airflow_logs.py
+++ b/dags/tools/dags/airflow_logs.py
@@ -1,8 +1,8 @@
 import logging
-from datetime import datetime
 
 from airflow import DAG
 from airflow.operators.python import PythonOperator
+from airflow.utils.dates import days_ago
 from utils.django import django_setup_full
 
 # Load Django environement to test Django and saving airflow logs to s3 storage are
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 default_args = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": datetime(2024, 2, 7),
+    "start_date": days_ago(1),
     "email_on_failure": False,
     "email_on_retry": False,
 }

--- a/dags/views/view_acteur_tous.py
+++ b/dags/views/view_acteur_tous.py
@@ -1,18 +1,18 @@
 import time
-from datetime import datetime, timedelta
 from logging import getLogger
 from pathlib import Path
 
 from airflow import DAG
 from airflow.decorators import task
 from airflow.providers.postgres.hooks.postgres import PostgresHook
+from airflow.utils.dates import days_ago
 
 logger = getLogger(__name__)
 
 DEFAULT_ARGS = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d"),
+    "start_date": days_ago(1),
     "email_on_failure": False,
     "email_on_retry": False,
     "retries": 0,

--- a/dags/views/view_acteur_tous.py
+++ b/dags/views/view_acteur_tous.py
@@ -2,17 +2,17 @@ import time
 from logging import getLogger
 from pathlib import Path
 
+import pendulum
 from airflow import DAG
 from airflow.decorators import task
 from airflow.providers.postgres.hooks.postgres import PostgresHook
-from airflow.utils.dates import days_ago
 
 logger = getLogger(__name__)
 
 DEFAULT_ARGS = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": days_ago(1),
+    "start_date": pendulum.today("UTC").add(days=-1),
     "email_on_failure": False,
     "email_on_retry": False,
     "retries": 0,

--- a/dags_unit_tests/e2e/utils.py
+++ b/dags_unit_tests/e2e/utils.py
@@ -11,7 +11,7 @@ from airflow.models import TaskInstance
 logger = logging.getLogger(__name__)
 
 # Function `days_ago` is deprecated and will be removed in Airflow 3.0.
-# from airflow.utils.dates import days_ago
+# import pendulum
 # TODO: remove above once we migrated to Airflow 3.0
 DATE_IN_PAST = pendulum.today("UTC").add(days=-2)
 

--- a/data/admin.py
+++ b/data/admin.py
@@ -76,6 +76,7 @@ class SuggestionAdmin(admin.ModelAdmin):
         "donnees_initiales",
         "changements_suggeres",
     ]
+    readonly_fields = ["cree_le", "modifie_le"]
     list_filter = ["suggestion_cohorte", "statut"]
     actions = [mark_as_rejected, mark_as_toproceed]
 


### PR DESCRIPTION
# Description succincte du problème résolu


**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Airflow

**💡 quoi**: généralisé le la date de début du DAG à hier

**🎯 pourquoi**: Uniformisation du du code

**🤔 comment**: remplacement des date de début arbitrairepar la fonction utilitaire `days_ago`

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
