### PR TITLE
J'ai oublié de mettre à jour le test du nombre de colonne 

### DIFF
--- a/dbt/models/exposure/acteurs/opendata/schema.yml
+++ b/dbt/models/exposure/acteurs/opendata/schema.yml
@@ -122,7 +122,7 @@ models:
           min_value: 250000
           max_value: 400000
       - dbt_expectations.expect_table_column_count_to_equal:
-          value: 24
+          value: 34
     config:
       materialized: table
       indexes:


### PR DESCRIPTION

# Description succincte du problème résolu

J'ai oublié de mettre à jour le test du nombre de colonne après avoir ajouté des colonnes au jeu de données opendata

Du coup, le jeux de donnée est à jour mais le DAG airflow fini en erreur

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Airflow DBT

**💡 quoi**: Test DBT du jeux de données opendata

**🎯 pourquoi**: Oubli du mise à jour du tests après avoir ajouté des colonnes

**🤔 comment**: Modification du nombre de colonne attendu

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
