### PR TITLE
🤯 L'acteur est mal renseigné lors du partage

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -9,20 +9,28 @@ Tout ce qui n'est pas sous ASSISTANT est commun à la carte et à l'assistant.
 bonus_reparation = "Propose le Bonus Réparation"
 DIGITAL_ACTEUR_CODE = "acteur_digital"
 
-# Introduction utilisé lors du partage d'un acteur ou d'un produit / déchet
-SHARE_INTRO = "Découvrez le site de l'ADEME “Que faire de mes objets & déchets”"
-# Texte utilisé lors du partage d'un acteur ou d'un produit / déchet.
-# sert essentiellement pour le partage par email
-SHARE_BODY = (
-    "Bonjour,\n "
-    "Vous souhaitez encourager au tri et la consommation responsable, "
-    "le site de l’ADEME Que faire de mes objets & déchets accompagne "
-    "les citoyens grâce à des bonnes pratiques et adresses près de chez eux,"
-    " pour éviter l'achat neuf et réduire les déchets.\n"
-    "Découvrez le ici : "
-)
+SHARE_BODY = ()
+
+CARTE = {
+    "partage": {
+        "titre": "[NOM] : L’ADEME partage ses bonnes adresses",
+        "corps": "J’ai trouvé une bonne adresse [NOM] grâce à l’ADEME : [URL]",
+    }
+}
 
 ASSISTANT = {
+    "partage": {
+        # Introduction utilisé lors du partage d'un acteur ou d'un produit / déchet
+        "titre": "Découvrez le site de l'ADEME “Que faire de mes objets & déchets”",
+        # Texte utilisé lors du partage d'un acteur ou d'un produit / déchet.
+        # sert essentiellement pour le partage par email
+        "corps": "Bonjour,\n "
+        "Vous souhaitez encourager au tri et la consommation responsable, "
+        "le site de l’ADEME Que faire de mes objets & déchets accompagne "
+        "les citoyens grâce à des bonnes pratiques et adresses près de chez eux,"
+        " pour éviter l'achat neuf et réduire les déchets.\n"
+        "Découvrez le ici : [URL]",
+    },
     "seo": {
         # Utilisé comme balise <title> dans les pages d'accueil et produit
         "title": "Que Faire de mes objets & déchets : votre assistant au tri",

--- a/core/constants.py
+++ b/core/constants.py
@@ -13,8 +13,8 @@ SHARE_BODY = ()
 
 CARTE = {
     "partage": {
-        "titre": "[NOM] : L’ADEME partage ses bonnes adresses",
-        "corps": "J’ai trouvé une bonne adresse [NOM] grâce à l’ADEME : [URL]",
+        "titre": "{NOM} : L’ADEME partage ses bonnes adresses",
+        "corps": "J’ai trouvé une bonne adresse {NOM} grâce à l’ADEME : {URL}",
     }
 }
 
@@ -29,7 +29,7 @@ ASSISTANT = {
         "le site de l’ADEME Que faire de mes objets & déchets accompagne "
         "les citoyens grâce à des bonnes pratiques et adresses près de chez eux,"
         " pour éviter l'achat neuf et réduire les déchets.\n"
-        "Découvrez le ici : [URL]",
+        "Découvrez le ici : {URL}",
     },
     "seo": {
         # Utilisé comme balise <title> dans les pages d'accueil et produit

--- a/core/templatetags/seo_tags.py
+++ b/core/templatetags/seo_tags.py
@@ -16,7 +16,6 @@ def get_sharer_content(request, object, social_network=None):
     share_url function below
     """
     carte = request.META.get("HTTP_HOST") not in settings.ASSISTANT["HOSTS"]
-    return ""
 
     try:
         url = object.get_share_url(request)
@@ -26,7 +25,7 @@ def get_sharer_content(request, object, social_network=None):
     share_body = ""
     share_intro = ""
     quoted_url = quote_plus(url)
-    replacements = []
+    replacements = [("[URL]", url)]
 
     if carte:
         share_intro = CARTE["partage"]["titre"]

--- a/core/templatetags/seo_tags.py
+++ b/core/templatetags/seo_tags.py
@@ -1,8 +1,9 @@
 from urllib.parse import quote, quote_plus
 
 from django import template
+from django.conf import settings
 
-from core.constants import SHARE_BODY, SHARE_INTRO
+from core.constants import ASSISTANT, CARTE
 
 register = template.Library()
 
@@ -14,30 +15,49 @@ def get_sharer_content(request, object, social_network=None):
     Once jinja will be removed from the project, this can be merged in
     share_url function below
     """
+    carte = request.META.get("HTTP_HOST") not in settings.ASSISTANT["HOSTS"]
+    return ""
+
     try:
-        url = quote_plus(object.get_share_url(request))
+        url = object.get_share_url(request)
     except AttributeError:
-        url = quote_plus(request.build_absolute_uri())
+        url = request.build_absolute_uri()
+
+    share_body = ""
+    share_intro = ""
+    quoted_url = quote_plus(url)
+    replacements = []
+
+    if carte:
+        share_intro = CARTE["partage"]["titre"]
+        share_body = CARTE["partage"]["corps"]
+        replacements.append(("[NOM]", object.libelle))
+    else:
+        share_intro = ASSISTANT["partage"]["titre"]
+        share_body = ASSISTANT["partage"]["corps"]
+
+    for search_string, replacement in replacements:
+        share_intro = share_intro.replace(search_string, replacement)
+        share_body = share_body.replace(search_string, replacement)
 
     template = {
         "url": url,
         "facebook": {
             "title": f"partager {object} sur Facebook - nouvelle fenêtre",
-            "url": f"https://www.facebook.com/sharer.php?u={url}",
+            "url": f"https://www.facebook.com/sharer.php?u={quoted_url}",
         },
         "twitter": {
             "title": f"partager {object} sur X - nouvelle fenêtre",
-            "url": f"https://twitter.com/intent/tweet?url={url}"
-            "&text={SHARE_INTRO}&via=Longue+vie+aux+objets&hashtags=longuevieauxobjets,ademe",
+            "url": f"https://twitter.com/intent/tweet?url={quoted_url}"
+            f"&text={share_intro}&via=Longue+vie+aux+objets&hashtags=longuevieauxobjets,ademe",
         },
         "linkedin": {
             "title": f"partager {object} sur LinkedIn - nouvelle fenêtre",
-            "url": f"https://www.linkedin.com/shareArticle?url={url}&title={SHARE_INTRO}",
+            "url": f"https://www.linkedin.com/shareArticle?url={quoted_url}&title={share_intro}",
         },
         "email": {
             "title": f"partager {object} par email - nouvelle fenêtre",
-            "url": f"mailto:?subject={quote(SHARE_INTRO)}"
-            f"&body={quote(SHARE_BODY)} {url}",
+            "url": f"mailto:?subject={quote(share_intro)}&body={quote(share_body)}",
         },
     }
     if not social_network:

--- a/core/templatetags/seo_tags.py
+++ b/core/templatetags/seo_tags.py
@@ -25,19 +25,20 @@ def get_sharer_content(request, object, social_network=None):
     share_body = ""
     share_intro = ""
     quoted_url = quote_plus(url)
-    replacements = [("[URL]", url)]
+    format_template = {
+        "URL": url,
+    }
 
     if carte:
         share_intro = CARTE["partage"]["titre"]
         share_body = CARTE["partage"]["corps"]
-        replacements.append(("[NOM]", object.libelle))
+        format_template["NOM"] = object.libelle
     else:
         share_intro = ASSISTANT["partage"]["titre"]
         share_body = ASSISTANT["partage"]["corps"]
 
-    for search_string, replacement in replacements:
-        share_intro = share_intro.replace(search_string, replacement)
-        share_body = share_body.replace(search_string, replacement)
+    share_intro = share_intro.format(**format_template)
+    share_body = share_body.format(**format_template)
 
     template = {
         "url": url,

--- a/core/templatetags/seo_tags.py
+++ b/core/templatetags/seo_tags.py
@@ -15,12 +15,12 @@ def get_sharer_content(request, object, social_network=None):
     Once jinja will be removed from the project, this can be merged in
     share_url function below
     """
+    if not request.META:
+        return {}
+
     carte = request.META.get("HTTP_HOST") not in settings.ASSISTANT["HOSTS"]
 
-    try:
-        url = object.get_share_url(request)
-    except AttributeError:
-        url = request.build_absolute_uri()
+    url = request.build_absolute_uri()
 
     share_body = ""
     share_intro = ""

--- a/qfdmd/views.py
+++ b/qfdmd/views.py
@@ -35,7 +35,6 @@ def generate_iframe_script(request) -> str:
         and request.resolver_match
         and request.resolver_match.view_name == "qfdmd:synonyme-detail"
     ):
-        logger.warning("generate_iframe_script")
         produit_slug = request.resolver_match.kwargs["slug"]
         script_parts.append(f'data-objet="{produit_slug}"')
 

--- a/unit_tests/core/test_seo_tags.py
+++ b/unit_tests/core/test_seo_tags.py
@@ -1,0 +1,49 @@
+# import pytest
+from django.http import HttpRequest
+from django.test import override_settings
+
+from core.templatetags.seo_tags import get_sharer_content
+
+
+class DummyObject:
+    libelle = "Coucou"
+
+
+class TestSharer:
+    @override_settings(
+        ASSISTANT={"HOSTS": ["quefairedemesdechets.domain"]},
+        ALLOWED_HOSTS=["quefairedemesdechets.domain", "lvao.domain"],
+    )
+    def test_sharer_assistant(self):
+        request = HttpRequest()
+        request.GET = {}
+        request.META["HTTP_HOST"] = "quefairedemesdechets.domain"
+        sharer = get_sharer_content(request, DummyObject())
+        assert "Coucou" not in sharer["email"]["url"]
+        assert "lvao.domain" not in sharer["email"]["url"]
+        assert "quefairedemesdechets.domain" in sharer["email"]["url"]
+
+    @override_settings(
+        ASSISTANT={"HOSTS": ["quefairedemesdechets.domain"]},
+        ALLOWED_HOSTS=["quefairedemesdechets.domain", "lvao.domain"],
+    )
+    def test_sharer_carte(self):
+        request = HttpRequest()
+        request.GET = {}
+        request.META["HTTP_HOST"] = "lvao.domain"
+        sharer = get_sharer_content(request, DummyObject())
+
+        assert "Coucou" in sharer["email"]["url"]
+        assert "lvao.domain" in sharer["email"]["url"]
+        assert "quefairedemesdechets.domain" not in sharer["email"]["url"]
+
+    @override_settings(
+        ASSISTANT={"HOSTS": ["quefairedemesdechets.domain"]},
+        ALLOWED_HOSTS=["quefairedemesdechets.domain", "lvao.domain"],
+    )
+    def test_sharer_url(self):
+        request = HttpRequest()
+        request.GET = {}
+        request.META["HTTP_HOST"] = "lvao.domain"
+        sharer = get_sharer_content(request, DummyObject())
+        assert sharer["url"].endswith("lvao.domain")


### PR DESCRIPTION
# Description succincte du problème résolu

https://www.notion.so/accelerateur-transition-ecologique-ademe/Fiche-acteur-L-acteur-est-mal-renseign-lors-du-partage-1536523d57d7802098c5fc89c42827ea?pvs=4


**🗺️ contexte**: Assistant v2 / partage

**💡 quoi**: l'acteur est mal renseigné lors du partage

**🎯 pourquoi**: car j'ai mutualisé du code sans réfléchir...

**🤔 comment**:
- définition d'un dictionnaire pour la carte et l'assistant permettant de définir un template différent pour l'assistant et la carte
- vérification dans la requête de si on est sur l'assitant ou la carte
- J'en ai profité pour corriger le problème de copie de l'url, et ajouter un test 

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code


## 📆 A faire (prochaine PR)

- [ ] ajouter du pydantic sur les constantes pour rendre le tout un peu plus robuste