### PR TITLE
⏭️ CLUSTERING: Enrichissement désactivable

### DIFF
--- a/dags/cluster/config/model.py
+++ b/dags/cluster/config/model.py
@@ -50,6 +50,7 @@ class ClusterConfig(BaseModel):
     cluster_fuzzy_threshold: float = Field(0.5, ge=0, le=1)
 
     # DEDUP
+    dedup_enrich_enabled: bool
     dedup_enrich_fields: list[str]
     dedup_enrich_exclude_sources: list[str]
     dedup_enrich_exclude_source_ids: list[int]  # to calculate from above
@@ -171,7 +172,13 @@ class ClusterConfig(BaseModel):
                 ]
         values["fields_transformed"] = list(set(values["fields_transformed"]))
 
-        # DEDUP
+        # Enrichment
+        if (
+            values["dedup_enrich_enabled"]
+            and not values["dedup_enrich_priority_sources"]
+        ):
+            raise ValueError("Enrichissement désactivé mais pas de sources définies")
+
         values["dedup_enrich_exclude_source_ids"] = (
             airflow_params_dropdown_selected_to_ids(
                 mapping_ids_by_codes=values["mapping_sources"],

--- a/dags/cluster/dags/cluster_acteur_suggestions.py
+++ b/dags/cluster/dags/cluster_acteur_suggestions.py
@@ -271,12 +271,18 @@ PARAMS = {
 
             {UI_PARAMS_SEPARATORS.DEDUP_ENRICH_PARENT}""",
     ),
+    "dedup_enrich_enabled": Param(
+        True,
+        type="boolean",
+        description_md="""**ACTIVATION ENRICHISSEMENT**: si décoché = enrichissement
+        désactivé ET reste des **champs dedup_enrich_ ignorés**""",
+    ),
     "dedup_enrich_fields": Param(
         fields_enrich,
         type=["array"],
         examples=fields_enrich,
-        description_md=f"""✍️ Champs à enrichir (certains champs de type calculés ou id
-        sont exclus)
+        description_md=f"""**✍️ Champs à enrichir** (certains champs de type
+        calculés ou id sont exclus)
 
         Exclus:
         {'  \n'.join([', '.join(chunck) for chunck in fields_enrich_excluded_ui])}
@@ -291,7 +297,9 @@ PARAMS = {
     ),
     "dedup_enrich_priority_sources": Param(
         [],
-        type=["array"],
+        # Must keep default NULL as we can't prefill (don't know what users will choose)
+        # BUT we allow dedup_enrich to be disabled
+        type=["null", "array"],
         examples=dropdown_sources,
         description_md=r"""**🔢 PRIORITES SOURCES**: sources sur lequelles
             on **PRÉFÈRE** prendre de données

--- a/dags/cluster/tasks/business_logic/cluster_acteurs_suggestions/display.py
+++ b/dags/cluster/tasks/business_logic/cluster_acteurs_suggestions/display.py
@@ -8,7 +8,7 @@ django_setup_full()
 
 
 def cluster_acteurs_suggestions_display(
-    df_clusters: pd.DataFrame,
+    df_clusters: pd.DataFrame, dedup_enrich_enabled: bool
 ) -> list[dict]:
     """Generate suggestion changes from a df of clusters. At
     this stage we don't work with the Cohorte & Suggestion models
@@ -56,7 +56,9 @@ def cluster_acteurs_suggestions_display(
                 ChangeActeurCreateAsParent.name(),
                 ChangeActeurKeepAsParent.name(),
             ]:
-                model_params["data"] = row[COL_PARENT_DATA_NEW]
+                model_params["data"] = (
+                    row[COL_PARENT_DATA_NEW] if dedup_enrich_enabled else None
+                )
             elif model_name == ChangeActeurVerifyRevision.name():
                 # no extra params to pass for this one
                 pass

--- a/dags_unit_tests/cluster/config/test_cluster_config_model.py
+++ b/dags_unit_tests/cluster/config/test_cluster_config_model.py
@@ -25,6 +25,7 @@ class TestClusterConfigModel:
             "cluster_fields_exact": ["exact1", "exact2"],
             "cluster_fields_fuzzy": ["fuzzy1", "fuzzy2"],
             "cluster_fuzzy_threshold": 0.5,
+            "dedup_enrich_enabled": True,
             "dedup_enrich_fields": ["f1_incl", "f2_incl", "f3_excl"],
             "dedup_enrich_exclude_sources": ["source1 (id=1)"],
             "dedup_enrich_priority_sources": ["source1 (id=1)"],
@@ -158,6 +159,15 @@ class TestClusterConfigModel:
         params_working["cluster_fields_exact"] = ["foo"]
         params_working["cluster_fields_fuzzy"] = ["foo"]
         with pytest.raises(ValueError, match="Champs en double dans exact/fuzzy"):
+            ClusterConfig(**params_working)
+
+    def test_error_if_dedup_enrich_enabled_but_no_sources(self, params_working):
+        # Because we allow dedup to be deactivated AND we can't prefill the sources
+        # (no way to know what user will select) we must prevent below case
+        params_working["dedup_enrich_enabled"] = True
+        params_working["dedup_enrich_priority_sources"] = []
+        msg = "Enrichissement désactivé mais pas de sources définies"
+        with pytest.raises(ValueError, match=msg):
             ClusterConfig(**params_working)
 
     @pytest.mark.parametrize("input", [None, []])


### PR DESCRIPTION
# ⏭️ CLUSTERING: Enrichissement désactivable

-------------

## :red_circle:  Abandonnée car trop de complexité à gérer en 1 semaine

[Confirmé avec](https://mattermost.incubateur.net/betagouv/pl/tjnj9hu1x7dytkp6jknipccfha) @chrischarousset 

**Solution de contournement**: Dans le paramètre de DAG `dedup_enrich_field`, renseigner uniquement le champ `acteur_type` (cela fait toujours de l’enrichissement, mais quasi-vide)
:large_orange_circle: inconvénients:
 - **UI**: on triche avec la UI, donc pas terrible pour la maintenance & onboarding d’autres utilisateurs Airflow
 - **Validation**: risque de cassure à cause de l’enrichissement quasi-nul

-------------

Carte Notion: [CLUSTERING: rendre l’enrichissement du parent optionnel](https://www.notion.so/accelerateur-transition-ecologique-ademe/CLUSTERING-rendre-l-enrichissement-du-parent-optionnel-1c96523d57d780168eb6c41f44d095d4)

**🗺️ contexte**: dans certains cas on considère nos parent suffisamment qualitatifs

**💡 quoi**: modification du DAG de clustering pour rendre l'enrichissement optionnel

**🎯 pourquoi**: satisfaire le besoin de @chrischarousset de nas pas faire d'enrichissement dans certains cas

**🤔 comment**: à déterminer, choisir entre options ci-dessous, le 🔴 **problème** étant que le clustering peut générer des nouveaux parents pour lesquels on a 0 data et donc **l'enrichissement est obligatoire`**

![image](https://github.com/user-attachments/assets/2a1ce3a8-6de7-494d-a30d-b6053d85eb90)


## ✅ Reste à faire (PR en cours)

- [ ] Décider de comment gérer cette optionnalité
- [ ] Mettre à jour DAG / tests en fonction