### PR TITLE
📦 DBT build en fin de DAGs de clonage

### DIFF
--- a/dags/clone/config/model.py
+++ b/dags/clone/config/model.py
@@ -21,6 +21,7 @@ class CloneConfig(BaseModel):
     file_unpacked: str
     delimiter: str
     run_timestamp: str
+    dbt_command: str
 
     @computed_field
     @property

--- a/dags/clone/dags/clone_ae_etablissement.py
+++ b/dags/clone/dags/clone_ae_etablissement.py
@@ -57,6 +57,11 @@ with DAG(
             type="string",
             description_md="🔤 Délimiteur utilisé dans le fichier",
         ),
+        "dbt_command": Param(
+            "dbt build --select tag:ae,tag:etablissement",
+            type="string",
+            description_md="🔨 Commande DBT à exécuter",
+        ),
     },
 ) as dag:
     chain_tasks(dag)

--- a/dags/clone/dags/clone_ae_unite_legale.py
+++ b/dags/clone/dags/clone_ae_unite_legale.py
@@ -57,6 +57,11 @@ with DAG(
             type="string",
             description_md="🔤 Délimiteur utilisé dans le fichier",
         ),
+        "dbt_command": Param(
+            "dbt build --select tag:ae,tag:unite_legale",
+            type="string",
+            description_md="🔨 Commande DBT à exécuter",
+        ),
     },
 ) as dag:
     chain_tasks(dag)

--- a/dags/clone/dags/clone_ban_adresses.py
+++ b/dags/clone/dags/clone_ban_adresses.py
@@ -57,6 +57,11 @@ with DAG(
             type="string",
             description_md="🔤 Délimiteur utilisé dans le fichier",
         ),
+        "dbt_command": Param(
+            "dbt build --select tag:ban,tag:adresses",
+            type="string",
+            description_md="🔨 Commande DBT à exécuter",
+        ),
     },
 ) as dag:
     chain_tasks(dag)

--- a/dags/clone/dags/clone_ban_lieux_dits.py
+++ b/dags/clone/dags/clone_ban_lieux_dits.py
@@ -57,6 +57,11 @@ with DAG(
             type="string",
             description_md="🔤 Délimiteur utilisé dans le fichier",
         ),
+        "dbt_command": Param(
+            "dbt build --select tag:ban,tag:lieux_dits",
+            type="string",
+            description_md="🔨 Commande DBT à exécuter",
+        ),
     },
 ) as dag:
     chain_tasks(dag)

--- a/dags/clone/tasks/airflow_logic/chain_tasks.py
+++ b/dags/clone/tasks/airflow_logic/chain_tasks.py
@@ -15,6 +15,9 @@ from clone.tasks.airflow_logic.clone_table_validate_task import (
 from clone.tasks.airflow_logic.clone_view_in_use_switch_task import (
     clone_view_in_use_switch_task,
 )
+from shared.tasks.airflow_logic.dbt_command_task import (
+    dbt_command_task,
+)
 
 
 def chain_tasks(dag: DAG) -> None:
@@ -25,4 +28,5 @@ def chain_tasks(dag: DAG) -> None:
         clone_table_validate_task(dag),
         clone_view_in_use_switch_task(dag),
         clone_old_tables_remove_task(dag),
+        dbt_command_task(dag),
     )

--- a/dags/clone/tasks/airflow_logic/chain_tasks.py
+++ b/dags/clone/tasks/airflow_logic/chain_tasks.py
@@ -28,5 +28,5 @@ def chain_tasks(dag: DAG) -> None:
         clone_table_validate_task(dag),
         clone_view_in_use_switch_task(dag),
         clone_old_tables_remove_task(dag),
-        dbt_command_task(dag),
+        dbt_command_task(dag, task_id="clone_dbt_build"),
     )

--- a/dags/clone/tasks/airflow_logic/clone_config_create_task.py
+++ b/dags/clone/tasks/airflow_logic/clone_config_create_task.py
@@ -4,7 +4,7 @@ import logging
 
 from airflow import DAG
 from airflow.operators.python import PythonOperator
-from clone.config import TASKS, XCOMS
+from clone.config import TASKS, XCOMS, CloneConfig
 from clone.tasks.business_logic.clone_config_create import clone_config_create
 from utils import logging_utils as log
 
@@ -26,7 +26,7 @@ def task_info_get():
 
 def clone_config_create_wrapper(ti, params) -> None:
 
-    config = clone_config_create(params)
+    config: CloneConfig = clone_config_create(params)
 
     logger.info(task_info_get())
     log.preview("Configuration générée", config.model_dump())

--- a/dags/shared/tasks/airflow_logic/dbt_command_task.py
+++ b/dags/shared/tasks/airflow_logic/dbt_command_task.py
@@ -1,0 +1,30 @@
+"""Reusable task to run a dbt command in a DAG
+(ex: after clone DAGs -> rebuild the corresponding DBT models).
+TODO: to reuse multiple times in 1 DAG, add a prefix to make task_id unique"""
+
+import logging
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+
+logger = logging.getLogger(__name__)
+
+
+def dbt_command_task(dag: DAG) -> BashOperator:
+    params = dag.params
+    dbt_command = params.get("dbt_command", "").strip()
+
+    logger.info("Commande DBT à exécuter: %s", dbt_command)
+
+    if not dbt_command:
+        raise ValueError("Paramètre dbt_command requis")
+
+    if params.get("dry_run") is True:
+        logger.info("Mode dry_run activé, commande DBT non exécutée")
+        dbt_command = ""
+
+    return BashOperator(
+        task_id="dbt_command",
+        bash_command=dbt_command,
+        dag=dag,
+    )

--- a/dags_unit_tests/clone/test_config_model.py
+++ b/dags_unit_tests/clone/test_config_model.py
@@ -14,6 +14,7 @@ class TestCloneConfig:
             file_unpacked="data.csv",
             delimiter=",",
             run_timestamp="20220305120000",
+            dbt_command="not tested for now",
         )
 
     def test_table_name(self, config):


### PR DESCRIPTION
# 📦 DBT build en fin de DAGs de clonage

Carte Notion: [📦 DBT build en fin de DAGs de clonage](https://www.notion.so/accelerateur-transition-ecologique-ademe/DBT-build-en-fin-de-DAGs-de-clonage-1c76523d57d7809d8f17cb0beacba093)

**🗺️ contexte**: [on s'est accordé sur la façon de gérer les builds dbt dans Airflow](https://mattermost.incubateur.net/betagouv/pl/chpefw7bb3gs5mwnmw6ohm3n5a)

**💡 quoi**: intégration `dbt` aux DAG de clonage

**🎯 pourquoi**: rafraichir les modèles dbt dont certains sont compilés

**🤔 comment**:
 - `dags/shared/tasks/airflow_logic/dbt_command_task.py`: tâche partagée pour lancer une commande dbt
 - `dags/clone/config/model.py` & `dags/clone/dags/clone_*.py`: ajout de `dbt_command`

## Illustration

![image](https://github.com/user-attachments/assets/dacaf562-f677-4bec-a1af-f81d3fe5220e)

## Note sur la BAN

Bien que la **BAN n'ait pas encore de modèles DBT**, j'ai **déjà intégré dbt à la BAN dans cette PR** car en cas de **modèles non-existants, dbt n'échoue pas**, il indique juste ne pas avoir trouvé de modèle:

![image](https://github.com/user-attachments/assets/4f0592de-2863-4ca9-a035-756a62be1595)

## :calendar: Prochaines PRs

 - [ ] **Validation**: transférer à DBT (maintenant que DBT s'exécute en fin de DAG) et supprimer la tâche `clone_table_validate`
    - :green_circle:  **avantage**: simplification du code, on centralise un maximum dans dbt
    - :orange_circle: **inconvénient**: le switch se produit avant la validation, donc on peut se retrouver avec une nouvelle version clonée cassée (ce qui n'est pas le cas quand le DAG fait la validation avant le switch)
      - d'où idéalement il faudrait déplacer les tâches `clone_old_tables_remove` et `clone_view_in_use_switch` après `dbt` après la validation dbt (ex: utiliser variable environement dans dbt pour faire pointer le runtime de validation vers le nouveau clonage)