### PR TITLE
Suppression du bouton infos en desktop sur les intégrations iframe

### DIFF
--- a/static/to_compile/js/iframe.ts
+++ b/static/to_compile/js/iframe.ts
@@ -3,11 +3,14 @@ Deprecation notice : this will be deprecated as soon as the map
 will be embedded without an iframe but using a turbo-frame in a
 near future (around january 2025)
 */
-window.addEventListener("DOMContentLoaded", (event) => {
+function removeUnwantedElements() {
   const domain = new URL(document.referrer).hostname
   if (domain === 'localhost' || domain.endsWith(".ademe.fr") || domain === "quefairedemesobjets-preprod.osc-fr1.scalingo.io") {
     for (const elementToRemove of document.querySelectorAll("[data-remove-if-internal]")) {
+      console.log(elementToRemove)
       elementToRemove.remove()
     }
   }
-});
+}
+window.addEventListener("DOMContentLoaded", removeUnwantedElements);
+document.addEventListener("turbo:frame-load", removeUnwantedElements)


### PR DESCRIPTION
# Description succincte du problème résolu

https://www.notion.so/accelerateur-transition-ecologique-ademe/Carte-Supprimer-le-bouton-Infos-A-propos-au-niveau-de-la-carte-quand-dans-l-assistant-15e6523d57d7802485bcfd05eaadeb0d?pvs=4


**🗺️ contexte**: Assistant v2

**💡 quoi**: supprimer le bouton infos en desktop sur l'assistant

**🎯 pourquoi**: car on l'a fait _théoriquement_ mais c'est dysfontionnel

En effet, on supprime les éléments de la façon suivante : 
1. au load, on vérifie si on est sur un domaine connu (ademe)
2. Si on l'est, on supprime le logo et certains boutons permettant d'avoir des infos sur le projet / l'Ademe. 

Ici le bouton s'affiche toujours en desktop 

**🤔 comment**: la légende charge aujorud'hui dans une `turbo-frame`, elle n'est donc pas présente au load de `window` (le navigateur).  
Il faut donc écouter un autre événement, `turbo:frame-load` qui est déclenché dès qu'une frame charge, cf https://turbo.hotwired.dev/reference/events#turbo%3Aframe-load


## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
