### PR TITLE
On a besoin de l'acteur_type pour définir l'identifiant unique

### DIFF
--- a/dags/sources/dags/source_aliapur.py
+++ b/dags/sources/dags/source_aliapur.py
@@ -81,6 +81,7 @@ with DAG(
                 "origin": [
                     "identifiant_externe",
                     "source_code",
+                    "acteur_type_code",
                 ],
                 "transformation": "clean_identifiant_unique",
                 "destination": ["identifiant_unique"],

--- a/dags/sources/dags/source_citeo.py
+++ b/dags/sources/dags/source_citeo.py
@@ -76,6 +76,7 @@ with DAG(
                 "origin": [
                     "identifiant_externe",
                     "source_code",
+                    "acteur_type_code",
                 ],
                 "transformation": "clean_identifiant_unique",
                 "destination": ["identifiant_unique"],

--- a/dags/sources/dags/source_cma.py
+++ b/dags/sources/dags/source_cma.py
@@ -118,6 +118,7 @@ with DAG(
                 "origin": [
                     "identifiant_externe",
                     "source_code",
+                    "acteur_type_code",
                 ],
                 "transformation": "clean_identifiant_unique",
                 "destination": ["identifiant_unique"],

--- a/dags/sources/dags/source_corepile.py
+++ b/dags/sources/dags/source_corepile.py
@@ -80,6 +80,7 @@ with DAG(
                 "origin": [
                     "identifiant_externe",
                     "source_code",
+                    "acteur_type_code",
                 ],
                 "transformation": "clean_identifiant_unique",
                 "destination": ["identifiant_unique"],

--- a/dags/sources/dags/source_cyclevia.py
+++ b/dags/sources/dags/source_cyclevia.py
@@ -104,6 +104,7 @@ with DAG(
                 "origin": [
                     "identifiant_externe",
                     "source_code",
+                    "acteur_type_code",
                 ],
                 "transformation": "clean_identifiant_unique",
                 "destination": ["identifiant_unique"],

--- a/dags/sources/dags/source_ecodds.py
+++ b/dags/sources/dags/source_ecodds.py
@@ -91,6 +91,7 @@ with DAG(
                 "origin": [
                     "identifiant_externe",
                     "source_code",
+                    "acteur_type_code",
                 ],
                 "transformation": "clean_identifiant_unique",
                 "destination": ["identifiant_unique"],

--- a/dags/sources/dags/source_ecologic.py
+++ b/dags/sources/dags/source_ecologic.py
@@ -81,6 +81,7 @@ with DAG(
                 "origin": [
                     "identifiant_externe",
                     "source_code",
+                    "acteur_type_code",
                 ],
                 "transformation": "clean_identifiant_unique",
                 "destination": ["identifiant_unique"],

--- a/dags/sources/dags/source_ecomaison.py
+++ b/dags/sources/dags/source_ecomaison.py
@@ -90,6 +90,7 @@ with DAG(
                 "origin": [
                     "identifiant_externe",
                     "source_code",
+                    "acteur_type_code",
                 ],
                 "transformation": "clean_identifiant_unique",
                 "destination": ["identifiant_unique"],

--- a/dags/sources/dags/source_ecopae.py
+++ b/dags/sources/dags/source_ecopae.py
@@ -90,6 +90,7 @@ with DAG(
                 "origin": [
                     "identifiant_externe",
                     "source_code",
+                    "acteur_type_code",
                 ],
                 "transformation": "clean_identifiant_unique",
                 "destination": ["identifiant_unique"],

--- a/dags/sources/dags/source_ecosystem.py
+++ b/dags/sources/dags/source_ecosystem.py
@@ -80,6 +80,7 @@ with DAG(
                 "origin": [
                     "identifiant_externe",
                     "source_code",
+                    "acteur_type_code",
                 ],
                 "transformation": "clean_identifiant_unique",
                 "destination": ["identifiant_unique"],

--- a/dags/sources/dags/source_ocab.py
+++ b/dags/sources/dags/source_ocab.py
@@ -80,6 +80,7 @@ with DAG(
                 "origin": [
                     "identifiant_externe",
                     "source_code",
+                    "acteur_type_code",
                 ],
                 "transformation": "clean_identifiant_unique",
                 "destination": ["identifiant_unique"],

--- a/dags/sources/dags/source_ocad3e.py
+++ b/dags/sources/dags/source_ocad3e.py
@@ -90,6 +90,7 @@ with DAG(
                 "origin": [
                     "identifiant_externe",
                     "source_code",
+                    "acteur_type_code",
                 ],
                 "transformation": "clean_identifiant_unique",
                 "destination": ["identifiant_unique"],

--- a/dags/sources/dags/source_pharmacies.py
+++ b/dags/sources/dags/source_pharmacies.py
@@ -94,6 +94,7 @@ with DAG(
                 "origin": [
                     "identifiant_externe",
                     "source_code",
+                    "acteur_type_code",
                 ],
                 "transformation": "clean_identifiant_unique",
                 "destination": ["identifiant_unique"],

--- a/dags/sources/dags/source_pyreo.py
+++ b/dags/sources/dags/source_pyreo.py
@@ -105,6 +105,7 @@ with DAG(
                 "origin": [
                     "identifiant_externe",
                     "source_code",
+                    "acteur_type_code",
                 ],
                 "transformation": "clean_identifiant_unique",
                 "destination": ["identifiant_unique"],

--- a/dags/sources/dags/source_refashion.py
+++ b/dags/sources/dags/source_refashion.py
@@ -105,6 +105,7 @@ with DAG(
                 "origin": [
                     "identifiant_externe",
                     "source_code",
+                    "acteur_type_code",
                 ],
                 "transformation": "clean_identifiant_unique",
                 "destination": ["identifiant_unique"],

--- a/dags/sources/dags/source_s3.py
+++ b/dags/sources/dags/source_s3.py
@@ -125,6 +125,7 @@ with DAG(
                 "origin": [
                     "identifiant_externe",
                     "source_code",
+                    "acteur_type_code",
                 ],
                 "transformation": "clean_identifiant_unique",
                 "destination": ["identifiant_unique"],

--- a/dags/sources/dags/source_screlec.py
+++ b/dags/sources/dags/source_screlec.py
@@ -101,6 +101,7 @@ with DAG(
                 "origin": [
                     "identifiant_externe",
                     "source_code",
+                    "acteur_type_code",
                 ],
                 "transformation": "clean_identifiant_unique",
                 "destination": ["identifiant_unique"],

--- a/dags/sources/dags/source_sinoe.py
+++ b/dags/sources/dags/source_sinoe.py
@@ -108,6 +108,7 @@ with DAG(
                 "origin": [
                     "identifiant_externe",
                     "source_code",
+                    "acteur_type_code",
                 ],
                 "transformation": "clean_identifiant_unique",
                 "destination": ["identifiant_unique"],

--- a/dags/sources/dags/source_soren.py
+++ b/dags/sources/dags/source_soren.py
@@ -97,6 +97,7 @@ with DAG(
                 "origin": [
                     "identifiant_externe",
                     "source_code",
+                    "acteur_type_code",
                 ],
                 "transformation": "clean_identifiant_unique",
                 "destination": ["identifiant_unique"],

--- a/dags/sources/dags/source_valdelia.py
+++ b/dags/sources/dags/source_valdelia.py
@@ -96,6 +96,7 @@ with DAG(
                 "origin": [
                     "identifiant_externe",
                     "source_code",
+                    "acteur_type_code",
                 ],
                 "transformation": "clean_identifiant_unique",
                 "destination": ["identifiant_unique"],


### PR DESCRIPTION
# Description succincte du problème résolu

Github suite :  Comparer les acteurs de la source et en DB via leur source + identifiant_externe #1521 

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Airflow - Source

**💡 quoi**: le calcul de l'identifiant_unique à besoin de la colonne acteur_type_code

**🎯 pourquoi**: Pour suffixer les acteur digitaux

**🤔 comment**: passer la colonne acteur_type_code à la fonction clean_identifiant_unique

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
