### PR TITLE
public_accueilli et reprise ne sont pas null par defaut

### DIFF
--- a/dags/sources/config/shared_constants.py
+++ b/dags/sources/config/shared_constants.py
@@ -18,6 +18,7 @@ PUBLIC_PAR = "Particuliers"
 PUBLIC_PRO = "Professionnels"
 PUBLIC_PRO_ET_PAR = "Particuliers et professionnels"
 PUBLIC_AUCUN = "Aucun"
+PUBLIC_NP = ""
 
 # Acteur statut
 ACTEUR_ACTIF = "ACTIF"
@@ -27,6 +28,7 @@ ACTEUR_SUPPRIME = "SUPPRIME"
 # Reprise
 REPRISE_1POUR0 = "1 pour 0"
 REPRISE_1POUR1 = "1 pour 1"
+REPRISE_NP = ""
 
 # Special field values
 EMPTY_ACTEUR_FIELD = "__empty__"

--- a/dags/sources/tasks/transform/transform_column.py
+++ b/dags/sources/tasks/transform/transform_column.py
@@ -119,7 +119,7 @@ def clean_acteur_type_code(value, _):
 
 def clean_public_accueilli(value, _):
     if not value:
-        return None
+        return constants.PUBLIC_NP
 
     values_mapping = {
         "particuliers et professionnels": constants.PUBLIC_PRO_ET_PAR,
@@ -129,15 +129,15 @@ def clean_public_accueilli(value, _):
         "dma/pro": constants.PUBLIC_PRO_ET_PAR,
         "dma": constants.PUBLIC_PAR,
         "pro": constants.PUBLIC_PRO,
-        "np": None,
+        "np": constants.PUBLIC_NP,
     }
 
-    return values_mapping.get(value.lower().strip())
+    return values_mapping.get(value.lower().strip(), constants.PUBLIC_NP)
 
 
 def clean_reprise(value, _):
     if not value:
-        return None
+        return constants.REPRISE_NP
 
     values_mapping = {
         "1 pour 0": constants.REPRISE_1POUR0,
@@ -145,7 +145,7 @@ def clean_reprise(value, _):
         "non": constants.REPRISE_1POUR0,
         "oui": constants.REPRISE_1POUR1,
     }
-    return values_mapping.get(value.lower().strip())
+    return values_mapping.get(value.lower().strip(), constants.REPRISE_NP)
 
 
 def clean_url(url, _) -> str:

--- a/dags_unit_tests/sources/tasks/transform/test_transform_column.py
+++ b/dags_unit_tests/sources/tasks/transform/test_transform_column.py
@@ -222,14 +222,14 @@ class TestCleanPublicAccueilli:
     @pytest.mark.parametrize(
         "value, expected_value",
         [
-            (None, None),
-            ("fake", None),
+            (None, ""),
+            ("fake", ""),
             ("PARTICULIERS", "Particuliers"),
             ("Particuliers", "Particuliers"),
             ("DMA", "Particuliers"),
             ("DMA/PRO", "Particuliers et professionnels"),
             ("PRO", "Professionnels"),
-            ("NP", None),
+            ("NP", ""),
             ("Particuliers et professionnels", "Particuliers et professionnels"),
         ],
     )
@@ -247,12 +247,12 @@ class TestCleanReprise:
     @pytest.mark.parametrize(
         "value,expected_value",
         [
-            (None, None),
+            (None, ""),
             ("1 pour 0", "1 pour 0"),
             ("1 pour 1", "1 pour 1"),
             ("non", "1 pour 0"),
             ("oui", "1 pour 1"),
-            ("fake", None),
+            ("fake", ""),
         ],
     )
     def test_clean_reprise(


### PR DESCRIPTION
# Description succincte du problème résolu

Encore une adaptation

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Airflow source

**💡 quoi**: public_accueilli et reprise ne sont pas null et sont vide par defaut

**🎯 pourquoi**: simplification du modele de données

**🤔 comment**: mettre la valeur vide par défaut

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
