### PR TITLE
Réponse redirect et non trouvé sur les routes adresse et adresse-details

### DIFF
--- a/integration_tests/qfdmo/test_acteur_detail.py
+++ b/integration_tests/qfdmo/test_acteur_detail.py
@@ -5,6 +5,7 @@ from qfdmo.models.acteur import ActeurStatus
 from unit_tests.qfdmo.acteur_factory import (
     DisplayedActeurFactory,
     LabelQualiteFactory,
+    RevisionActeurFactory,
     SourceFactory,
 )
 
@@ -183,6 +184,33 @@ class TestRedirects:
         url = f"/adresse/{acteur.identifiant_unique}"
         response = client.get(url)
         assert response.status_code == 301
+
+    def test_redirect_to_parent_acteur(self, client):
+        parent_revision_acteur = RevisionActeurFactory(
+            identifiant_unique="parent",
+        )
+        child_revision_acteur = RevisionActeurFactory(
+            identifiant_unique="child",
+            parent=parent_revision_acteur,
+        )
+        parent_displayed_acteur = DisplayedActeurFactory(
+            identifiant_unique=parent_revision_acteur.identifiant_unique,
+        )
+
+        url = f"/adresse/{child_revision_acteur.identifiant_unique}"
+        response = client.get(url)
+        assert response.status_code == 301
+        assert response.url == f"/adresse_details/{parent_displayed_acteur.uuid}"
+
+    def test_adresse_details_404_not_found(self, client):
+        url = "/adresse_details/doesnt_exist"
+        response = client.get(url)
+        assert response.status_code == 404
+
+    def test_adresse_404_not_found(self, client):
+        url = "/adresse/doesnt_exist"
+        response = client.get(url)
+        assert response.status_code == 404
 
     def not_found_actor_do_not_raise_error(self, client):
         pass

--- a/qfdmo/views/adresses.py
+++ b/qfdmo/views/adresses.py
@@ -7,11 +7,12 @@ from django.conf import settings
 from django.contrib.postgres.lookups import Unaccent
 from django.contrib.postgres.search import TrigramWordDistance
 from django.core.cache import cache
+from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
 from django.db.models.functions import Length, Lower
 from django.db.models.query import QuerySet
 from django.forms import model_to_dict
-from django.http import JsonResponse
+from django.http import Http404, JsonResponse
 from django.shortcuts import redirect, render
 from django.utils.safestring import mark_safe
 from django.views.decorators.http import require_GET
@@ -614,10 +615,20 @@ def get_object_list(request):
     )
 
 
+def _get_acteur_or_parent(**query_kwargs) -> DisplayedActeur | None:
+    try:
+        return DisplayedActeur.objects.get(**query_kwargs)
+    except DisplayedActeur.DoesNotExist:
+        revision_acteur = RevisionActeur.objects.get(**query_kwargs)
+        return DisplayedActeur.objects.get(identifiant_unique=revision_acteur.parent_id)
+
+
 def acteur_detail_redirect(request, identifiant_unique):
-    displayed_acteur = DisplayedActeur.objects.get(
-        identifiant_unique=identifiant_unique
-    )
+    try:
+        displayed_acteur = _get_acteur_or_parent(identifiant_unique=identifiant_unique)
+    except ObjectDoesNotExist:
+        raise Http404("L'adresse que vous cherchez n'existe plus")
+
     return redirect("qfdmo:acteur-detail", uuid=displayed_acteur.uuid, permanent=True)
 
 
@@ -640,9 +651,14 @@ def acteur_detail(request, uuid):
             "sources",
         ).get(uuid=uuid)
     except DisplayedActeur.DoesNotExist:
-        return redirect(settings.ASSISTANT["BASE_URL"], permanent=True)
+        # FIXME: it is impossible to get check if the revisionacteur has a parent
+        # because the revision_acteur doesn't have any UUID
+        # to resolve it we need compute uuid on revisionacteur layer
+        raise Http404("L'adresse que vous cherchez n'existe plus")
 
-    if displayed_acteur.statut != ActeurStatus.ACTIF:
+    # FIXME: This case shouldn't occure because we compute only active displayed
+    # acteurs in dislayedacteur table
+    if displayed_acteur is None or displayed_acteur.statut != ActeurStatus.ACTIF:
         return redirect(settings.ASSISTANT["BASE_URL"], permanent=True)
 
     context = {


### PR DESCRIPTION
# Description succincte du problème résolu

Pour faire suite à notre séminaire
- la route `/adresse` redirige vers `/adresse-details` si l'acteur affiché existe
- la route `/adresse` redirige vers `/adresse-details` vers le parent si l'acteur affiché n'existe car il a un parent
- la route `/adresse-details` retourne 404 si l'acteur n'existe pas
- la route `/adresse-details` affiche la fiche acteur sinon

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: fiche acteur detail

**💡 quoi**: Rediriger correctement le cas echéant

**🎯 pourquoi**: perdre le moins de SEO possible

**🤔 comment**: 

- la route `/adresse` redirige vers `/adresse-details` si l'acteur affiché existe
- la route `/adresse` redirige vers `/adresse-details` vers le parent si l'acteur affiché n'existe car il a un parent
- la route `/adresse-details` retourne 404 si l'acteur n'existe pas
- la route `/adresse-details` affiche la fiche acteur sinon

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [x] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code

## 📆 A faire (prochaine PR)

- [ ] Gestion de la redirection de `/adresse-details` -> `/adresse-details` dans le cas d'une relation enfant - parent
Pour ce faire, il faut que les révisions ai des uuid (ce qui est une modification importante)
