### PR TITLE
Forcer l'identifiant exterieur en string

### DIFF
--- a/dags/sources/dags/source_s3.py
+++ b/dags/sources/dags/source_s3.py
@@ -104,6 +104,11 @@ with DAG(
                 "transformation": "strip_string",
                 "destination": "ville",
             },
+            {
+                "origin": "identifiant_externe",
+                "transformation": "strip_string",
+                "destination": "identifiant_externe",
+            },
             # 3. Ajout des colonnes avec une valeur par défaut
             # 4. Transformation du dataframe
             {
@@ -140,8 +145,6 @@ with DAG(
                 "destination": ["proposition_service_codes"],
             },
             # 5. Supression des colonnes
-            {"remove": "action_principale"},
-            {"remove": "parent"},
             # 6. Colonnes à garder (rien à faire, utilisé pour le controle)
             {"keep": "acteur_type_code"},
             {"keep": "commentaires"},

--- a/dags/sources/tasks/transform/transform_df.py
+++ b/dags/sources/tasks/transform/transform_df.py
@@ -163,7 +163,7 @@ def clean_identifiant_unique(row, _):
         raise ValueError(
             "identifiant_externe is required to generate identifiant_unique"
         )
-    unique_str = row["identifiant_externe"].replace("/", "-").strip()
+    unique_str = str(row["identifiant_externe"]).replace("/", "-").strip()
     if row.get("acteur_type_code") == ACTEUR_TYPE_DIGITAL:
         unique_str = unique_str + "_d"
     row["identifiant_unique"] = row.get("source_code").lower() + "_" + unique_str

--- a/dags_unit_tests/sources/tasks/transform/test_transform_df.py
+++ b/dags_unit_tests/sources/tasks/transform/test_transform_df.py
@@ -391,6 +391,7 @@ class TestCleanIdentifiantUnique:
             " expected_identifiant_unique"
         ),
         [
+            (12345, "commerce", "source", "source_12345"),
             ("12345", "commerce", "source", "source_12345"),
             (" 12345 ", "commerce", "source", "source_12345"),
             ("ABC123", "commerce", "source", "source_ABC123"),


### PR DESCRIPTION
# Description succincte du problème résolu

Forcer l'idenifiant externe en string

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Airflow

**💡 quoi**: forcer l'id externe en string

**🎯 pourquoi**: eviter les erreurs, permettre une colonne d'entier

**🤔 comment**: caster en str

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
