### PR TITLE
📏 Correction d'une régression sur la hauteur de la fiche acteur sur une carte sur mesure

### DIFF
--- a/static/to_compile/entrypoints/qfdmo.css
+++ b/static/to_compile/entrypoints/qfdmo.css
@@ -91,7 +91,9 @@ Style the autocomplete container:
 }
 
 :root[data-legend-hidden] {
-  --header-height: 0;
+  @media (max-width: 768px) {
+    --header-height: 72px;
+  }
 }
 
 :root[data-formulaire] {


### PR DESCRIPTION
# Description succincte du problème résolu

Cf #1558 j'ai introduit une régression, j'avais testé uniquement en mobile ma modification. 


**🗺️ contexte**: Suit #1558 

**💡 quoi**: Correction d'une régression

**🤔 comment**: 

- récupération de la hauteur du header qu'on hardcode 
- entourage dans une media query

## Exemple résultats / UI / Data

### Avant

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/739c3043-66c8-4c9c-b169-7ff08efc693f" />


### Après

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/8040c46c-6064-48ee-91a4-29a849f3e9ff" />


## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

