### PR TITLE
Ajouter un index lors de la résolution de mapping

### DIFF
--- a/dags/sources/tasks/business_logic/keep_acteur_changed.py
+++ b/dags/sources/tasks/business_logic/keep_acteur_changed.py
@@ -91,6 +91,18 @@ def retrieve_identifiant_unique_from_existing_acteur(
         axis=1,
     )
 
+    # find the duplicated identifiant in df_acteur_from_db and raise if any because
+    # we can't resolve simply the mapping between source and db
+    duplicates = df_acteur_from_db[
+        df_acteur_from_db.duplicated("identifiant", keep=False)
+    ]
+    if not duplicates.empty:
+        logger.warning(
+            "Duplicated identifiant in df_acteur_from_db"
+            f" {duplicates["identifiant"].tolist()}"
+        )
+        raise ValueError("Duplicated identifiant in df_acteur_from_db")
+
     # Replace identifiant_unique (from source) by identifiant (from db) for acteur
     # which doesn't have corelation between source, external_id and identifiant_unique
     df_normalized.set_index("identifiant", inplace=True)

--- a/dags_unit_tests/sources/tasks/business_logic/test_keep_acteur_changed.py
+++ b/dags_unit_tests/sources/tasks/business_logic/test_keep_acteur_changed.py
@@ -991,3 +991,72 @@ def test_keep_acteur_changed_same_acteur_but_different_identifiant_unique(dag_co
     pd.testing.assert_frame_equal(df_acteur, df_expected, check_dtype=False)
     pd.testing.assert_frame_equal(df_acteur_from_db, df_expected, check_dtype=False)
     assert metadata == {}
+
+
+def test_keep_acteur_changed_same_acteur_but_different_identifiant_unique2(dag_config):
+    df_normalized = pd.DataFrame(
+        {
+            "nom": ["nom 1", "nom 2"],
+            "identifiant_unique": ["source1_id1", "source1_id2"],
+            "source_code": ["source1", "source1"],
+            "identifiant_externe": ["id1", "id2"],
+            "label_codes": [[], []],
+            "acteur_type_code": [[], []],
+            "acteur_service_codes": [[], []],
+            "proposition_service_codes": [[], []],
+        }
+    )
+    df_acteur_from_db = pd.DataFrame(
+        {
+            "nom": ["nom 1", "nom 3"],
+            "identifiant_unique": ["source1_id_old", "source1_id3"],
+            "source_code": ["source1", "source1"],
+            "identifiant_externe": ["id1", "id3"],
+            "label_codes": [[], []],
+            "acteur_type_code": [[], []],
+            "acteur_service_codes": [[], []],
+            "proposition_service_codes": [[], []],
+        }
+    )
+    df_expected = pd.DataFrame(
+        {
+            "nom": ["nom 2"],
+            "identifiant_unique": ["source1_id2"],
+            "source_code": ["source1"],
+            "identifiant_externe": ["id2"],
+            "label_codes": [[]],
+            "acteur_type_code": [[]],
+            "acteur_service_codes": [[]],
+            "proposition_service_codes": [[]],
+        }
+    )
+    df_expected_from_db = pd.DataFrame(
+        {
+            "nom": ["nom 3"],
+            "identifiant_unique": ["source1_id3"],
+            "source_code": ["source1"],
+            "identifiant_externe": ["id3"],
+            "label_codes": [[]],
+            "acteur_type_code": [[]],
+            "acteur_service_codes": [[]],
+            "proposition_service_codes": [[]],
+        }
+    )
+
+    df_acteur, df_acteur_from_db, metadata = keep_acteur_changed(
+        df_normalized=df_normalized,
+        df_acteur_from_db=df_acteur_from_db,
+        dag_config=dag_config,
+    )
+
+    pd.testing.assert_frame_equal(
+        df_acteur.reset_index(drop=True),
+        df_expected.reset_index(drop=True),
+        check_dtype=False,
+    )
+    pd.testing.assert_frame_equal(
+        df_acteur_from_db.reset_index(drop=True),
+        df_expected_from_db.reset_index(drop=True),
+        check_dtype=False,
+    )
+    assert metadata == {}

--- a/qfdmo/admin/acteur.py
+++ b/qfdmo/admin/acteur.py
@@ -155,6 +155,7 @@ class BaseActeurAdmin(admin.GISModelAdmin):
         "siret",
         "siren",
         "identifiant_unique",
+        "identifiant_externe",
         "code_postal",
         "ville",
         "adresse",
@@ -163,6 +164,7 @@ class BaseActeurAdmin(admin.GISModelAdmin):
     search_fields = [
         "code_postal",
         "identifiant_unique",
+        "identifiant_externe",
         "nom__unaccent",
         "siret",
         "siren",

--- a/qfdmo/management/commands/update_external_ids.py
+++ b/qfdmo/management/commands/update_external_ids.py
@@ -2,10 +2,9 @@ import argparse
 import json
 
 from django.core.management.base import BaseCommand
+from django.db import transaction
 
 from qfdmo.models.acteur import Acteur, ActeurStatus, RevisionActeur
-
-CHUNK = 1000
 
 
 class Command(BaseCommand):
@@ -39,48 +38,54 @@ class Command(BaseCommand):
         with open(mapping_file, "r") as f:
             mapping = json.load(f)
 
-        for old_id, new_id in mapping.items():
-            # Check if the ids are not empty
-            if old_id and new_id:
-                self.stdout.write(
-                    self.style.SUCCESS(f"Updating `{old_id}` to `{new_id}`")
-                )
-            else:
-                self.stdout.write(
-                    self.style.WARNING(
-                        f"Skipping `{old_id}` to `{new_id}` : one of the ids is empty"
+        with transaction.atomic():
+            for old_id, new_id in mapping.items():
+                # Check if the ids are not empty
+                if old_id and new_id:
+                    self.stdout.write(
+                        self.style.SUCCESS(f"Mapping `{old_id}` to `{new_id}`")
                     )
-                )
-                continue
+                else:
+                    self.stdout.write(
+                        self.style.WARNING(
+                            f"Skipping `{old_id}` to `{new_id}` : one of the ids is"
+                            " empty"
+                        )
+                    )
+                    continue
 
-            # test acteur with this new external id already exists
-            acteur_from_db = Acteur.objects.filter(
-                identifiant_externe=new_id, source__code=source_code
-            ).first()
-            id_index = 0
-            while acteur_from_db:
-                id_index += 1
-                new_id_indexed = f"{new_id}_{id_index}"
-                acteur_from_db = Acteur.objects.filter(
-                    identifiant_externe=new_id_indexed, source__code=source_code
+                # Update acteur if exists
+                acteur = Acteur.objects.filter(
+                    identifiant_externe=old_id, source__code=source_code
                 ).first()
 
-            try:
-                new_id = new_id_indexed
-                statut = ActeurStatus.INACTIF
-            except NameError:
+                if not acteur:
+                    self.stdout.write(self.style.WARNING(f"Acteur {old_id} not found"))
+                    continue
+
+                # test acteur with this new external id already exists
+                acteur_from_db = Acteur.objects.filter(
+                    identifiant_externe=new_id, source__code=source_code
+                ).first()
+                id_index = 0
+                while acteur_from_db:
+                    self.stdout.write(
+                        self.style.WARNING(
+                            f"Acteur {acteur_from_db.identifiant_externe} already"
+                            " exists, trying to find an unused id"
+                        )
+                    )
+                    id_index += 1
+                    new_id_indexed = f"{new_id}_{id_index}"
+                    acteur_from_db = Acteur.objects.filter(
+                        identifiant_externe=new_id_indexed, source__code=source_code
+                    ).first()
+
                 statut = ActeurStatus.ACTIF
+                if id_index:
+                    new_id = f"{new_id}_{id_index}"
+                    statut = ActeurStatus.INACTIF
 
-            # Update acteur if exists
-            acteur = Acteur.objects.filter(
-                identifiant_externe=old_id, source__code=source_code
-            ).first()
-
-            if not acteur:
-                self.stdout.write(self.style.WARNING(f"Acteur {old_id} not found"))
-                continue
-
-            if not dry_run:
                 self.stdout.write(
                     self.style.SUCCESS(
                         f"Updating acteur {acteur.identifiant_unique} to {new_id}"
@@ -89,31 +94,23 @@ class Command(BaseCommand):
                 acteur.identifiant_externe = new_id
                 acteur.statut = statut
                 acteur.save()
-            else:
-                self.stdout.write(
-                    self.style.WARNING(
-                        f"Dry run: would update Acteur {old_id} to {new_id}"
-                    )
-                )
 
-            # Update revision acteur if exists
-            revision_acteur = RevisionActeur.objects.filter(
-                identifiant_externe=old_id, source__code=source_code
-            ).first()
+                # Update revision acteur if exists
+                revision_acteur = RevisionActeur.objects.filter(
+                    identifiant_externe=old_id, source__code=source_code
+                ).first()
 
-            if revision_acteur and not dry_run:
-                self.stdout.write(
-                    self.style.SUCCESS(
-                        f"Updating revision acteur {revision_acteur.identifiant_unique}"
-                        f" to {new_id}"
+                if revision_acteur:
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            "Updating revision acteur "
+                            f"{revision_acteur.identifiant_unique} to {new_id}"
+                        )
                     )
-                )
-                revision_acteur.identifiant_externe = new_id
-                revision_acteur.statut = statut
-                revision_acteur.save()
-            if revision_acteur and dry_run:
-                self.stdout.write(
-                    self.style.WARNING(
-                        f"Dry run: would update RevisionActeur {old_id} to {new_id}"
-                    )
-                )
+                    revision_acteur.identifiant_externe = new_id
+                    revision_acteur.statut = statut
+                    revision_acteur.save()
+
+            if dry_run:
+                # Rollback the transaction
+                raise Exception("Rolling back transaction because of dry run")

--- a/qfdmo/management/commands/update_external_ids.py
+++ b/qfdmo/management/commands/update_external_ids.py
@@ -3,7 +3,7 @@ import json
 
 from django.core.management.base import BaseCommand
 
-from qfdmo.models.acteur import Acteur, RevisionActeur
+from qfdmo.models.acteur import Acteur, ActeurStatus, RevisionActeur
 
 CHUNK = 1000
 
@@ -53,6 +53,22 @@ class Command(BaseCommand):
                 )
                 continue
 
+            # test acteur with this new external id already exists
+            acteur_from_db = Acteur.objects.filter(
+                identifiant_externe=new_id, source__code=source_code
+            ).first()
+            id_index = 0
+            while acteur_from_db:
+                id_index += 1
+                new_id_indexed = f"{new_id}_{id_index}"
+                acteur_from_db = Acteur.objects.filter(
+                    identifiant_externe=new_id_indexed, source__code=source_code
+                ).first()
+            statut = ActeurStatus.ACTIF
+            if id_index:
+                new_id = f"{new_id}_{id_index}"
+                statut = ActeurStatus.INACTIF
+
             # Update acteur if exists
             acteur = Acteur.objects.filter(
                 identifiant_externe=old_id, source__code=source_code
@@ -69,6 +85,7 @@ class Command(BaseCommand):
                     )
                 )
                 acteur.identifiant_externe = new_id
+                acteur.statut = statut
                 acteur.save()
             else:
                 self.stdout.write(
@@ -90,6 +107,7 @@ class Command(BaseCommand):
                     )
                 )
                 revision_acteur.identifiant_externe = new_id
+                revision_acteur.statut = statut
                 revision_acteur.save()
             if revision_acteur and dry_run:
                 self.stdout.write(

--- a/qfdmo/management/commands/update_external_ids.py
+++ b/qfdmo/management/commands/update_external_ids.py
@@ -64,10 +64,12 @@ class Command(BaseCommand):
                 acteur_from_db = Acteur.objects.filter(
                     identifiant_externe=new_id_indexed, source__code=source_code
                 ).first()
-            statut = ActeurStatus.ACTIF
-            if id_index:
-                new_id = f"{new_id}_{id_index}"
+
+            try:
+                new_id = new_id_indexed
                 statut = ActeurStatus.INACTIF
+            except NameError:
+                statut = ActeurStatus.ACTIF
 
             # Update acteur if exists
             acteur = Acteur.objects.filter(


### PR DESCRIPTION
# Description succincte du problème résolu

Suite #1521

Notion : [Importer le fichier v3 Valdelia (EA, PMCB) dans LVAO - avec table de pivot vers nouvel ID](https://www.notion.so/Importer-le-fichier-v3-Valdelia-EA-PMCB-dans-LVAO-avec-table-de-pivot-vers-nouvel-ID-1c86523d57d7805db04cf33e891ffea7?pvs=8&n=github_linkback)

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Airflow Source

**💡 quoi**: lors de la migration des identifiant_externe, il faut s'assurer de ne pas créer des duplicats d'identifiant_externe pour la même source

**🎯 pourquoi**: Après le mapping est impossible entre ca qu'on a en DB et ce qu'on a dans la source

**🤔 comment**: 

* On cherche si un acteur avec la même source et le même identifiant_unique 'exte pas déjà, si oui, on index l'identifiant externe à mettre à jour et on recommence
* On en profite pour inactiver les acteurs en doublons (identifiant_externe indexé)
* Dans le DAG, on vérifie qu'il n'existe pas plusieurs mapping possible pour un même identifiant_externe

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [x] Testé sur mon airflow local avec succès
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code

## 📆 A faire (prochaine PR)

- [ ] Rendre le couple source_id, identifiant_externe unique
