### PR TITLE
🦦 Ajout des sources dans l'API Rest 

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -3,6 +3,6 @@ from ninja import NinjaAPI
 from qfdmd.api import router as qfdmd_router
 from qfdmo.api import router as qfdmo_router
 
-api = NinjaAPI(title="Longue vie aux objets", version="0.0.1")
+api = NinjaAPI(title="Longue vie aux objets", version="0.0.2")
 api.add_router("/qfdmo/", qfdmo_router, tags=["Que faire de mes objets"])
 api.add_router("/qfdmd/", qfdmd_router, tags=["Que faire de mes déchets"])

--- a/qfdmo/admin/acteur.py
+++ b/qfdmo/admin/acteur.py
@@ -577,14 +577,31 @@ class DisplayedActeurResource(ActeurResource):
         model = DisplayedActeur
 
 
-class OpenSourceDisplayedActeurResource(resources.ModelResource):
+class GenericExporterMixin:
+    licenses = []
+
+    def get_sources(self, acteur):
+        sources = ["Longue Vie Aux Objets", "ADEME"]
+        acteur_sources = acteur.sources.all()
+        if self.licenses:
+            acteur_sources = acteur_sources.filter(licence__in=self.licenses)
+        sources.extend([f"{source.libelle}" for source in acteur_sources])
+        seen = set()
+        deduplicated_sources = []
+        for source in sources:
+            if source not in seen:
+                deduplicated_sources.append(source)
+                seen.add(source)
+        return deduplicated_sources
+
+
+class OpenSourceDisplayedActeurResource(resources.ModelResource, GenericExporterMixin):
     """
     Only used to export data to open-source in Koumoul
     """
 
     limit = 0
     offset = 0
-    licenses = []
 
     def __init__(
         self, limit: int = 0, offset: int = 0, licenses: List[str] = [], **kwargs
@@ -598,18 +615,8 @@ class OpenSourceDisplayedActeurResource(resources.ModelResource):
     sources = fields.Field(column_name="Paternité", attribute="sources", readonly=True)
 
     def dehydrate_sources(self, acteur):
-        sources = ["Longue Vie Aux Objets", "ADEME"]
-        acteur_sources = acteur.sources.all()
-        if self.licenses:
-            acteur_sources = acteur_sources.filter(licence__in=self.licenses)
-        sources.extend([f"{source.libelle}" for source in acteur_sources])
-        seen = set()
-        deduplicated_sources = []
-        for source in sources:
-            if source not in seen:
-                deduplicated_sources.append(source)
-                seen.add(source)
-        return "|".join(deduplicated_sources)
+        sources = self.get_sources(acteur)
+        return "|".join(sources)
 
     nom = fields.Field(column_name="Nom", attribute="nom", readonly=True)
     nom_commercial = fields.Field(

--- a/qfdmo/api.py
+++ b/qfdmo/api.py
@@ -64,9 +64,11 @@ class ActeurServiceSchema(ModelSchema):
 
 
 class SourceSchema(ModelSchema):
+    logo: Optional[str] = Field(..., alias="logo_file_absolute_url")
+
     class Meta:
         model = Source
-        fields = ["id", "code", "libelle", "logo_fiel", "url"]
+        fields = ["id", "code", "libelle", "url"]
 
 
 class ActeurSchema(ModelSchema):

--- a/qfdmo/api.py
+++ b/qfdmo/api.py
@@ -8,6 +8,7 @@ from django.shortcuts import get_object_or_404
 from ninja import Field, FilterSchema, ModelSchema, Query, Router
 from ninja.pagination import paginate
 
+from qfdmo.admin.acteur import OpenSourceDisplayedActeurResource
 from qfdmo.geo_api import search_epci_code
 from qfdmo.models import (
     ActeurService,
@@ -16,6 +17,7 @@ from qfdmo.models import (
     Action,
     DisplayedActeur,
     GroupeAction,
+    Source,
 )
 
 router = Router()
@@ -61,6 +63,12 @@ class ActeurServiceSchema(ModelSchema):
         fields = ["id", "code", "libelle"]
 
 
+class SourceSchema(ModelSchema):
+    class Meta:
+        model = Source
+        fields = ["id", "code", "libelle", "logo_fiel", "url"]
+
+
 class ActeurSchema(ModelSchema):
     latitude: float
     longitude: float
@@ -80,6 +88,12 @@ class ActeurSchema(ModelSchema):
     adresse: str = Field(
         ..., alias="adresse_display", description="l'adresse complète de l'acteur"
     )
+    sources: str = Field(..., description="La paternité de l'acteur")
+
+    @staticmethod
+    def resolve_sources(obj):
+        resource = OpenSourceDisplayedActeurResource()
+        return resource.dehydrate_sources(obj)
 
     @staticmethod
     def resolve_distance(obj):
@@ -96,6 +110,15 @@ class ActeurFilterSchema(FilterSchema):
     types: Optional[List[int]] = Field(None, q="acteur_type__in")
     services: Optional[List[int]] = Field(None, q="acteur_services__in")
     actions: Optional[List[int]] = Field(None, q="proposition_services__action_id__in")
+
+
+@router.get("/sources", response=List[SourceSchema], summary="Liste des sources")
+def sources(request):
+    """
+    Liste l'ensemble des <i>sources</i> possibles pour un acteur.
+    """  # noqa
+    qs = Source.objects.filter(afficher=True)
+    return qs
 
 
 @router.get(

--- a/qfdmo/api.py
+++ b/qfdmo/api.py
@@ -8,7 +8,7 @@ from django.shortcuts import get_object_or_404
 from ninja import Field, FilterSchema, ModelSchema, Query, Router
 from ninja.pagination import paginate
 
-from qfdmo.admin.acteur import OpenSourceDisplayedActeurResource
+from qfdmo.admin.acteur import GenericExporterMixin
 from qfdmo.geo_api import search_epci_code
 from qfdmo.models import (
     ActeurService,
@@ -90,12 +90,12 @@ class ActeurSchema(ModelSchema):
     adresse: str = Field(
         ..., alias="adresse_display", description="l'adresse complète de l'acteur"
     )
-    sources: str = Field(..., description="La paternité de l'acteur")
+    sources: List[str] = Field(..., description="La paternité de l'acteur")
 
     @staticmethod
     def resolve_sources(obj):
-        resource = OpenSourceDisplayedActeurResource()
-        return resource.dehydrate_sources(obj)
+        exporter = GenericExporterMixin()
+        return exporter.get_sources(obj)
 
     @staticmethod
     def resolve_distance(obj):

--- a/qfdmo/models/acteur.py
+++ b/qfdmo/models/acteur.py
@@ -189,6 +189,13 @@ class Source(CodeAsNaturalKeyModel):
         db_default=DataLicense.NO_LICENSE,
     )
 
+    @property
+    def logo_file_absolute_url(self) -> str:
+        if not self.logo_file:
+            return ""
+
+        return f"{settings.BASE_URL}{self.logo_file.url}"
+
 
 def validate_opening_hours(value):
     if value and not opening_hours.validate(value):


### PR DESCRIPTION
# Description succincte du problème résolu

Cf https://www.notion.so/accelerateur-transition-ecologique-ademe/API-J-Agis-Ajout-paternit-et-filtre-objet-15a6523d57d780e48655f56ce0443400?pvs=4 


**🗺️ contexte**: API Rest - J'agis

**💡 quoi**: exposition des sources dans l'API Rest

**🎯 pourquoi**: pour afficher la paternité sur J'agis

**🤔 comment**: 
- Isolement de la méthode `get_sources` dans un mixin pour la rendre plus facilement exploitable 
- Ajout d'un endpoint listant les sources
- Ajout d'une property récupérant l'url absolue du logo d'une source
- Ajout du champ sources sur le schema acteurs

## Exemple résultats / UI / Data

```sh
Curl

curl -X 'GET' \
  'http://localhost:8000/api/qfdmo/sources' \
  -H 'accept: application/json'
```

```json
[
  {
    "logo": "http://localhost:8000/media/logos/Sans_titre_22.jpg",
    "id": 92,
    "code": "ecodds",
    "libelle": "ECODDS",
    "url": "https://www.ecodds.com/"
  },
  {
    "logo": "",
    "id": 253,
    "code": "deprecated_lvao",
    "libelle": "",
    "url": null
  },
  {
    "logo": "http://localhost:8000/media/logos/planete_liege.jpg",
    "id": 254,
    "code": "planeteliege",
    "libelle": "Planète Liège - Fédération Française du Liège",
    "url": "https://planeteliege.com/"
  },
  {
    "logo": "http://localhost:8000/media/logos/unique.jpg",
    "id": 255,
    "code": "uniqueapp",
    "libelle": "Adresse ajoutée de manière collaborative par la communauté UNIQUE",
    "url": "http://www.unique-app.com/"
  },
  {
    "logo": "http://localhost:8000/media/logos/cropped-big-logo-REFER-72.png",
    "id": 116,
    "code": "lerefer",
    "libelle": "Le REFER",
    "url": "https://www.reemploi-idf.org/"
  },
  {
    "logo": "http://localhost:8000/media/logos/Emmaus_defi.png",
    "id": 111,
    "code": "emmausdefi",
    "libelle": "Emmaüs Défi",
    "url": "https://emmaus-defi.org/"
  },
  {
    "logo": "http://localhost:8000/media/logos/zac.jpg",
    "id": 112,
    "code": "lunettesdezac",
    "libelle": "Lunettes de Zac",
    "url": "https://lunettesdezac.com/"
  },
  {
    "logo": "http://localhost:8000/media/logos/crar.jpg",
    "id": 113,
    "code": "crarnormandie",
    "libelle": "CRAR Normandie",
    "url": "https://www.crar-normandie.fr/"
  },
  {
    "logo": "http://localhost:8000/media/logos/ordre_pharmaciens.jpg",
    "id": 149,
    "code": "ordredespharmaciens",
    "libelle": "Ordre National Des Pharmaciens",
    "url": "https://www.ordre.pharmacien.fr/"
  },
  {
    "logo": "http://localhost:8000/media/logos/Sans_titre_6.jpg",
    "id": 109,
    "code": "emmausconnect",
    "libelle": "Emmaüs Connect",
    "url": "https://emmaus-connect.org/"
  },
  {
    "logo": "http://localhost:8000/media/logos/Logo_recycloptics_new-FT-1.png",
    "id": 110,
    "code": "recycloptics",
    "libelle": "RecylOptics",
    "url": "https://recycloptics.org/"
  },
  {
    "logo": "http://localhost:8000/media/logos/syvadec.jpg",
    "id": 114,
    "code": "syvadec",
    "libelle": "Syvadec",
    "url": "https://www.syvadec.fr/"
  },
  {
    "logo": "http://localhost:8000/media/logos/aliapur.jpg",
    "id": 85,
    "code": "aliapur",
    "libelle": "ALIAPUR",
    "url": "https://aliapur.fr/"
  },
  {
    "logo": "http://localhost:8000/media/logos/paris.jpg",
    "id": 115,
    "code": "villedeparis",
    "libelle": "Ville de Paris",
    "url": "https://www.paris.fr/"
  },
  {
    "logo": "http://localhost:8000/media/logos/Origine.png",
    "id": 106,
    "code": "originecycles",
    "libelle": "Origine Cycles",
    "url": "https://www.origine-cycles.com/"
  },
  {
    "logo": "http://localhost:8000/media/logos/Reseau_ressourceries_et_recycleries.jpeg",
    "id": 49,
    "code": "ressourceries",
    "libelle": "Réseau National des Ressourceries et Recycleries",
    "url": "https://ressourcerie.fr/"
  },
  {
    "logo": "http://localhost:8000/media/logos/recyclivre.jpeg",
    "id": 12,
    "code": "recyclivrebal",
    "libelle": "Recyclivre - Boîtes à lire",
    "url": "https://www.boite-a-lire.com/"
  },
  {
    "logo": "http://localhost:8000/media/logos/ALF.jpeg",
    "id": 10,
    "code": "ludotheques",
    "libelle": "Association des Ludothèques Françaises",
    "url": "https://www.kananas.com/associationdesludothequesfrancaises"
  },
  {
    "logo": "http://localhost:8000/media/logos/Sans_titre_1.jpg",
    "id": 9,
    "code": "bibliotheques",
    "libelle": "Bibliothèques - Ministère de la culture",
    "url": "https://data.culture.gouv.fr/explore/dataset/adresses-des-bibliotheques-publiques/information/"
  },
  {
    "logo": "http://localhost:8000/media/logos/ademe_logo.jpeg",
    "id": 5,
    "code": "ademelocales",
    "libelle": "ADEME - Initiatives locales",
    "url": "https://www.ademe.fr/"
  },
  {
    "logo": "http://localhost:8000/media/logos/ademe_logo.jpeg",
    "id": 1,
    "code": "ademedigitaux",
    "libelle": "ADEME - Acteurs digitaux",
    "url": "https://www.ademe.fr/"
  },
  {
    "logo": "http://localhost:8000/media/logos/ademe_logo.jpeg",
    "id": 7,
    "code": "ademenationales",
    "libelle": "ADEME - Initiatives nationales",
    "url": "https://www.ademe.fr/"
  },
  {
    "logo": "http://localhost:8000/media/logos/essfrance-logo-carteco.png",
    "id": 107,
    "code": "carteco",
    "libelle": "CartEco - ESS France",
    "url": "https://carteco-ess.org/"
  },
  {
    "logo": "http://localhost:8000/media/logos/ademe_logo.jpeg",
    "id": 3,
    "code": "ademelocation",
    "libelle": "ADEME - Locations",
    "url": "https://www.ademe.fr/"
  },
  {
    "logo": "http://localhost:8000/media/logos/Findis.png",
    "id": 47,
    "code": "findis",
    "libelle": "Groupe Findis",
    "url": "https://www.groupefindis.fr/"
  },
  {
    "logo": "http://localhost:8000/media/logos/batribox.jpg",
    "id": 99,
    "code": "batribox",
    "libelle": "Batribox",
    "url": "https://www.batribox.fr/"
  },
  {
    "logo": "http://localhost:8000/media/logos/qualirepar.jpg",
    "id": 215,
    "code": "ocad3e",
    "libelle": "Ecologic & Ecosystem",
    "url": "https://www.label-qualirepar.fr/"
  },
  {
    "logo": "http://localhost:8000/media/logos/logo-orange.jpg",
    "id": 218,
    "code": "orange",
    "libelle": "Orange",
    "url": "https://collecte-mobile.orange.fr/notre-programme-deconomie-circulaire"
  },
  {
    "logo": "http://localhost:8000/media/logos/ECOPAE_LOGO_CMJN_1.png",
    "id": 252,
    "code": "ecopae",
    "libelle": "ECOPAE",
    "url": "https://www.ecopae.fr/"
  },
  {
    "logo": "http://localhost:8000/media/logos/ademe_logo.jpeg",
    "id": 6,
    "code": "sinoe",
    "libelle": "ADEME - SINOE",
    "url": "https://www.sinoe.org/"
  },
  {
    "logo": "http://localhost:8000/media/logos/Logo_Ecomaison.png",
    "id": 48,
    "code": "ecomaison",
    "libelle": "ECOMAISON",
    "url": "https://ecomaison.com/"
  },
  {
    "logo": "http://localhost:8000/media/logos/Sans_titre_2.png",
    "id": 46,
    "code": "communautelvao",
    "libelle": "Communauté Longue Vie Aux Objets",
    "url": "https://longuevieauxobjets.ademe.fr/"
  },
  {
    "logo": "http://localhost:8000/media/logos/encore.png",
    "id": 11,
    "code": "encore",
    "libelle": "Collectif Encore",
    "url": "https://www.cadeausecondemain.fr/"
  },
  {
    "logo": "http://localhost:8000/media/logos/Sans_titre_1.jpg",
    "id": 90,
    "code": "cyclevia",
    "libelle": "CYCLEVIA",
    "url": "https://www.cyclevia.com/"
  },
  {
    "logo": "http://localhost:8000/media/logos/AmbertLivradoisForez.png",
    "id": 104,
    "code": "alv",
    "libelle": "Collectivité Ambert Livradois Forez",
    "url": "https://www.ambertlivradoisforez.fr/"
  },
  {
    "logo": "http://localhost:8000/media/logos/Sans_titre_2.jpg",
    "id": 82,
    "code": "envie",
    "libelle": "Fédération Envie",
    "url": "https://www.envie.org/"
  },
  {
    "logo": "http://localhost:8000/media/logos/corepile.jpg",
    "id": 88,
    "code": "corepile",
    "libelle": "COREPILE",
    "url": "https://www.corepile.fr/"
  },
  {
    "logo": "http://localhost:8000/media/logos/ecologic.jpg",
    "id": 93,
    "code": "ecologic",
    "libelle": "ECOLOGIC",
    "url": "https://www.ecologic-france.com/"
  },
  {
    "logo": "http://localhost:8000/media/logos/valdelia.jpg",
    "id": 102,
    "code": "valdelia",
    "libelle": "VALDELIA",
    "url": "https://www.valdelia.org/"
  },
  {
    "logo": "http://localhost:8000/media/logos/valobat.png",
    "id": 103,
    "code": "valobat",
    "libelle": "VALOBAT",
    "url": "http://www.valobat.fr"
  },
  {
    "logo": "http://localhost:8000/media/logos/ecominero.png",
    "id": 94,
    "code": "ecominero",
    "libelle": "ECOMINERO",
    "url": "https://www.ecominero.fr/"
  },
  {
    "logo": "http://localhost:8000/media/logos/pyreo.jpg",
    "id": 98,
    "code": "pyreo",
    "libelle": "PYREO",
    "url": "https://www.pyreo.fr/"
  },
  {
    "logo": "http://localhost:8000/media/logos/refashion.png",
    "id": 45,
    "code": "refashion",
    "libelle": "REFASHION",
    "url": "https://refashion.fr/citoyen/fr"
  },
  {
    "logo": "http://localhost:8000/media/logos/recyclivre.jpeg",
    "id": 105,
    "code": "recyclivrepl",
    "libelle": "Recyclivre - Point livres",
    "url": "https://www.point-livres.com/"
  },
  {
    "logo": "http://localhost:8000/media/logos/Logo-Ademe-32.jpg",
    "id": 216,
    "code": "ademesinoedecheteries",
    "libelle": "ADEME - SINOE - Déchèteries",
    "url": "https://www.sinoe.org/"
  },
  {
    "logo": "http://localhost:8000/media/logos/Sans_titre_2.png",
    "id": 2,
    "code": "lvao",
    "libelle": "Longue Vie Aux Objets",
    "url": "https://longuevieauxobjets.ademe.fr/"
  },
  {
    "logo": "http://localhost:8000/media/logos/ecosystem.jpg",
    "id": 95,
    "code": "ecosystem",
    "libelle": "ECOSYSTEM",
    "url": "https://ecosystem.eco/"
  },
  {
    "logo": "http://localhost:8000/media/logos/soren.jpg",
    "id": 100,
    "code": "soren",
    "libelle": "SOREN",
    "url": "https://www.soren.eco/"
  },
  {
    "logo": "http://localhost:8000/media/logos/leroy_merlin.jpg",
    "id": 182,
    "code": "leroymerlin",
    "libelle": "Leroy Merlin",
    "url": "https://leroymerlin.fr"
  },
  {
    "logo": "http://localhost:8000/media/logos/laposte.jpg",
    "id": 217,
    "code": "laposte",
    "libelle": "La Poste",
    "url": "https://laposte.fr/"
  },
  {
    "logo": "http://localhost:8000/media/logos/Sans_titre_1.png",
    "id": 4,
    "code": "cmareparacteur",
    "libelle": "CMA - Chambre des métiers et de l'artisanat",
    "url": "https://www.artisanat.fr/"
  }
]
```

```sh
curl -X 'GET' \
  'http://localhost:8000/api/qfdmo/acteurs?rayon=2&limit=1&offset=0' \
  -H 'accept: application/json'
```

```json 
{
  "items": [
    {
      "latitude": 50.56344,
      "longitude": 2.898195,
      "services": [
        {
          "id": 4,
          "code": "structure_de_collecte",
          "libelle": "Structure de collecte"
        }
      ],
      "actions": [
        {
          "services": "yellow-tournesol-sun-407-moon-922-active",
          "id": 11,
          "code": "trier",
          "libelle": "déposer",
          "icon": "fr-icon-recycle-line"
        }
      ],
      "type": {
        "id": 11,
        "code": "pav_prive",
        "libelle": "point d'apport volontaire privé"
      },
      "distance": null,
      "nom": "  LA PHARMACIE DU 127 ",
      "adresse": "127  RUE GAMBETTA, 59184, SAINGHIN-EN-WEPPES",
      "sources": [
        "Longue Vie Aux Objets",
        "ADEME",
        "Ordre National Des Pharmaciens"
      ],
      "nom_commercial": "",
      "identifiant_unique": "ordredespharmaciens_2BA2F8252E7A577002F1B8B5226FA8FA",
      "siret": "88969938500015"
    }
  ],
  "count": 357032
}
```

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
