### PR TITLE
🚀 Déployer lors des release GitHub plutôt que sur les tags 

### DIFF
--- a/.github/workflows/cd_prod.yml
+++ b/.github/workflows/cd_prod.yml
@@ -1,10 +1,8 @@
 name: "[🔴 Prod] Déploiement continu"
 
 on:
-  push:
-    tags:
-      - v*
-
+  release:
+    types: [published]
 
 defaults:
   run:
@@ -13,16 +11,6 @@ defaults:
 jobs:
   run_tests:
     uses: ./.github/workflows/run_tests.yml
-
-  create-release:
-    name: Create GitHub Release
-    needs: [run_tests]
-    runs-on: "ubuntu-latest"
-    steps:
-      - uses: "marvinpinto/action-automatic-releases@v1.2.1"
-        with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          prerelease: false
 
   deploy:
     name: Deploy on Scalingo


### PR DESCRIPTION
# Description succincte du problème résolu

Proposition de revoir le mode de déclenchement des release GitHub 

**🗺️ contexte**: déploiements continus

**💡 quoi**: simplifier le déploiement en production

**🎯 pourquoi**: pour plus facilement communiquer le contenu de la release, avec moins d'étapes

**🤔 comment**: 

**Aujourd'hui :** 
- pour communiquer sur la release, on doit récupérer manuellement la liste des commits avant toute chose
- création du tag
- push en prod
- la CI/CD tourne

**Demain :** 
- création en draft de la release GitHub + tag 
- on peut communiquer sur le contenu de la release via la génération automatique des notes (proposée par GitHub)
- une fois la PR validée, on publie la release qui lance le déploiement


## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

