### PR TITLE
📉 CLONAGE: relaxer la validation

### DIFF
--- a/dags/clone/config/sql/validation/ae_etablissement/validate_join_acteurs_count_siret.sql
+++ b/dags/clone/config/sql/validation/ae_etablissement/validate_join_acteurs_count_siret.sql
@@ -11,7 +11,7 @@ WITH acteurs_with_siret_matched AS (
 )
 SELECT
     CASE
-        WHEN nombre_acteurs >= 150000 THEN TRUE
+        WHEN nombre_acteurs >= 75000 THEN TRUE
         ELSE FALSE
     END AS is_valid,
     nombre_acteurs AS debug_value

--- a/dags/clone/config/sql/validation/ae_etablissement/validate_rows_count.sql
+++ b/dags/clone/config/sql/validation/ae_etablissement/validate_rows_count.sql
@@ -1,6 +1,6 @@
 SELECT
     CASE
-        WHEN COUNT(*) >= 40067694 THEN TRUE
+        WHEN COUNT(*) >= 39000000 THEN TRUE
         ELSE FALSE
     END AS is_valid,
     COUNT(*) as debug_value

--- a/dags/clone/config/sql/validation/ae_unite_legale/validate_join_acteurs_count_siren.sql
+++ b/dags/clone/config/sql/validation/ae_unite_legale/validate_join_acteurs_count_siren.sql
@@ -8,7 +8,7 @@ WITH acteurs_with_siren_matched AS (
 )
 SELECT
     CASE
-        WHEN nombre_acteurs >= 150000 THEN TRUE
+        WHEN nombre_acteurs >= 75000 THEN TRUE
         ELSE FALSE
     END AS is_valid,
     nombre_acteurs AS debug_value

--- a/dags/clone/config/sql/validation/ae_unite_legale/validate_rows_count.sql
+++ b/dags/clone/config/sql/validation/ae_unite_legale/validate_rows_count.sql
@@ -1,6 +1,6 @@
 SELECT
     CASE
-        WHEN COUNT(*) >= 27766501 THEN TRUE
+        WHEN COUNT(*) >= 26000000 THEN TRUE
         ELSE FALSE
     END AS is_valid,
     COUNT(*) as debug_value

--- a/dags/clone/config/sql/validation/ban_adresses/validate_rows_count.sql
+++ b/dags/clone/config/sql/validation/ban_adresses/validate_rows_count.sql
@@ -1,6 +1,6 @@
 SELECT
     CASE
-        WHEN COUNT(*) >= 26000000 THEN TRUE
+        WHEN COUNT(*) >= 24000000 THEN TRUE
         ELSE FALSE
     END AS is_valid,
     COUNT(*) as debug_value

--- a/dags/clone/config/sql/validation/ban_lieux_dits/validate_rows_count.sql
+++ b/dags/clone/config/sql/validation/ban_lieux_dits/validate_rows_count.sql
@@ -1,6 +1,6 @@
 SELECT
     CASE
-        WHEN COUNT(*) >= 220000 THEN TRUE
+        WHEN COUNT(*) >= 210000 THEN TRUE
         ELSE FALSE
     END AS is_valid,
     COUNT(*) as debug_value


### PR DESCRIPTION
# 📉 CLONAGE: relaxer la validation

**🗺️ contexte**: commencé à tester le clonage en PREPROD

**💡 quoi**: relaxation des règles de validation post-import (et avant switch)

**🎯 pourquoi**: trop strictes actuellement, par exemple:
 - **la BAN avait > 26M d'adresses**: ils sont fait du nettoyage et en on plus que 25.9M
 - **on avait 150K acteurs avec SIRET matchés**: on en a plus que 115K

**🤔 comment**:
 - **Compteur les lignes BAN/AE**:  relaxé **d'1 ordre de magnitue** (e.g. 27M -> 26M) car **pas de raison que le volume baisse drastiquement** s'agissant de table de cumul
 - **Compteur SIRET chez nous**: relaxé de 1/2 car on a bcp de fluctuations chez nous
 
## :framed_picture: Exemple de validation en échec

Les adresses de la BAN avait >= 26M de lignes avant, et 25.9M maintenant ([voir run](https://app-d3c229bf-be85-4dbd-aca2-c8df1c6166de.cleverapps.io/dags/clone_ban_adresses/grid?dag_run_id=manual__2025-04-03T07%3A53%3A42%2B00%3A00&task_id=clone_table_create&tab=logs))

![image](https://github.com/user-attachments/assets/623864c7-98b8-489d-bcfa-1a4635c5527b)

![image](https://github.com/user-attachments/assets/48f69947-4a4c-46f3-ae7f-9f9c60bf4b1d)