### PR TITLE
🔗 Crawl URLs: améliorations syntaxe + cohorte "standard"

### DIFF
--- a/dags/crawl/config/cohorts.py
+++ b/dags/crawl/config/cohorts.py
@@ -9,8 +9,8 @@ class COHORTS:
     SYNTAX_FAIL = "🔴 Syntaxe invalide → mise à vide"
     DNS_FAIL = "🔴 Domaine inaccessible → mise à vide"
     CRAWL_FAIL = "🔴 URL inaccessible → mise à vide"
-    CRAWL_DIFF_HTTPS = "🟡 URL différente HTTPs dispo → HTTPs proposée"
-    CRAWL_DIFF_OTHER = "🟡 URL différente (et pas juste HTTPs) → nouvelle proposée"
+    CRAWL_DIFF_STANDARD = "🟢 URL diff standard (ex: http->https) → nouvelle proposée"
+    CRAWL_DIFF_OTHER = "🟠 URL diff non-standard → nouvelle proposée"
 
     # Cohorts for display purposes only
     SYNTAX_OK = "🟢 Syntaxe en succès"

--- a/dags/crawl/config/tasks.py
+++ b/dags/crawl/config/tasks.py
@@ -11,5 +11,5 @@ class TASKS:
     CHECK_CRAWL: str = "crawl_urls_check_crawl"
     SUGGEST_SYNTAX_FAIL: str = "crawl_urls_suggest_syntax_fail"
     SUGGEST_DNS_FAIL: str = "crawl_urls_suggest_dns_fail"
-    SUGGEST_CRAWL_DIFF_HTTPS: str = "crawl_urls_suggest_crawl_diff_https"
+    SUGGEST_CRAWL_DIFF_STANDARD: str = "crawl_urls_suggest_crawl_diff_standard"
     SUGGEST_CRAWL_DIFF_OTHER: str = "crawl_urls_suggest_crawl_diff_other"

--- a/dags/crawl/config/xcoms.py
+++ b/dags/crawl/config/xcoms.py
@@ -23,7 +23,7 @@ class XCOMS:
     DF_SYNTAX_FAIL: str = "df_syntax_fail"
     DF_DNS_OK: str = "df_dns_ok"
     DF_DNS_FAIL: str = "df_dns_fail"
-    DF_CRAWL_DIFF_HTTPS: str = "df_crawl_diff_https"
+    DF_CRAWL_DIFF_STANDARD: str = "df_crawl_diff_standard"
     DF_CRAWL_DIFF_OTHER: str = "df_crawl_diff_other"
     DF_CRAWL_FAIL: str = "df_crawl_fail"
 
@@ -31,7 +31,7 @@ class XCOMS:
     SUGGEST_META: str = "suggestions_metadata"
     SUGGEST_SYNTAX_FAIL: str = "suggestions_syntax_fail"
     SUGGEST_DNS_FAIL: str = "suggestions_dns_fail"
-    SUGGEST_CRAWL_DIFF_HTTPS: str = "suggestions_crawl_diff_https"
+    SUGGEST_CRAWL_DIFF_STANDARD: str = "suggestions_crawl_diff_standard"
     SUGGEST_CRAWL_DIFF_OTHER: str = "suggestions_crawl_diff_other"
 
 
@@ -50,7 +50,7 @@ def xcom_pull(ti: TaskInstance, key: str, skip_if_empty: bool = False) -> Any:
         value = ti.xcom_pull(key=key, task_ids=TASKS.CHECK_DNS)
     elif key == XCOMS.DF_DNS_FAIL:
         value = ti.xcom_pull(key=key, task_ids=TASKS.CHECK_DNS)
-    elif key == XCOMS.DF_CRAWL_DIFF_HTTPS:
+    elif key == XCOMS.DF_CRAWL_DIFF_STANDARD:
         value = ti.xcom_pull(key=key, task_ids=TASKS.CHECK_CRAWL)
     elif key == XCOMS.DF_CRAWL_DIFF_OTHER:
         value = ti.xcom_pull(key=key, task_ids=TASKS.CHECK_CRAWL)

--- a/dags/crawl/dags/crawl_urls.py
+++ b/dags/crawl/dags/crawl_urls.py
@@ -13,11 +13,11 @@ from crawl.tasks.airflow_logic.crawl_urls_check_syntax_task import (
 from crawl.tasks.airflow_logic.crawl_urls_read_urls_from_db_task import (
     crawl_urls_read_urls_from_db_task,
 )
-from crawl.tasks.airflow_logic.crawl_urls_suggest_crawl_diff_https_task import (
-    crawl_urls_suggest_crawl_diff_https_task,
-)
 from crawl.tasks.airflow_logic.crawl_urls_suggest_crawl_diff_other_task import (
     crawl_urls_suggest_crawl_diff_other_task,
+)
+from crawl.tasks.airflow_logic.crawl_urls_suggest_crawl_diff_standard_task import (
+    crawl_urls_suggest_crawl_diff_standard_task,
 )
 from crawl.tasks.airflow_logic.crawl_urls_suggest_dns_fail_task import (
     crawl_urls_suggest_dns_fail_task,
@@ -83,7 +83,7 @@ with DAG(
     check_crawl = crawl_urls_check_crawl_task(dag)
     suggest_syntax = crawl_urls_suggest_syntax_fail_task(dag)
     suggest_dns = crawl_urls_suggest_dns_fail_task(dag)
-    suggest_diff_https = crawl_urls_suggest_crawl_diff_https_task(dag)
+    suggest_diff_standard = crawl_urls_suggest_crawl_diff_standard_task(dag)
     suggest_diff_other = crawl_urls_suggest_crawl_diff_other_task(dag)
 
     # Always reading and checking syntax
@@ -91,4 +91,4 @@ with DAG(
     # DNS depends on syntax
     check_syntax >> check_dns >> suggest_dns  # type: ignore
     # Crawl depends on DNS
-    check_dns >> check_crawl >> [suggest_diff_https, suggest_diff_other]  # type: ignore
+    check_dns >> check_crawl >> [suggest_diff_standard, suggest_diff_other]  # type: ignore

--- a/dags/crawl/tasks/airflow_logic/crawl_urls_check_crawl_task.py
+++ b/dags/crawl/tasks/airflow_logic/crawl_urls_check_crawl_task.py
@@ -36,11 +36,11 @@ def crawl_urls_check_crawl_wrapper(ti, params) -> None:
     if not urls_check_crawl:
         raise AirflowSkipException(f"{urls_check_crawl=}, on s'arrête là")
 
-    df_crawl_diff_https, df_crawl_diff_other, df_crawl_fail = crawl_urls_check_crawl(
+    df_crawl_diff_standard, df_crawl_diff_other, df_crawl_fail = crawl_urls_check_crawl(
         df=xcom_pull(ti, XCOMS.DF_DNS_OK, skip_if_empty=True),
     )
 
-    ti.xcom_push(key=XCOMS.DF_CRAWL_DIFF_HTTPS, value=df_crawl_diff_https)
+    ti.xcom_push(key=XCOMS.DF_CRAWL_DIFF_STANDARD, value=df_crawl_diff_standard)
     ti.xcom_push(key=XCOMS.DF_CRAWL_DIFF_OTHER, value=df_crawl_diff_other)
     ti.xcom_push(key=XCOMS.DF_CRAWL_FAIL, value=df_crawl_fail)
 

--- a/dags/crawl/tasks/airflow_logic/crawl_urls_suggest_crawl_diff_standard_task.py
+++ b/dags/crawl/tasks/airflow_logic/crawl_urls_suggest_crawl_diff_standard_task.py
@@ -14,10 +14,10 @@ def task_info_get():
     return f"""
 
     ============================================================
-    Description de la tâche "{TASKS.SUGGEST_CRAWL_DIFF_HTTPS}"
+    Description de la tâche "{TASKS.SUGGEST_CRAWL_DIFF_STANDARD}"
     ============================================================
 
-    💡 quoi: suggestions pour {COHORTS.CRAWL_DIFF_HTTPS}
+    💡 quoi: suggestions pour {COHORTS.CRAWL_DIFF_STANDARD}
 
     🎯 pourquoi: URLs joignables avec redirection HTTPs
 
@@ -26,20 +26,20 @@ def task_info_get():
     """
 
 
-def crawl_urls_suggest_crawl_diff_https_wrapper(ti, params, dag, run_id) -> None:
+def crawl_urls_suggest_crawl_diff_standard_wrapper(ti, params, dag, run_id) -> None:
     logger.info(task_info_get())
 
     crawl_urls_suggest(
-        df=xcom_pull(ti, XCOMS.DF_CRAWL_DIFF_HTTPS, skip_if_empty=True),
+        df=xcom_pull(ti, XCOMS.DF_CRAWL_DIFF_STANDARD, skip_if_empty=True),
         dag_id=dag.dag_id,
         run_id=run_id,
         dry_run=params.get("dry_run", True),
     )
 
 
-def crawl_urls_suggest_crawl_diff_https_task(dag: DAG) -> PythonOperator:
+def crawl_urls_suggest_crawl_diff_standard_task(dag: DAG) -> PythonOperator:
     return PythonOperator(
-        task_id=TASKS.SUGGEST_CRAWL_DIFF_HTTPS,
-        python_callable=crawl_urls_suggest_crawl_diff_https_wrapper,
+        task_id=TASKS.SUGGEST_CRAWL_DIFF_STANDARD,
+        python_callable=crawl_urls_suggest_crawl_diff_standard_wrapper,
         dag=dag,
     )

--- a/dags/crawl/tasks/business_logic/crawl_urls_check_crawl.py
+++ b/dags/crawl/tasks/business_logic/crawl_urls_check_crawl.py
@@ -8,7 +8,7 @@ from crawl.config.cohorts import COHORTS
 from crawl.config.columns import COLS
 from crawl.config.constants import SORT_COLS
 from crawl.tasks.business_logic.crawl_urls_check_syntax import (
-    urls_are_standard_redirect,
+    urls_are_diff_standard,
 )
 from pydantic import BaseModel
 from sources.config.shared_constants import EMPTY_ACTEUR_FIELD
@@ -139,7 +139,7 @@ def df_cohorts_split(
             # - those which are just HTTP -> HTTPS redirects
             # - those which are more subtantially different
             df_ok_diff[COLS.URL_HTTPS] = df_ok_diff.apply(
-                lambda x: urls_are_standard_redirect(
+                lambda x: urls_are_diff_standard(
                     x[COLS.URL_ORIGIN], x[COLS.CRAWL_URL_SUCCESS]
                 ),
                 axis=1,

--- a/dags/crawl/tasks/business_logic/crawl_urls_check_crawl.py
+++ b/dags/crawl/tasks/business_logic/crawl_urls_check_crawl.py
@@ -8,7 +8,7 @@ from crawl.config.cohorts import COHORTS
 from crawl.config.columns import COLS
 from crawl.config.constants import SORT_COLS
 from crawl.tasks.business_logic.crawl_urls_check_syntax import (
-    urls_are_http_https_versions,
+    urls_are_standard_redirect,
 )
 from pydantic import BaseModel
 from sources.config.shared_constants import EMPTY_ACTEUR_FIELD
@@ -24,7 +24,10 @@ logger = logging.getLogger(__name__)
 
 # Bear minimum to pretend we're a browser
 USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)"
-HEADERS = {"User-Agent": USER_AGENT}
+HEADERS = {
+    "User-Agent": USER_AGENT,
+    "Accept-Language": "fr;q=1.0, *;q=0.0",
+}
 
 
 class CrawlUrlModel(BaseModel):
@@ -105,10 +108,10 @@ def df_cohorts_split(
     # and we have several successive splitings to create cohorts. Maybe
     # we could refactor this to be more elegant.
 
-    # Final df for each cohort we we initialize to None due to the nested
+    # Final df for each cohort: init to None due to nested
     # if structure meaning certain dfs might never be set
     empty = pd.DataFrame()
-    df_ok_same, df_ok_diff_https, df_ok_diff_other = empty, empty, empty
+    df_ok_same, df_ok_diff_standard, df_ok_diff_other = empty, empty, empty
 
     # Splitting success vs. failure
     filter_success = df[COLS.CRAWL_WAS_SUCCESS]
@@ -136,38 +139,38 @@ def df_cohorts_split(
             # - those which are just HTTP -> HTTPS redirects
             # - those which are more subtantially different
             df_ok_diff[COLS.URL_HTTPS] = df_ok_diff.apply(
-                lambda x: urls_are_http_https_versions(
+                lambda x: urls_are_standard_redirect(
                     x[COLS.URL_ORIGIN], x[COLS.CRAWL_URL_SUCCESS]
                 ),
                 axis=1,
             )
             filter_https = df_ok_diff[COLS.URL_HTTPS]
-            df_ok_diff_https, df_ok_diff_other = df_split_on_filter(
+            df_ok_diff_standard, df_ok_diff_other = df_split_on_filter(
                 df_ok_diff, filter_https
             )
 
             # Final cohorts
-            df_ok_diff_https[COLS.COHORT] = COHORTS.CRAWL_DIFF_HTTPS
+            df_ok_diff_standard[COLS.COHORT] = COHORTS.CRAWL_DIFF_STANDARD
             df_ok_diff_other[COLS.COHORT] = COHORTS.CRAWL_DIFF_OTHER
 
             # Sorting
-            df_ok_diff_https = df_sort(df_ok_diff_https, sort_cols=SORT_COLS)
+            df_ok_diff_standard = df_sort(df_ok_diff_standard, sort_cols=SORT_COLS)
             df_ok_diff_other = df_sort(df_ok_diff_other, sort_cols=SORT_COLS)
 
     logging.info(log.banner_string("🏁 Résultat final de cette tâche"))
     log.preview_df_as_markdown(COHORTS.CRAWL_OK_SAME, df_ok_same)
-    log.preview_df_as_markdown(COHORTS.CRAWL_DIFF_HTTPS, df_ok_diff_https)
+    log.preview_df_as_markdown(COHORTS.CRAWL_DIFF_STANDARD, df_ok_diff_standard)
     log.preview_df_as_markdown(COHORTS.CRAWL_DIFF_OTHER, df_ok_diff_other)
     log.preview_df_as_markdown(COHORTS.CRAWL_FAIL, df_crawl_fail)
 
     # Validation: all cohorts should add up to the original df
     dfs_assert_add_up_to_df(
-        dfs=[df_ok_same, df_ok_diff_https, df_ok_diff_other, df_crawl_fail],
+        dfs=[df_ok_same, df_ok_diff_standard, df_ok_diff_other, df_crawl_fail],
         df=df,
     )
 
     # We only return what we make suggestions for, thus df_ok_same left out
-    return df_ok_diff_https, df_ok_diff_other, df_crawl_fail
+    return df_ok_diff_standard, df_ok_diff_other, df_crawl_fail
 
 
 def crawl_urls_check_crawl(

--- a/dags/crawl/tasks/business_logic/crawl_urls_check_syntax.py
+++ b/dags/crawl/tasks/business_logic/crawl_urls_check_syntax.py
@@ -36,7 +36,7 @@ def url_is_valid(url) -> bool:
         return False
 
 
-def urls_are_standard_redirect(url1, url2) -> bool:
+def urls_are_diff_standard(url1, url2) -> bool:
     """Check if 2 URLs a "standard" redirection of each other, defined as:
     - case insensitive
     - http vs. https

--- a/dags/crawl/tasks/business_logic/crawl_urls_check_syntax.py
+++ b/dags/crawl/tasks/business_logic/crawl_urls_check_syntax.py
@@ -21,8 +21,8 @@ def url_is_valid(url) -> bool:
     """Checks if URL is valid"""
     try:
         # Not using urlparse which was too permissive
-        # (e.g. it accepts "http://")
-        # Using a regex also allows us to be more specific
+        # (e.g. it accepts "http://" only)
+        # Using a regex also allows to be more specific
         # with what we consider a valid URL vs. pure technical
         # aspect
         pattern = re.compile(
@@ -36,13 +36,18 @@ def url_is_valid(url) -> bool:
         return False
 
 
-def urls_are_http_https_versions(url1, url2) -> bool:
-    """Check if 2 URLs are http and https versions of each other,
-    which helps us create a special cohort of "safe" recommendations
-    of HTTP -> HTTPS URLs"""
+def urls_are_standard_redirect(url1, url2) -> bool:
+    """Check if 2 URLs a "standard" redirection of each other, defined as:
+    - case insensitive
+    - http vs. https
+    - www vs. no www
+    - tolerate trailing slashes
+    """
     if not url1 or not url1.strip() or not url2 or not url2.strip():
         return False
-    return re.sub(r"^https?://", "", url1) == re.sub(r"^https?://", "", url2)
+    url1 = re.sub(r"^https?://(www\.)?|/$", "", url1.strip(), flags=re.I).lower()
+    url2 = re.sub(r"^https?://(www\.)?|/$", "", url2.strip(), flags=re.I).lower()
+    return url1 == url2
 
 
 def url_domain_get(url: str) -> str | None:
@@ -68,13 +73,16 @@ def url_to_dns_to_try(url: str) -> list[str] | None:
     return [domain] if domain else None
 
 
-def url_protocol_fix(url: str) -> str:
+def url_fix_protocol(url: str) -> str:
     """Tries to fix protocol from URL as we
     have encountered several examples of urls
     with missing or extra : or /"""
     # Removing noise before http
     if not url.startswith("http"):
         url = re.sub(r".*http", r"http", url)
+
+    # Duplicate protocols (replace up to 2nd http takes care of optional s)
+    url = re.sub(r"(https?(?:://)?http)", r"http", url)
 
     # Adding https if protocol totally missing
     if not url.startswith("http"):
@@ -95,6 +103,24 @@ def url_protocol_fix(url: str) -> str:
     return url
 
 
+def url_fix_www(url: str) -> str:
+    """Attempts to fix the www as we have had many cases of:
+    - missing dot
+    - too many or too few www"""
+    return re.sub(r"^(https?://)((?:ww\.?|wwww+\.?))([^w])", r"\1www.\3", url)
+
+
+def url_fix_language(url: str) -> str:
+    """Replacing the common English language code
+    coming out of using a crawler"""
+    return re.sub("/en/?$", "/", url)
+
+
+def url_fix_consecutive_dots(url: str) -> str:
+    """Fix multiple consecutive dots"""
+    return re.sub(r"\.{2,}", ".", url)
+
+
 def url_to_urls_to_try(url: str) -> list[str] | None:
     """Suggests URLs to try from a given URL,
     return None if no suggestion can be made"""
@@ -108,7 +134,11 @@ def url_to_urls_to_try(url: str) -> list[str] | None:
     if "." not in url:
         return None
 
-    url = url_protocol_fix(url)
+    # Various fixes
+    url = url_fix_protocol(url)
+    url = url_fix_www(url)
+    url = url_fix_consecutive_dots(url)
+    url = url_fix_language(url)
 
     results = []
 

--- a/dags_unit_tests/crawl/tasks/business_logic/test_crawl_urls_check_crawl.py
+++ b/dags_unit_tests/crawl/tasks/business_logic/test_crawl_urls_check_crawl.py
@@ -14,7 +14,7 @@ from dags.crawl.tasks.business_logic.crawl_urls_check_crawl import (
 )
 
 
-class TestHandler(BaseHTTPRequestHandler):
+class MockHTTPHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         if self.path == "/200":
             self.send_response(200)
@@ -41,7 +41,7 @@ class TestHandler(BaseHTTPRequestHandler):
 
 @pytest.fixture(scope="module")
 def test_server():
-    server = HTTPServer(("localhost", 0), TestHandler)
+    server = HTTPServer(("localhost", 0), MockHTTPHandler)
     port = server.server_address[1]
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -91,7 +91,7 @@ class TestCrawlUrlsCheckCrawl:
             COLS.DOMAINS_TO_TRY: ["localhost"],
         }
         # 🟡 URL différente HTTPs dispo -> HTTPs proposée
-        case_diff_https = {
+        case_diff_standard = {
             COLS.CRAWL_WAS_SUCCESS: True,
             COLS.URL_ORIGIN: "http://www.google.com/",
             COLS.URLS_TO_TRY: ["https://www.google.com/"],
@@ -118,7 +118,7 @@ class TestCrawlUrlsCheckCrawl:
             [
                 case_ok_same,
                 # x 1
-                case_diff_https,
+                case_diff_standard,
                 # x 2
                 case_diff_other,
                 case_diff_other,
@@ -128,10 +128,10 @@ class TestCrawlUrlsCheckCrawl:
                 case_fail,
             ]
         )
-        df_ok_diff_https, df_ok_diff_other, df_fail = df_cohorts_split(df=df)
-        assert len(df_ok_diff_https) == 1
+        df_ok_diff_standard, df_ok_diff_other, df_fail = df_cohorts_split(df=df)
+        assert len(df_ok_diff_standard) == 1
         assert len(df_ok_diff_other) == 2
         assert len(df_fail) == 3
-        assert df_ok_diff_https[COLS.COHORT].iloc[0] == COHORTS.CRAWL_DIFF_HTTPS
+        assert df_ok_diff_standard[COLS.COHORT].iloc[0] == COHORTS.CRAWL_DIFF_STANDARD
         assert df_ok_diff_other[COLS.COHORT].iloc[0] == COHORTS.CRAWL_DIFF_OTHER
         assert df_fail[COLS.COHORT].iloc[0] == COHORTS.CRAWL_FAIL

--- a/dags_unit_tests/crawl/tasks/business_logic/test_crawl_urls_check_syntax.py
+++ b/dags_unit_tests/crawl/tasks/business_logic/test_crawl_urls_check_syntax.py
@@ -12,7 +12,7 @@ from dags.crawl.tasks.business_logic.crawl_urls_check_syntax import (
     url_fix_www,
     url_is_valid,
     url_to_urls_to_try,
-    urls_are_standard_redirect,
+    urls_are_diff_standard,
 )
 
 
@@ -62,8 +62,8 @@ class TestUrlsAreStandardRedirect:
             ("https://a.com", "https://b.com", False),
         ],
     )
-    def test_urls_are_standard_redirect(self, url1, url2, expected):
-        assert urls_are_standard_redirect(url1, url2) == expected
+    def test_urls_are_diff_standard(self, url1, url2, expected):
+        assert urls_are_diff_standard(url1, url2) == expected
 
 
 class TestUrlDomainGet:

--- a/dags_unit_tests/crawl/tasks/business_logic/test_crawl_urls_check_syntax.py
+++ b/dags_unit_tests/crawl/tasks/business_logic/test_crawl_urls_check_syntax.py
@@ -7,10 +7,12 @@ from dags.crawl.config.columns import COLS
 from dags.crawl.tasks.business_logic.crawl_urls_check_syntax import (
     crawl_urls_check_syntax,
     url_domain_get,
+    url_fix_language,
+    url_fix_protocol,
+    url_fix_www,
     url_is_valid,
-    url_protocol_fix,
     url_to_urls_to_try,
-    urls_are_http_https_versions,
+    urls_are_standard_redirect,
 )
 
 
@@ -40,15 +42,17 @@ class TestUrlIsValid:
         assert url_is_valid(url) == expected
 
 
-class TestUrlsAreHttpAndHttpsVersions:
+class TestUrlsAreStandardRedirect:
 
     @pytest.mark.parametrize(
         ("url1", "url2", "expected"),
         [
             # Valid cases
-            ("http://a.com", "https://a.com", True),
-            ("https://b.com", "http://b.com", True),
-            ("https://c.com", "https://c.com", True),
+            ("http://a.com", "https://a.com", True),  # http -> https
+            ("https://b.com", "http://b.com", True),  # https -> http
+            ("HTTPS://C.COM", "https://c.com", True),  # case
+            # http->https + no www->www + trailing slash
+            ("http://a.com", "https://www.a.com/", True),
             # Empty cases
             ("  ", "", False),
             ("", "https://a.com", False),
@@ -58,11 +62,32 @@ class TestUrlsAreHttpAndHttpsVersions:
             ("https://a.com", "https://b.com", False),
         ],
     )
-    def test_crawl_urls_are_http_and_https_versions(self, url1, url2, expected):
-        assert urls_are_http_https_versions(url1, url2) == expected
+    def test_urls_are_standard_redirect(self, url1, url2, expected):
+        assert urls_are_standard_redirect(url1, url2) == expected
 
 
-class TestUrlProtocolFix:
+class TestUrlDomainGet:
+
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            # Valid cases
+            ("http://a.com", "a.com"),
+            ("https://b.com", "b.com"),
+            # We don't tolerate ports in URLs, thus we
+            # don't try to extract the domain
+            ("https://www.c.com:8080", None),
+            # Empty
+            (None, None),
+            ("", None),
+            ("   ", None),
+        ],
+    )
+    def test_crawl_url_domain_get(self, url, expected):
+        assert url_domain_get(url) == expected
+
+
+class TestUrlFixProtocol:
 
     @pytest.mark.parametrize(
         ("url", "expected"),
@@ -88,31 +113,53 @@ class TestUrlProtocolFix:
             ("https:///c.com", "https://c.com"),
             # Full mess
             ("ahttps::///c.com", "https://c.com"),
+            # Duplicate protocols
+            ("httphttp://b.com", "http://b.com"),
+            ("http://http://b.com", "http://b.com"),
+            ("httpshttps://b.com", "https://b.com"),
+            ("https://https://b.com", "https://b.com"),
         ],
     )
-    def test_crawl_url_protocol_fix(self, url, expected):
-        assert url_protocol_fix(url) == expected
+    def test_crawl_url_fix_protocol(self, url, expected):
+        assert url_fix_protocol(url) == expected
 
 
-class TestUrlDomainGet:
+class TestUrlFixWww:
 
     @pytest.mark.parametrize(
         ("url", "expected"),
         [
-            # Valid cases
-            ("http://a.com", "a.com"),
-            ("https://b.com", "b.com"),
-            # We don't tolerate ports in URLs, thus we
-            # don't try to extract the domain
-            ("https://www.c.com:8080", None),
-            # Empty
-            (None, None),
-            ("", None),
-            ("   ", None),
+            # CHANGED:
+            # 2 w (w/ and w/o dot)
+            ("https://ww.b.com", "https://www.b.com"),
+            ("https://wwb.com", "https://www.b.com"),
+            # 4+ w (w/ and w/o dot)
+            ("https://wwwwb.com", "https://www.b.com"),
+            ("https://wwwwwb.com", "https://www.b.com"),
+            # 3 w (w/ and w/o dot)
+            ("https://wwwwb.com", "https://www.b.com"),
+            # UNCHANGED:
+            ("https://wwww.b.com", "https://www.b.com"),
         ],
     )
-    def test_crawl_url_domain_get(self, url, expected):
-        assert url_domain_get(url) == expected
+    def test_crawl_url_fix_www(self, url, expected):
+        assert url_fix_www(url) == expected
+
+
+class TestUrlFixLanguage:
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            # Replacements
+            ("https://www.b.com/en", "https://www.b.com/"),
+            ("https://www.b.com/en/", "https://www.b.com/"),
+            # No replacement
+            ("https://www.b.com/fr/", "https://www.b.com/fr/"),
+            ("https://www.b.com/environnement", "https://www.b.com/environnement"),
+        ],
+    )
+    def test_crawl_url_fix_language(self, url, expected):
+        assert url_fix_language(url) == expected
 
 
 class TestUrlSyntaxSuggestReplacements:
@@ -123,6 +170,15 @@ class TestUrlSyntaxSuggestReplacements:
             # Valid cases
             # We always add a https version if missing
             ("http://a.com", ["https://a.com", "http://a.com"]),
+            # Test url_fix_www
+            ("http://ww.b.com", ["https://www.b.com", "http://www.b.com"]),
+            ("http://wwwwb.com", ["https://www.b.com", "http://www.b.com"]),
+            # Test url_fix_consecutive_dots
+            ("http://www.b..com", ["https://www.b.com", "http://www.b.com"]),
+            ("http://www..b..fr", ["https://www.b.fr", "http://www.b.fr"]),
+            # Test url_fix_language
+            ("http://www.b.com/en", ["https://www.b.com/", "http://www.b.com/"]),
+            ("http://www.b.com/en/", ["https://www.b.com/", "http://www.b.com/"]),
             # Cleanup cases
             ("ahttps://b.com", ["https://b.com"]),
             ("https:://b.com", ["https://b.com"]),


### PR DESCRIPTION
# 🔗 Crawl URLs: mieux sur syntaxe + cohorte "standard"

Carte Notion: [Revue des URL cassées dans notre bdd](https://www.notion.so/accelerateur-transition-ecologique-ademe/Revue-des-URL-cass-es-dans-notre-bdd-1bb6523d57d78014a144fc517da8e4cf) de @chrischarousset 

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: @chrischarousset a fait tourné le DAG de crawl, et a identifié des améliorations

**💡 quoi**: divers changements de nettoyage de syntaxe + changement d'1 cohorte

**🎯 pourquoi**: améliorer le taux de correction, réduire les faux positifs

**🤔 comment**:
 - **cohorte HTTP -> HTTPS** devient **standard** et regroupe les changements considérés comme normaux et a approuvé avec confiance, à savoir on **tolère les changements de**
    - `casse`
    - `www`
    - `http -> https`
    - `/ en fin `
 - **langue du parseur = 🇫🇷** pour éviter les redirections type `/en`

## :calendar: Prochaine PR

 - [ ] **Tester avec LLM** si on veut aller au delà, gestion de tous les cas de figures en instruction machine c'est sans fin