### PR TITLE
🔗 Hardcoder les hostnames de l'assistant

### DIFF
--- a/static/to_compile/js/iframe.ts
+++ b/static/to_compile/js/iframe.ts
@@ -5,7 +5,7 @@ near future (around january 2025)
 */
 function removeUnwantedElements() {
   const domain = new URL(document.referrer).hostname
-  if (domain === 'localhost' || domain.endsWith(".ademe.fr") || domain === "quefairedemesobjets-preprod.osc-fr1.scalingo.io") {
+  if (domain === 'localhost' || domain.endsWith(".ademe.fr") || domain.endsWith(".ademe.dev")) {
     for (const elementToRemove of document.querySelectorAll("[data-remove-if-internal]")) {
       console.log(elementToRemove)
       elementToRemove.remove()

--- a/static/to_compile/js/iframe.ts
+++ b/static/to_compile/js/iframe.ts
@@ -7,7 +7,6 @@ function removeUnwantedElements() {
   const domain = new URL(document.referrer).hostname
   if (domain === 'localhost' || domain.endsWith(".ademe.fr") || domain.endsWith(".ademe.dev")) {
     for (const elementToRemove of document.querySelectorAll("[data-remove-if-internal]")) {
-      console.log(elementToRemove)
       elementToRemove.remove()
     }
   }


### PR DESCRIPTION
# Description succincte du problème résolu

Suit https://www.notion.so/accelerateur-transition-ecologique-ademe/Carte-Supprimer-le-bouton-Infos-A-propos-au-niveau-de-la-carte-quand-dans-l-assistant-15e6523d57d7802485bcfd05eaadeb0d?pvs=4 


**🗺️ contexte**: Assistant v2

**💡 quoi**: bien gérer les personnalisations de la carte pour l'Ademe sur la staging

**🎯 pourquoi**: 

La carte dispose de certaines personnalisations réservées aux réutilisateurs Ademe (dont on fait partie). 
Ici ce code n'est pas testable en l'état, car il hardcode les URLs, notamment un domaine de preprod qui n'est plus utilisé. 

**🤔 comment**: 

- on applique une modification sur tous les sous-domaines .ademe.dev

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code


## 📆 A faire (prochaine PR)

- [ ] Lorsqu'on gèrera les canonical URL, récupérer les domaines des canonical URLs pour définir les endroits où on personnalise la carte 
