### PR TITLE
🛑 🕵 dbt: désactiver le tracking

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -7,6 +7,9 @@ version: "1.0.0"
 # This setting configures which "profile" dbt uses for this project.
 profile: "default"
 
+flags:
+  send_anonymous_usage_stats: false
+
 # These configurations specify where dbt should look for different types of files.
 # The `model-paths` config, for example, states that models in this project can be
 # found in the "models/" directory. You probably won't need to change these!


### PR DESCRIPTION
# 🛑 🕵 dbt: désactiver le tracking

**🗺️ contexte**: en débuggant dbt (--debug) j'ai constaté qu'on était tracké (dbt semble utiliser https://snowplow.io/ pour ce faire):

```bash
dbt run --debug

08:54:26  Sending event: {'category': 'dbt', 'action': 'invocation', 'label': 'end', 'context': [<snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7c61ba704740>, <snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7c61b8140b60>, <snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7c61bae94fb0>]}
```

```bash
tcpdump -i any 'tcp[tcpflags] & (tcp-syn|tcp-fin) != 0 and not port 6543 and not port 5432'

10:58:51.768880 wlp5s0 Out IP me > ec2-184-72-188-7.compute-1.amazonaws.com.https: Flags [S], seq 1680824202, win 64240, options [mss 1460,sackOK,TS val 3939850066 ecr 0,nop,wscale 7], length 0
```

**💡 quoi**: désactiver le tracking dbt

**🎯 pourquoi**: protection de notre vie privée

**🤔 comment**: option dans `dbt_project.yml`