### PR TITLE
Simplifier le nom des Cohortes

### DIFF
--- a/dags/cluster/dags/cluster_acteur_suggestions.py
+++ b/dags/cluster/dags/cluster_acteur_suggestions.py
@@ -277,7 +277,7 @@ if keys_missing_in_conf:
 
 with DAG(
     dag_id=DAG_ID,
-    dag_display_name="Cluster - Acteurs - Suggestions",
+    dag_display_name="Cluster - Suggestions",
     default_args={
         "owner": "airflow",
         "depends_on_past": False,

--- a/dags/cluster/tasks/airflow_logic/cluster_acteurs_suggestions_to_db_task.py
+++ b/dags/cluster/tasks/airflow_logic/cluster_acteurs_suggestions_to_db_task.py
@@ -49,8 +49,8 @@ def cluster_acteurs_suggestions_to_db_wrapper(ti, dag, run_id) -> None:
     cluster_acteurs_suggestions_to_db(
         df_clusters=df_clusters,
         suggestions=suggestions,
-        identifiant_action=f"dag_id={dag.dag_id}",
-        identifiant_execution=f"run_id={run_id}",
+        identifiant_action=dag.dag_display_name,
+        identifiant_execution=run_id,
         # Rest assured: we are no longer clustering, but
         # we use cluster config to generate useful context
         # data for the Django Admin UI

--- a/dags/crawl/tasks/airflow_logic/crawl_urls_suggest_crawl_diff_other_task.py
+++ b/dags/crawl/tasks/airflow_logic/crawl_urls_suggest_crawl_diff_other_task.py
@@ -32,7 +32,7 @@ def crawl_urls_suggest_crawl_diff_other_wrapper(ti, params, dag, run_id) -> None
 
     crawl_urls_suggest(
         df=xcom_pull(ti, XCOMS.DF_CRAWL_DIFF_OTHER, skip_if_empty=True),
-        dag_id=dag.dag_id,
+        dag_display_name=dag.dag_display_name,
         run_id=run_id,
         dry_run=params.get("dry_run", True),
     )

--- a/dags/crawl/tasks/airflow_logic/crawl_urls_suggest_crawl_diff_standard_task.py
+++ b/dags/crawl/tasks/airflow_logic/crawl_urls_suggest_crawl_diff_standard_task.py
@@ -31,7 +31,7 @@ def crawl_urls_suggest_crawl_diff_standard_wrapper(ti, params, dag, run_id) -> N
 
     crawl_urls_suggest(
         df=xcom_pull(ti, XCOMS.DF_CRAWL_DIFF_STANDARD, skip_if_empty=True),
-        dag_id=dag.dag_id,
+        dag_display_name=dag.dag_display_name,
         run_id=run_id,
         dry_run=params.get("dry_run", True),
     )

--- a/dags/crawl/tasks/airflow_logic/crawl_urls_suggest_dns_fail_task.py
+++ b/dags/crawl/tasks/airflow_logic/crawl_urls_suggest_dns_fail_task.py
@@ -31,7 +31,7 @@ def crawl_urls_suggest_dns_fail_wrapper(ti, params, dag, run_id) -> None:
 
     crawl_urls_suggest(
         df=xcom_pull(ti, XCOMS.DF_DNS_FAIL, skip_if_empty=True),
-        dag_id=dag.dag_id,
+        dag_display_name=dag.dag_display_name,
         run_id=run_id,
         dry_run=params.get("dry_run", True),
     )

--- a/dags/crawl/tasks/airflow_logic/crawl_urls_suggest_syntax_fail_task.py
+++ b/dags/crawl/tasks/airflow_logic/crawl_urls_suggest_syntax_fail_task.py
@@ -31,7 +31,7 @@ def crawl_urls_suggest_syntax_fail_wrapper(ti, params, dag, run_id) -> None:
 
     crawl_urls_suggest(
         df=xcom_pull(ti, XCOMS.DF_SYNTAX_FAIL, skip_if_empty=True),
-        dag_id=dag.dag_id,
+        dag_display_name=dag.dag_display_name,
         run_id=run_id,
         dry_run=params.get("dry_run", True),
     )

--- a/dags/crawl/tasks/business_logic/crawl_urls_suggest.py
+++ b/dags/crawl/tasks/business_logic/crawl_urls_suggest.py
@@ -139,7 +139,7 @@ def crawl_urls_suggestions_to_db(
 
 
 def crawl_urls_suggest(
-    df: pd.DataFrame, dag_id: str, run_id: str, dry_run: bool = True
+    df: pd.DataFrame, dag_display_name: str, run_id: str, dry_run: bool = True
 ) -> int:
     """Main function to generate suggestions for URLs"""
     if df_none_or_empty(df):
@@ -160,8 +160,8 @@ def crawl_urls_suggest(
         crawl_urls_suggestions_to_db(
             metadata=metadata,
             suggestions=suggestions,
-            identifiant_action=f"dag={dag_id}",
-            identifiant_execution=f"run={run_id}, cohorte={cohort}",
+            identifiant_action=f"{dag_display_name} - {cohort}",
+            identifiant_execution=f"{run_id}",
         )
         written_to_db_count = len(suggestions)
     return written_to_db_count

--- a/dags/sources/tasks/business_logic/db_write_type_action_suggestions.py
+++ b/dags/sources/tasks/business_logic/db_write_type_action_suggestions.py
@@ -31,14 +31,14 @@ def db_write_type_action_suggestions(
     insert_suggestion(
         df=df_acteur_to_delete,
         metadata=metadata,
-        dag_name=f"{dag_name} - SUPRESSION",
+        dag_name=f"{dag_name} - SUP",
         run_name=run_name,
         type_action=constants.SUGGESTION_SOURCE_SUPRESSION,
     )
     insert_suggestion(
         df=df_acteur_to_update,
         metadata=metadata,
-        dag_name=f"{dag_name} - MISES A JOUR",
+        dag_name=f"{dag_name} - MODIF",
         run_name=run_name,
         type_action=constants.SUGGESTION_SOURCE_MODIFICATION,
     )

--- a/dags_unit_tests/crawl/tasks/business_logic/test_crawl_urls_suggest.py
+++ b/dags_unit_tests/crawl/tasks/business_logic/test_crawl_urls_suggest.py
@@ -31,7 +31,7 @@ class TestCrawlUrlsSuggest:
         written_to_db_count = crawl_urls_suggest(
             df=df_syntax_fail,
             dry_run=dry_run,
-            dag_id=f"test_crawl_urls_action_{dry_run=}",
+            dag_display_name=f"test_crawl_urls_action_{dry_run=}",
             run_id=f"test_crawl_urls_execution_{dry_run=}",
         )
         assert written_to_db_count == db_cnt_sugg
@@ -40,9 +40,9 @@ class TestCrawlUrlsSuggest:
 
     def test_raise_if_df_none_or_empty(self):
         with pytest.raises(ValueError, match="DF vide ou None"):
-            crawl_urls_suggest(df=None, dry_run=True, dag_id="a", run_id="b")  # type: ignore
+            crawl_urls_suggest(df=None, dry_run=True, dag_display_name="a", run_id="b")
 
     def test_raise_if_multiple_cohorts(self):
         df = pd.DataFrame({COLS.COHORT: ["a", "b"]})
         with pytest.raises(ValueError, match=f"Colonne {COLS.COHORT} doit être unique"):
-            crawl_urls_suggest(df=df, dry_run=True, dag_id="a", run_id="b")
+            crawl_urls_suggest(df=df, dry_run=True, dag_display_name="a", run_id="b")

--- a/data/admin.py
+++ b/data/admin.py
@@ -1,5 +1,4 @@
-from django.contrib import messages
-from django.contrib.gis import admin
+from django.contrib import admin, messages
 from django.utils.html import format_html
 
 from core.admin import NotEditableMixin
@@ -108,7 +107,10 @@ class SuggestionAdmin(admin.ModelAdmin):
         "changements_suggeres",
     ]
     readonly_fields = ["cree_le", "modifie_le"]
-    list_filter = ["suggestion_cohorte", "statut"]
+    list_filter = [
+        ("suggestion_cohorte", admin.RelatedFieldListFilter),
+        ("statut", admin.ChoicesFieldListFilter),
+    ]
     actions = [mark_as_rejected, mark_as_toproceed]
 
     def get_queryset(self, request):

--- a/data/admin.py
+++ b/data/admin.py
@@ -117,9 +117,7 @@ class SuggestionAdmin(admin.ModelAdmin):
 
     def cohorte(self, obj):
         coh = obj.suggestion_cohorte
-        return format_html(
-            "{}<br/>{}", coh.identifiant_action, coh.identifiant_execution
-        )
+        return format_html(str(coh).replace(" -- ", "<br/>"))
 
     def acteur_link_html(self, id):
         return format_html(

--- a/data/admin.py
+++ b/data/admin.py
@@ -98,6 +98,11 @@ def mark_as_toproceed(self, request, queryset):
 
 
 class SuggestionAdmin(admin.ModelAdmin):
+
+    class SuggestionCohorteFilter(admin.RelatedFieldListFilter):
+        def field_choices(self, field, request, model_admin):
+            return field.get_choices(include_blank=False, ordering=("-cree_le",))
+
     search_fields = ["contexte", "suggestion"]
     list_display = [
         "id",
@@ -108,7 +113,7 @@ class SuggestionAdmin(admin.ModelAdmin):
     ]
     readonly_fields = ["cree_le", "modifie_le"]
     list_filter = [
-        ("suggestion_cohorte", admin.RelatedFieldListFilter),
+        ("suggestion_cohorte", SuggestionCohorteFilter),
         ("statut", admin.ChoicesFieldListFilter),
     ]
     actions = [mark_as_rejected, mark_as_toproceed]

--- a/data/models/suggestion.py
+++ b/data/models/suggestion.py
@@ -122,7 +122,7 @@ class SuggestionCohorte(TimestampedModel):
         return execution_datetime
 
     def __str__(self) -> str:
-        return f"""{self.identifiant_action} -- {self.execution_datetime}"""
+        return f"""{self.id} - {self.identifiant_action} -- {self.execution_datetime}"""
 
 
 class Suggestion(models.Model):

--- a/data/models/suggestion.py
+++ b/data/models/suggestion.py
@@ -1,4 +1,6 @@
 import logging
+import re
+from datetime import datetime
 
 from django.contrib.gis.db import models
 from django.db.models.functions import Now
@@ -106,8 +108,21 @@ class SuggestionCohorte(TimestampedModel):
     def is_clustering_type(self) -> bool:
         return self.type_action == SuggestionAction.CLUSTERING
 
+    @property
+    def execution_datetime(self) -> str:
+        execution_datetime = self.identifiant_execution
+        date_match = re.search(
+            r"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})", execution_datetime
+        )
+        if date_match:
+            # Conversion et formatage de la date en une seule ligne
+            execution_datetime = datetime.fromisoformat(date_match.group(1)).strftime(
+                "%d/%m/%Y %H:%M"
+            )
+        return execution_datetime
+
     def __str__(self) -> str:
-        return f"{self.identifiant_action} - {self.identifiant_execution}"
+        return f"""{self.identifiant_action} -- {self.execution_datetime}"""
 
 
 class Suggestion(models.Model):


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [DjangoAdmin : La vue des suggestions/cohortes devient trop polluée](https://www.notion.so/accelerateur-transition-ecologique-ademe/DjangoAdmin-La-vue-des-suggestions-cohortes-devient-trop-pollu-e-1ca6523d57d78004b823d148be62af40?pvs=4)

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Django Admin

**💡 quoi**: simplifier le nom des cohortes

**🎯 pourquoi**: elles sont difficilement lisibles

**🤔 comment**: Modification du __str__ de SuggestionCohorte


## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
