### PR TITLE
👯‍♀️ Cloner: streaming & build dbt optionnel

### DIFF
--- a/dags/clone/config/tasks.py
+++ b/dags/clone/config/tasks.py
@@ -10,3 +10,4 @@ class TASKS:
     TABLE_VALIDATE = "clone_table_validate"
     VIEW_IN_USE_SWITCH = "clone_view_in_use_switch"
     OLD_TABLES_REMOVE = "clone_old_tables_remove"
+    DBT_BUILD = "clone_dbt_build"

--- a/dags/clone/dags/clone_ae_etablissement.py
+++ b/dags/clone/dags/clone_ae_etablissement.py
@@ -42,6 +42,15 @@ with DAG(
             type="string",
             description_md="📥 URL pour télécharger les données",
         ),
+        "clone_method": Param(
+            "download_to_disk_first",
+            type="string",
+            description_md=r"""📥 **Méthode de création** de la table:
+            - `download_to_disk_first`: télécharge/unpack sur disque avant import DB
+            - `stream_directly`: télécharge/unpack/charge en DB à la volée
+            """,
+            enum=["download_to_disk_first", "stream_directly"],
+        ),
         "file_downloaded": Param(
             "StockEtablissement_utf8.zip",
             type="string",
@@ -57,7 +66,12 @@ with DAG(
             type="string",
             description_md="🔤 Délimiteur utilisé dans le fichier",
         ),
-        "dbt_command": Param(
+        "dbt_build_skip": Param(
+            False,
+            type="boolean",
+            description_md="🚫 Si coché, le build DBT ne sera pas exécuté",
+        ),
+        "dbt_build_command": Param(
             "dbt build --select tag:ae,tag:etablissement",
             type="string",
             description_md="🔨 Commande DBT à exécuter",

--- a/dags/clone/dags/clone_ae_unite_legale.py
+++ b/dags/clone/dags/clone_ae_unite_legale.py
@@ -42,6 +42,15 @@ with DAG(
             type="string",
             description_md="📥 URL pour télécharger les données",
         ),
+        "clone_method": Param(
+            "stream_directly",
+            type="string",
+            description_md=r"""📥 **Méthode de création** de la table:
+            - `download_to_disk_first`: télécharge/unpack sur disque avant import DB
+            - `stream_directly`: télécharge/unpack/charge en DB à la volée
+            """,
+            enum=["download_to_disk_first", "stream_directly"],
+        ),
         "file_downloaded": Param(
             "StockUniteLegale_utf8.zip",
             type="string",
@@ -57,7 +66,12 @@ with DAG(
             type="string",
             description_md="🔤 Délimiteur utilisé dans le fichier",
         ),
-        "dbt_command": Param(
+        "dbt_build_skip": Param(
+            False,
+            type="boolean",
+            description_md="🚫 Si coché, la build DBT ne sera pas exécuté",
+        ),
+        "dbt_build_command": Param(
             "dbt build --select tag:ae,tag:unite_legale",
             type="string",
             description_md="🔨 Commande DBT à exécuter",

--- a/dags/clone/dags/clone_ban_adresses.py
+++ b/dags/clone/dags/clone_ban_adresses.py
@@ -42,6 +42,15 @@ with DAG(
             type="string",
             description_md="📥 URL pour télécharger les données",
         ),
+        "clone_method": Param(
+            "stream_directly",
+            type="string",
+            description_md=r"""📥 **Méthode de création** de la table:
+            - `download_to_disk_first`: télécharge/unpack sur disque avant import DB
+            - `stream_directly`: télécharge/unpack/charge en DB à la volée
+            """,
+            enum=["download_to_disk_first", "stream_directly"],
+        ),
         "file_downloaded": Param(
             "adresses-france.csv.gz",
             type="string",
@@ -57,7 +66,12 @@ with DAG(
             type="string",
             description_md="🔤 Délimiteur utilisé dans le fichier",
         ),
-        "dbt_command": Param(
+        "dbt_build_skip": Param(
+            False,
+            type="boolean",
+            description_md="🚫 Si coché, le build DBT ne sera pas exécuté",
+        ),
+        "dbt_build_command": Param(
             "dbt build --select tag:ban,tag:adresses",
             type="string",
             description_md="🔨 Commande DBT à exécuter",

--- a/dags/clone/dags/clone_ban_lieux_dits.py
+++ b/dags/clone/dags/clone_ban_lieux_dits.py
@@ -42,6 +42,15 @@ with DAG(
             type="string",
             description_md="📥 URL pour télécharger les données",
         ),
+        "clone_method": Param(
+            "stream_directly",
+            type="string",
+            description_md=r"""📥 **Méthode de création** de la table:
+            - `download_to_disk_first`: télécharge/unpack sur disque avant import DB
+            - `stream_directly`: télécharge/unpack/charge en DB à la volée
+            """,
+            enum=["download_to_disk_first", "stream_directly"],
+        ),
         "file_downloaded": Param(
             "lieux-dits-beta-france.csv.gz",
             type="string",
@@ -57,7 +66,12 @@ with DAG(
             type="string",
             description_md="🔤 Délimiteur utilisé dans le fichier",
         ),
-        "dbt_command": Param(
+        "dbt_build_skip": Param(
+            False,
+            type="boolean",
+            description_md="🚫 Si coché, le build DBT ne sera pas exécuté",
+        ),
+        "dbt_build_command": Param(
             "dbt build --select tag:ban,tag:lieux_dits",
             type="string",
             description_md="🔨 Commande DBT à exécuter",

--- a/dags/clone/tasks/airflow_logic/chain_tasks.py
+++ b/dags/clone/tasks/airflow_logic/chain_tasks.py
@@ -3,6 +3,11 @@ from airflow.models.baseoperator import chain
 from clone.tasks.airflow_logic.clone_config_create_task import (
     clone_config_create_task,
 )
+
+# from clone.tasks.airflow_logic.clone_dbt_command import (
+#    dbt_command_task,
+# )
+from clone.tasks.airflow_logic.clone_dbt_build import clone_dbt_build_task
 from clone.tasks.airflow_logic.clone_old_tables_remove_task import (
     clone_old_tables_remove_task,
 )
@@ -15,9 +20,6 @@ from clone.tasks.airflow_logic.clone_table_validate_task import (
 from clone.tasks.airflow_logic.clone_view_in_use_switch_task import (
     clone_view_in_use_switch_task,
 )
-from shared.tasks.airflow_logic.dbt_command_task import (
-    dbt_command_task,
-)
 
 
 def chain_tasks(dag: DAG) -> None:
@@ -28,5 +30,14 @@ def chain_tasks(dag: DAG) -> None:
         clone_table_validate_task(dag),
         clone_view_in_use_switch_task(dag),
         clone_old_tables_remove_task(dag),
-        dbt_command_task(dag, task_id="clone_dbt_build"),
+        clone_dbt_build_task(dag),
     )
+
+
+"""
+dbt_command_task(
+    dag,
+    task_id="clone_dbt_build",
+    cmd=dag.params["dbt_build_command"].strip(),
+),
+"""

--- a/dags/clone/tasks/airflow_logic/clone_dbt_build.py
+++ b/dags/clone/tasks/airflow_logic/clone_dbt_build.py
@@ -1,0 +1,58 @@
+"""Performs crawl checks on the URLs"""
+
+import logging
+
+from airflow import DAG
+from airflow.exceptions import AirflowSkipException
+from airflow.operators.bash import BashOperator
+from airflow.operators.python import PythonOperator
+from clone.config import (
+    TASKS,
+    XCOMS,
+    CloneConfig,
+    xcom_pull,
+)
+from utils import logging_utils as log
+
+logger = logging.getLogger(__name__)
+
+
+def task_info_get(config: CloneConfig) -> str:
+    return f"""
+    ============================================================
+    Description de la tâche "{TASKS.DBT_BUILD}"
+    ============================================================
+    💡 quoi: build dbt
+
+    🎯 pourquoi: rafraichir les modèles DBT après import des données
+
+    🏗️ comment: exécuter commande '{config.dbt_build_command}' si
+    dbt_build_skip=False (actuellement={config.dbt_build_skip})
+    """
+
+
+def clone_dbt_build_wrapper(ti) -> None:
+
+    config: CloneConfig = xcom_pull(ti, XCOMS.CONFIG)
+    logger.info(task_info_get(config))
+    log.preview("Configuration", config.model_dump())
+    logger.info(f"Commande DBT: {config.dbt_build_command}")
+
+    if config.dry_run:
+        raise AirflowSkipException("✋ dry_run=True, on s'arrête là")
+    if config.dbt_build_skip:
+        raise AirflowSkipException("✋ dbt_build_skip=True, on s'arrête là")
+
+    bash = BashOperator(
+        task_id=TASKS.DBT_BUILD + "_bash",
+        bash_command=config.dbt_build_command,
+    )
+    bash.execute(context=ti.get_template_context())
+
+
+def clone_dbt_build_task(dag: DAG) -> PythonOperator:
+    return PythonOperator(
+        task_id=TASKS.DBT_BUILD,
+        python_callable=clone_dbt_build_wrapper,
+        dag=dag,
+    )

--- a/dags/clone/tasks/airflow_logic/clone_table_create_task.py
+++ b/dags/clone/tasks/airflow_logic/clone_table_create_task.py
@@ -36,12 +36,12 @@ def clone_table_create_wrapper(ti) -> None:
 
     clone_table_create(
         data_endpoint=config.data_endpoint,
+        clone_method=config.clone_method,
         file_downloaded=config.file_downloaded,
         file_unpacked=config.file_unpacked,
         delimiter=config.delimiter,
         table_name=config.table_name,
         table_schema_file_path=config.table_schema_file_path,
-        run_timestamp=config.run_timestamp,
         dry_run=config.dry_run,
     )
 

--- a/dags/clone/tasks/business_logic/clone_table_create.py
+++ b/dags/clone/tasks/business_logic/clone_table_create.py
@@ -3,7 +3,7 @@
 import logging
 from pathlib import Path
 
-from pydantic import AnyHttpUrl
+from pydantic import AnyUrl
 from utils import logging_utils as log
 from utils.cmd import cmd_run
 from utils.django import django_schema_create_and_check, django_setup_full
@@ -13,22 +13,65 @@ django_setup_full()
 logger = logging.getLogger(__name__)
 
 
-def csv_url_to_commands(
-    data_endpoint: str,
+def command_psql_copy(
+    table_name: str,
+    delimiter: str,
+) -> tuple[str, dict]:
+    """Command to load CSV into DB, factored out for reuse"""
+    from django.db import connection
+
+    db = connection.settings_dict
+    cmd_from = f'stdin WITH (FORMAT csv, HEADER true, DELIMITER "{delimiter}");'
+    cmd = (
+        f"psql -h {db['HOST']} -p {db['PORT']} -U {db['USER']} -d {db['NAME']} "
+        f"-c '\\copy {table_name} FROM {cmd_from}'"
+    )
+    env = {"PGPASSWORD": db["PASSWORD"]}
+    return cmd, env
+
+
+def commands_stream_directly(
+    data_endpoint: AnyUrl,
+    delimiter: str,
+    table_name: str,
+) -> tuple[list[dict], dict]:
+    """Commands to create table while streaming directly to DB (no disk)"""
+
+    cmds_create = []
+    cmd_cleanup = {"cmd": "echo 'Pas de nettoyage requis en streaming'", "env": {}}
+
+    cmd_psql, env_psql = command_psql_copy(table_name=table_name, delimiter=delimiter)
+    cmds_create.append(
+        {
+            "cmd": (f"curl -s {data_endpoint} | " "zcat | " f"{cmd_psql}"),
+            "env": env_psql,
+        }
+    )
+
+    return cmds_create, cmd_cleanup
+
+
+def commands_download_to_disk_first(
+    data_endpoint: AnyUrl,
     file_downloaded: str,
     file_unpacked: str,
     delimiter: str,
     table_name: str,
 ) -> tuple[list[dict], dict]:
-    """Generates a list of commands to run to replicate the data locally"""
-    from django.db import connection
+    """Commands to create table while first dowloading to disk"""
 
     # File download and unpacking: all done within a temporary folder
     # so cleanup is easier AND to avoid collisions (table name contains timestamp)
     folder = f"/tmp/{table_name}"
     cmds_create = []
+
+    # Create folder to hold temporary files
     cmds_create.append(f"mkdir {folder}")
+
+    # Download to folder
     cmds_create.append(f"curl -sSL {data_endpoint} -o {folder}/{file_downloaded}")
+
+    # Unpack the file
     if str(data_endpoint).endswith(".zip"):
         cmds_create.append(f"unzip {folder}/{file_downloaded} -d {folder}/")
     elif str(data_endpoint).endswith(".gz"):
@@ -39,22 +82,19 @@ def csv_url_to_commands(
         pass
     else:
         raise NotImplementedError(f"URL non supportée: {data_endpoint}")
+
+    # Check the unpacked file
     cmds_create.append(f"wc -l {folder}/{file_unpacked}")
 
-    # Converting commands so far into results format
+    # Convert commands so far into results format
     cmds_create = [{"cmd": cmd, "env": {}} for cmd in cmds_create]
 
-    # Finally the command to load the CSV into the DB
-    db = connection.settings_dict
-    cmd_from = f'stdin WITH (FORMAT csv, HEADER true, DELIMITER "{delimiter}");'
+    # Load into DB
+    cmd_psql, env_psql = command_psql_copy(table_name=table_name, delimiter=delimiter)
     cmds_create.append(
         {
-            "cmd": (
-                f"cat {folder}/{file_unpacked} | "
-                f"psql -h {db['HOST']} -p {db['PORT']} -U {db['USER']} -d {db['NAME']} "
-                f"-c '\\copy {table_name} FROM {cmd_from}'"
-            ),
-            "env": {"PGPASSWORD": db["PASSWORD"]},
+            "cmd": (f"cat {folder}/{file_unpacked} | " f"{cmd_psql}"),
+            "env": env_psql,
         }
     )
 
@@ -64,24 +104,11 @@ def csv_url_to_commands(
     return cmds_create, cmd_cleanup
 
 
-def csv_from_url_to_table(
-    data_endpoint: AnyHttpUrl,
-    file_downloaded: str,
-    file_unpacked: str,
-    delimiter: str,
-    table_name: str,
-    run_timestamp: str,
+def commands_run(
+    cmds_create: list[dict],
+    cmd_cleanup: dict,
     dry_run: bool,
 ):
-    r"""Streams a CSV from a URL directly into a PG.
-    🔴 Requires the table schema to be created prior to this"""
-    cmds_create, cmd_cleanup = csv_url_to_commands(
-        data_endpoint=data_endpoint,
-        file_downloaded=file_downloaded,
-        file_unpacked=file_unpacked,
-        delimiter=delimiter,
-        table_name=table_name,
-    )
 
     # Trying creation commands
     error = None
@@ -101,36 +128,61 @@ def csv_from_url_to_table(
 
 
 def clone_table_create(
-    data_endpoint: AnyHttpUrl,
+    data_endpoint: AnyUrl,
+    clone_method: str,
     file_downloaded: str,
     file_unpacked: str,
     delimiter: str,
     table_name: str,
     table_schema_file_path: Path,
-    run_timestamp: str,
     dry_run: bool,
 ) -> None:
     """Create a table in the DB from a CSV file downloaded via URL"""
 
-    # Read tasks
     logger.info(log.banner_string(f"Création du schema de la table {table_name}"))
-    sql = table_schema_file_path.read_text().replace(r"{{table_name}}", table_name)
 
-    # Write tasks
-    django_schema_create_and_check(table_name, sql, dry_run=dry_run)
-    csv_from_url_to_table(
-        data_endpoint=data_endpoint,
-        file_downloaded=file_downloaded,
-        file_unpacked=file_unpacked,
-        delimiter=delimiter,
-        table_name=table_name,
-        run_timestamp=run_timestamp,
-        dry_run=dry_run,
-    )
+    try:
+        # Create table schema to hold the data
+        sql = table_schema_file_path.read_text().replace(r"{{table_name}}", table_name)
+        django_schema_create_and_check(table_name, sql, dry_run=dry_run)
 
-    # Final log
-    logger.info(log.banner_string("🏁 Résultat final de la tâche"))
-    logger.info(f"Nom de le table: {table_name}")
-    log.preview("Schema obtenu", sql)
-    logger.info("Création schema: " + "✋ (dry_run)" if dry_run else "🟢 effectuée")
-    logger.info("Chargement CSV: " + "✋ (dry_run)" if dry_run else "🟢 effectué")
+        # Get commands based on the create method
+        if clone_method == "download_to_disk_first":
+            cmds_create, cmd_cleanup = commands_download_to_disk_first(
+                data_endpoint=data_endpoint,
+                file_downloaded=file_downloaded,
+                file_unpacked=file_unpacked,
+                delimiter=delimiter,
+                table_name=table_name,
+            )
+        elif clone_method == "stream_directly":
+            cmds_create, cmd_cleanup = commands_stream_directly(
+                data_endpoint=data_endpoint,
+                delimiter=delimiter,
+                table_name=table_name,
+            )
+        else:
+            raise ValueError(f"Méthode {clone_method=} invalide")
+
+        # Run the commands
+        commands_run(
+            cmds_create=cmds_create,
+            cmd_cleanup=cmd_cleanup,
+            dry_run=dry_run,
+        )
+
+        # Final log
+        logger.info(log.banner_string("🏁 Résultat final de la tâche"))
+        logger.info(f"Nom de le table: {table_name}")
+        log.preview("Schema obtenu", sql)
+        logger.info("Création schema: " + "✋ (dry_run)" if dry_run else "🟢 effectuée")
+        logger.info("Chargement CSV: " + "✋ (dry_run)" if dry_run else "🟢 effectué")
+
+    # If anything went wrong = delete schema if it exists
+    except Exception as e:
+        from django.db import connection
+
+        logger.error(log.banner_string(f"❌ Erreur rencontrée: {e}"))
+        logger.error(f"On supprime la table {table_name} si créée")
+        with connection.cursor() as cursor:
+            cursor.execute(f"DROP TABLE IF EXISTS {table_name};")

--- a/dags_unit_tests/clone/test_config_model.py
+++ b/dags_unit_tests/clone/test_config_model.py
@@ -10,11 +10,13 @@ class TestCloneConfig:
             dry_run=False,
             table_kind="my_table",
             data_endpoint="https://example.org/data.zip",  # type: ignore
+            clone_method="download_to_disk_first",
             file_downloaded="data.zip",
             file_unpacked="data.csv",
             delimiter=",",
             run_timestamp="20220305120000",
-            dbt_command="not tested for now",
+            dbt_build_skip=False,
+            dbt_build_command="dbt build --select tag:nothing_to_do",
         )
 
     def test_table_name(self, config):


### PR DESCRIPTION
# 👯‍♀️ Cloner: streaming & build dbt optionnel

**🗺️ contexte**:
 - **streaming**: dans la PR initiale Annuaire Entreprise (https://github.com/incubateur-ademe/quefairedemesobjets/pull/1408) j'avais testé du streaming, mais ne fonctionnant pas pour AE Etablissement, je l'avais enlevé, entre temps j'ai fait la BAN qui a rendu les DAGs paramètrables (https://github.com/incubateur-ademe/quefairedemesobjets/pull/1451), donc je peux remettre du streaming là où il fonctionne
 - **build dbt**: on s'est rendu compte la semaine dernière des gros problèmes de perf DB

**💡 quoi**:
 - **streaming**: ré-introduction via un paramètre, tout en streaming sauf AE Etablissement
 - **build dbt**: paramètre de config rendant le build optionnel

**🎯 pourquoi**:
 - **streaming**: pour éviter de toucher le disque/IO quand c'est pas nécessaire
 - **build dbt**: pouvoir faire clonage sans systématiquement faire dbt (ex: pour l'instant problème de perf)

**🤔 comment**:
 - **streaming**: `curl | zcat | psql`
 - **build dbt**: j'utilise `BashOperator.execute()` dans ma tâche Python. Au final toutes les méthodes utilisées jusqu'à présent, y compris BashOperator, finissent par utiliser subprocess (ex: pour [BashOperator](https://github.com/apache/airflow/blob/6c885cd26386ec42f0c594ef0df2c55c675b4995/providers/standard/src/airflow/providers/standard/operators/bash.py#L216) via [SubprocessHook](https://github.com/apache/airflow/blob/main/providers/standard/src/airflow/providers/standard/hooks/subprocess.py#L46)).
 
## :framed_picture: Illustration

 - **run 1** = streaming + DBT
 - **run 2** = streaming - DBT
 - **run 3** = download - DBT

![image](https://github.com/user-attachments/assets/49f41475-895d-4075-8bb2-99ba5ba7d527)

Pour la création de la table, on **réduit le temps du ~20%** mais surtout **on n'occupe pas l'IO du disque**

![image](https://github.com/user-attachments/assets/888edd32-0770-49e1-801e-8a166bc03b48)
