### PR TITLE
⏩ [PERF] DBT: modèles unlogged / désactiver le WAL

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -32,6 +32,7 @@ clean-targets:
   - "dbt_packages"
 
 models:
+  +unlogged: true
   base:
     schema: public
     +materialized: view


### PR DESCRIPTION
# ⏩ DBT: modèles unlogged / désactiver le WAL

Carte Notion: [⏩ DBT: modèles unlogged / désactiver le WAL](https://www.notion.so/accelerateur-transition-ecologique-ademe/DBT-mod-les-unlogged-d-sactiver-le-WAL-1dc6523d57d780a8bac6cc65949ca4f5)

**🗺️ contexte**: on utilise `dbt` pour compiler de la donnée, par défault le [WAL](https://www.postgresql.org/docs/current/wal-intro.html) de postresql est activé alors qu'on en a **pas besoin pour des modèles recompilés / reconstruit de zero à chaque fois**

**💡 quoi**: rendre les modèles `unlogged`

**🎯 pourquoi**: **désactiver le WAL** et **améliorer les performances**, cf https://www.postgresql.org/docs/current/sql-createtable.html#SQL-CREATETABLE-UNLOGGED

> If specified, the table is created as an unlogged table. Data written to unlogged tables is **⏩ not written to the write-ahead log** (see [Chapter 28](https://www.postgresql.org/docs/current/wal.html)), which makes them **🚀 considerably faster** than ordinary tables. However, they are **⚠️ not crash-safe**: an unlogged table is **automatically truncated after a crash** or unclean shutdown. The contents of an unlogged table are also not replicated to standby servers. Any indexes created on an unlogged table are automatically unlogged as well. If this is specified, any sequences created together with the unlogged table (for identity or serial columns) are also created as unlogged.

=> 🟢 **dans le pire des cas** quelque chose ne se passe pas bien et dbt doit reconstuire le modèle dans son intégralité, **ce qui est déjà ce qui se passe normallement** quand on fait des builds

**🤔 comment**: option dans [dbt_project.yml](https://github.com/incubateur-ademe/quefairedemesobjets/compare/dbt_unlogged_v1?expand=1#diff-b76d20c5098ce4259769a1862be1190b990aa8d825faf222e2755f9bb90cd576)

## ✅ Reste à faire (PR en cours)

- [ ] **Comparer les performances** avant / après activation de l'option sur un full build

## 📆 A faire (prochaine PR)

- [ ] **Si un jour on implémente les modèles [incremental](https://docs.getdbt.com/docs/build/incremental-models)**: alors **désactiver le unlogged pour ses modèles** car on ne veut pas être victime d'un TRUNCATE et perdre l'ensemble de l'historique
- [ ] **Bonus**: on pourrait faire la même chose avec la table de cache Django
