### PR TITLE
 😶‍🌫️ Totalement masquer la légende en mobile

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -178,7 +178,7 @@
         "filename": "jinja2/layout/base.html",
         "hashed_secret": "057dece35d736a3ae1e710a9cba3f080bd101cde",
         "is_verified": false,
-        "line_number": 62
+        "line_number": 65
       }
     ],
     "unit_tests/qfdmo/test_views.py": [
@@ -191,5 +191,5 @@
       }
     ]
   },
-  "generated_at": "2025-04-23T10:12:59Z"
+  "generated_at": "2025-04-24T11:22:55Z"
 }

--- a/jinja2/layout/base.html
+++ b/jinja2/layout/base.html
@@ -4,7 +4,7 @@
     class="qf-scroll-smooth"
     {% if not is_carte %}data-formulaire{% endif %}
     {% if carte_config and carte_config.hide_legend %}
-    data-legend="hidden"
+    data-legend-hidden
     {% endif %}
 >
     <head>

--- a/jinja2/layout/base.html
+++ b/jinja2/layout/base.html
@@ -3,6 +3,9 @@
     lang="fr"
     class="qf-scroll-smooth"
     {% if not is_carte %}data-formulaire{% endif %}
+    {% if carte_config and carte_config.hide_legend %}
+    data-legend="hidden"
+    {% endif %}
 >
     <head>
         <meta charset="utf-8">

--- a/jinja2/qfdmo/carte/header.html
+++ b/jinja2/qfdmo/carte/header.html
@@ -14,6 +14,7 @@
 >
     {% include 'qfdmo/_addresses_partials/adresse_input_form.html' %}
 
+    {% if carte_config and not carte_config.hide_legend %}
     <div class="lg:qf-hidden fr-mt-1w qf-flex qf-justify-between">
         <button
             class="fr-btn fr-btn--sm fr-btn--tertiary"
@@ -26,7 +27,6 @@
         </button>
         <div class="qf-flex qf-flex-row-reverse">
             {% if form.legend_grouped_action|length > 1 %}
-            {% if carte_config and not carte_config.hide_legend %}
             <button
                 class="fr-btn fr-btn--sm fr-btn--secondary fr-ml-1w fr-btn--icon-left fr-icon-eye-line"
                 type="button"
@@ -35,7 +35,6 @@
             >
                 Légende
             </button>
-            {% endif %}
             {% endif %}
             <button
                 class="fr-btn fr-btn--sm fr-btn--secondary fr-ml-1w fr-btn--icon-left fr-icon-equalizer-line"
@@ -47,4 +46,5 @@
             </button>
         </div>
     </div>
+    {% endif %}
 </div>

--- a/jinja2/qfdmo/carte/header.html
+++ b/jinja2/qfdmo/carte/header.html
@@ -14,7 +14,7 @@
 >
     {% include 'qfdmo/_addresses_partials/adresse_input_form.html' %}
 
-    {% if carte_config and not carte_config.hide_legend %}
+    {% if not carte_config or not carte_config.hide_legend %}
     <div class="lg:qf-hidden fr-mt-1w qf-flex qf-justify-between">
         <button
             class="fr-btn fr-btn--sm fr-btn--tertiary"

--- a/jinja2/qfdmo/carte/panels/legend.html
+++ b/jinja2/qfdmo/carte/panels/legend.html
@@ -1,4 +1,4 @@
-{% if carte_config and not carte_config.hide_legend %}
+{% if not carte_config or not carte_config.hide_legend %}
 <aside
     data-testid="carte-legend"
     class="

--- a/static/to_compile/entrypoints/qfdmo.css
+++ b/static/to_compile/entrypoints/qfdmo.css
@@ -90,7 +90,7 @@ Style the autocomplete container:
   --header-height: 120px;
 }
 
-:root[data-legend="hidden"] {
+:root[data-legend-hidden] {
   --header-height: 0;
 }
 

--- a/static/to_compile/entrypoints/qfdmo.css
+++ b/static/to_compile/entrypoints/qfdmo.css
@@ -8,7 +8,6 @@
 @tailwind components;
 @tailwind utilities;
 
-
 pre {
   font-family: Marianne, arial, sans-serif;
   font-weight: 500;
@@ -86,12 +85,16 @@ Style the autocomplete container:
 }
 
 :root {
-    --footer-height: 0;
-    --sidebar-width: 0;
-    --header-height: 120px;
+  --footer-height: 0;
+  --sidebar-width: 0;
+  --header-height: 120px;
+}
+
+:root[data-legend="hidden"] {
+  --header-height: 0;
 }
 
 :root[data-formulaire] {
-    --footer-height: 100px;
-    --header-height: 135px;
+  --footer-height: 100px;
+  --header-height: 135px;
 }


### PR DESCRIPTION
# Description succincte du problème résolu

https://www.notion.so/accelerateur-transition-ecologique-ademe/Masquer-toute-la-l-gende-pour-Cyclevia-1dd6523d57d7802bbbd0d0a7bd52edca?pvs=4

Suit #1554 


**🗺️ contexte**: Cartes sur mesure

**💡 quoi**: En mobile on masque pas uniquement le bouton mais toutes la "légende" (boutons infos et filtres y compris)

**🎯 pourquoi**: pour coller à la demande initiale :)

**🤔 comment**: 

- On wrap plus de choses dans la conditionnelle dans le template

## Exemple résultats / UI / Data

- [ ] TODO

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
