### PR TITLE
🙈 Masquer le bouton infos dans le cas où l'intégrateur est l'ADEME

### DIFF
--- a/jinja2/qfdmo/carte/header.html
+++ b/jinja2/qfdmo/carte/header.html
@@ -1,5 +1,7 @@
-<div class="qf-items-center qf-hidden md:qf-flex qf-flex-row" id="logo"
-        data-remove-if-internal
+<div
+    class="qf-items-center qf-hidden md:qf-flex qf-flex-row"
+    id="logo"
+    data-remove-if-internal
 >
     {% include 'layout/_partials/header_logos.html' %}
 </div>

--- a/jinja2/qfdmo/carte/header.html
+++ b/jinja2/qfdmo/carte/header.html
@@ -1,4 +1,6 @@
-<div class="qf-items-center qf-hidden md:qf-flex qf-flex-row" id="logo">
+<div class="qf-items-center qf-hidden md:qf-flex qf-flex-row" id="logo"
+        data-remove-if-internal
+>
     {% include 'layout/_partials/header_logos.html' %}
 </div>
 
@@ -16,8 +18,9 @@
             type="button"
             title="À propos"
             data-action="click -> search-solution-form#toggleAPropos"
+            data-remove-if-internal
         >
-            À propos
+            Infos
         </button>
         <div class="qf-flex qf-flex-row-reverse">
             <button

--- a/jinja2/qfdmo/carte/panels/legend.html
+++ b/jinja2/qfdmo/carte/panels/legend.html
@@ -39,6 +39,7 @@
         qf-w-full qf-flex qf-justify-center"
         type="button"
         data-action="click -> search-solution-form#toggleAPropos"
+        data-remove-if-internal
     >
         Infos
     </button>

--- a/static/to_compile/js/iframe.ts
+++ b/static/to_compile/js/iframe.ts
@@ -5,9 +5,8 @@ near future (around january 2025)
 */
 window.addEventListener("DOMContentLoaded", (event) => {
   const domain = new URL(document.referrer).hostname
-  if (true || domain === 'localhost' || domain.endsWith(".ademe.fr") || domain === "quefairedemesobjets-preprod.osc-fr1.scalingo.io") {
+  if (domain === 'localhost' || domain.endsWith(".ademe.fr") || domain === "quefairedemesobjets-preprod.osc-fr1.scalingo.io") {
     for (const elementToRemove of document.querySelectorAll("[data-remove-if-internal]")) {
-      console.log({ elementToRemove })
       elementToRemove.remove()
     }
   }

--- a/static/to_compile/js/iframe.ts
+++ b/static/to_compile/js/iframe.ts
@@ -5,7 +5,10 @@ near future (around january 2025)
 */
 window.addEventListener("DOMContentLoaded", (event) => {
   const domain = new URL(document.referrer).hostname
-  if (domain === 'localhost' || domain.endsWith(".ademe.fr") || domain === "quefairedemesobjets-preprod.osc-fr1.scalingo.io") {
-    document.querySelector("#logo")?.remove()
+  if (true || domain === 'localhost' || domain.endsWith(".ademe.fr") || domain === "quefairedemesobjets-preprod.osc-fr1.scalingo.io") {
+    for (const elementToRemove of document.querySelectorAll("[data-remove-if-internal]")) {
+      console.log({ elementToRemove })
+      elementToRemove.remove()
+    }
   }
 });


### PR DESCRIPTION
# Description succincte du problème résolu

https://www.notion.so/accelerateur-transition-ecologique-ademe/Carte-Supprimer-le-bouton-Infos-A-propos-au-niveau-de-la-carte-quand-dans-l-assistant-15e6523d57d7802485bcfd05eaadeb0d?pvs=4


**🗺️ contexte**: carte dans l'assistant

**💡 quoi**: Masquer le bouton infos dans le cas où l'intégrateur est l'ADEME

**🎯 pourquoi**: Car c'est bizarre dans le "Infos" de parler de la carte, alors qu'on est sur l'assistant. Et c'est déjà le cas dans la version existante.

**🤔 comment**: 
- ajout d'un sélecteur sur le logo (qu'on supprime déjà) et les éléments à supprimer
- mise à jour du script pour cibler ce sélecteur

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

