### PR TITLE
downgrade django pour django-import-export en attendant la 5.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1678,14 +1678,14 @@ static3 = "*"
 
 [[package]]
 name = "django"
-version = "5.1.7"
+version = "5.1.6"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "Django-5.1.7-py3-none-any.whl", hash = "sha256:1323617cb624add820cb9611cdcc788312d250824f92ca6048fda8625514af2b"},
-    {file = "Django-5.1.7.tar.gz", hash = "sha256:30de4ee43a98e5d3da36a9002f287ff400b43ca51791920bfb35f6917bfe041c"},
+    {file = "Django-5.1.6-py3-none-any.whl", hash = "sha256:8d203400bc2952fbfb287c2bbda630297d654920c72a73cc82a9ad7926feaad5"},
+    {file = "Django-5.1.6.tar.gz", hash = "sha256:1e39eafdd1b185e761d9fab7a9f0b9fa00af1b37b25ad980a8aa0dac13535690"},
 ]
 
 [package.dependencies]
@@ -7381,4 +7381,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12,<3.13"
-content-hash = "a0b04baa06786979be7e4a41886f9d9866b0d46f2beba873135d2f2e73f6b646"
+content-hash = "63f76ff1372199cb096156bf9f6f820864bdc3e7131e9a2a9b2ae613e77a6f7a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ python = "^3.12,<3.13"
 api-insee = "^1.6"
 boto3 = "<1.36"
 dj-database-url = "^2.3.0"
-django = "^5.1.4"
+django = "<=5.1.6" # cf. https://github.com/django/django/issues/16589
 django-extensions = "^3.2.3"
 django-import-export = {extras = ["xls", "xlsx"], version = "^4.3.3"}
 django-ninja = "^1.3.0"


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [je viens d'avoir la même erreur en préprod (sur de l'import d'acteurs) que j'ai eu hier en prod](https://mattermost.incubateur.net/betagouv/pl/j86k66wuy3f15cq81oca5s5yce)

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: import export

**💡 quoi**: regression à cause de django en 5.1.7 (cf. https://github.com/django/django/pull/19233)

**🎯 pourquoi**: pour que ça marche

**🤔 comment**: edition de pyproject pour fixer en 5.1.6

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
