### PR TITLE
🔍 Afficher le bouton *Proposer une adresse*

### DIFF
--- a/jinja2/qfdmo/shared/results.html
+++ b/jinja2/qfdmo/shared/results.html
@@ -31,7 +31,16 @@ They need to match the css variables used for .grid-map selector in qfdmo.css
             class="qf-inset-0 qf-h-full qf-relative qf-z-0"
             data-action="map:captureInteraction->analytics#captureInteractionWithMap"
         >
+            {% for acteur in acteurs %}
+                <script type="application/json" data-map-target="acteur">
+                    {{ acteur.json_acteur_for_display(direction=form.initial.direction, action_list=form.initial.action_list, carte=carte) | safe }}
+                </script>
+            {% endfor %}
+        </div>
+
+        {% if address_ok %}
             {% if is_carte %}
+                {% include "qfdmo/carte/panels/legend.html" %}
                 <a class="qf-flex lg:qf-hidden
                             qf-bg-white
                             fr-mb-1w fr-btn fr-btn--icon-left fr-icon-epingle-plus fr-btn--tertiary qf-whitespace-nowrap qf-w-auto qf-justify-center
@@ -45,21 +54,10 @@ They need to match the css variables used for .grid-map selector in qfdmo.css
                 </a>
             {% endif %}
 
-            {% for acteur in acteurs %}
-                <script type="application/json" data-map-target="acteur">
-                    {{ acteur.json_acteur_for_display(direction=form.initial.direction, action_list=form.initial.action_list, carte=carte) | safe }}
-                </script>
-            {% endfor %}
-        </div>
-
-        {% if address_ok %}
-            {% if is_carte %}
-                {% include "qfdmo/carte/panels/legend.html" %}
-            {% endif %}
-
             {% if not acteurs %}
                 {% include "qfdmo/shared/disclaimers/no_local_solution.html" %}
             {% endif %}
+
         {% else %}
             {% include "qfdmo/shared/disclaimers/adresse_missing.html" %}
         {% endif %}


### PR DESCRIPTION
# Description succincte du problème résolu

https://www.notion.so/accelerateur-transition-ecologique-ademe/Le-bouton-Proposer-une-adresse-appara-t-sous-la-carte-sur-mobile-1a16523d57d780ccbf8bda34e09cd8c7?pvs=4


**🗺️ contexte**: Carte

**💡 quoi**: Le bouton “Proposer une adresse” apparaît sous la carte sur mobile

**🎯 pourquoi**:
- La div étant dans le conteneur leaflet, qui applique des z-index à droite à gauche, le bouton se retrouve recouvert

**🤔 comment**: 
- on déplace le bouton en dehors du conteneur de la carte, _et voilà_
- pas besoin d'utiliser de z-index a priori

## Exemple résultats / UI / Data

![Capture d’écran 2025-04-02 à 14 52 47](https://github.com/user-attachments/assets/534dbe6f-49a7-4f86-96d3-52e38e06c7df)


## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
