### PR TITLE
Mise à jour de l'action GitHub de release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,6 @@ on:
   push:
     branches: [ "main" ]
 
-  pull_request:
-    types: [opened, reopened, synchronize]
-
 permissions:
   contents: read
 
@@ -15,7 +12,6 @@ jobs:
   update_release_draft:
     permissions:
       contents: write
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: 🔢 Release
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ "main" ]
 
   pull_request:
     types: [opened, reopened, synchronize]


### PR DESCRIPTION
Cf #1543 

Ajout de la branche `main` dans les cibles de l'action qui ne se déclenche pas 🤔 