### PR TITLE
Ajout d'un `line-height`sur les produits de l'assistant

### DIFF
--- a/templates/qfdmd/home.html
+++ b/templates/qfdmd/home.html
@@ -25,6 +25,7 @@
         </p>
         <ul
             class="qf-flex qf-gap-x-2w qf-gap-y-3w
+            qf-leading-[3]
             qf-flex-wrap qf-items-center qf-justify-center "
         >
             {% for suggestion in object_list %}


### PR DESCRIPTION
# Description succincte du problème résolu

https://www.notion.so/Probl-me-de-distance-entre-les-boutons-de-suggestions-sur-la-home-de-l-assistant-1a16523d57d78076968bd022a9aed1d5?pvs=4

**🗺️ contexte**: Assistant v2

**💡 quoi**: mise en forme de la home page de l'assistant

**🎯 pourquoi**: parce que c'est cassé !

**🤔 comment**: 

- Ajout d'un `line-height`sur les produits de l'assistant listés en page d'accueil
- cf https://tailwindcss.com/docs/line-height

## Exemple résultats / UI / Data

![Capture d’écran 2025-04-02 à 11 25 45](https://github.com/user-attachments/assets/1f8a3e70-c0c7-48c6-baa1-f609fd099300)

![Capture d’écran 2025-04-02 à 11 25 58](https://github.com/user-attachments/assets/4e6aa490-c3bb-4e3e-ac76-6729242d56d8)


## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
