### PR TITLE
📖 Suggestions: ouvrir détails par défaut

### DIFF
--- a/data/models/suggestion.py
+++ b/data/models/suggestion.py
@@ -150,14 +150,21 @@ class Suggestion(models.Model):
                 for item in self.contexte
                 if isinstance(item, dict)
             ]
-        return render_to_string(
-            "data/_partials/contexte_details.html",
-            {
-                "contexte": self.contexte,
-                "identifiant_unique": identifiant_unique,
-                "identifiant_uniques": identifiant_uniques,
-            },
-        )
+
+        context = {
+            "contexte": self.contexte,
+            "identifiant_unique": identifiant_unique,
+            "identifiant_uniques": identifiant_uniques,
+        }
+
+        # Opening details toggle by default
+        if self.suggestion_cohorte.type_action in [
+            SuggestionAction.CLUSTERING,
+            SuggestionAction.CRAWL_URLS,
+        ]:
+            context["details_open"] = True
+
+        return render_to_string("data/_partials/contexte_details.html", context)
 
     # FIXME: this display management will be reviewed with PYDANTIC classes which will
     # be used to handle all specificities of suggestions

--- a/templates/data/_partials/contexte_details.html
+++ b/templates/data/_partials/contexte_details.html
@@ -20,7 +20,7 @@
     {% endif %}
 </p>
 {% if contexte %}
-    <details>
+    <details {% if details_open %}open{% endif %}>
         <summary>Details</summary>
         {% include "data/_partials/value_details.html" with value=contexte %}
     </details>


### PR DESCRIPTION
# 📖 Suggestions: ouvrir détails par défaut

Carte Notion: [[Clustering - Suggestions] Petites améliorations post v1](https://www.notion.so/accelerateur-transition-ecologique-ademe/Clustering-Suggestions-Petites-am-liorations-post-v1-1a66523d57d780679b48e2084590efb1)

**🗺️ contexte**: on génère des suggestions de changement, par défaut le `<details>` du contexte est toujours fermé

**💡 quoi**: permettre d'ouvrir le `<details>` par défaut pour certaines suggestions

**🎯 pourquoi**: réduire les cliques / faire économiser du temps au métier

**🤔 comment**:
  - `templates/data/_partials/contexte_details.html`: ajout du paramètre `details_open`
  - `data/models/suggestion.py`: gestion de ce paramètre pour les différents cas d'usage

## :framed_picture:  Illustration

Avec le changement: ouverture par défaut sur les suggestions de clustering:

![image](https://github.com/user-attachments/assets/b9e7a040-06db-4ce8-a79c-bc0097b2b476)