### PR TITLE
🔄 [ENRICH] - DAG de rafraichissment DBT

### DIFF
--- a/dags/enrich/config/__init__.py
+++ b/dags/enrich/config/__init__.py
@@ -5,6 +5,7 @@ from .models import (  # noqa: F401
     DAG_ID_TO_CONFIG_MODEL,
     EnrichActeursClosedConfig,
     EnrichActeursRGPDConfig,
+    EnrichDbtModelsRefreshConfig,
 )
 from .tasks import TASKS  # noqa: F401
 from .xcoms import XCOMS, xcom_pull  # noqa: F401

--- a/dags/enrich/config/models.py
+++ b/dags/enrich/config/models.py
@@ -93,7 +93,15 @@ class EnrichActeursRGPDConfig(EnrichBaseConfig):
     )
 
 
+class EnrichDbtModelsRefreshConfig(BaseModel):
+    dbt_models_refresh_commands: list[str] = Field(
+        default=[],
+        description="🔄 Liste de commandes DBT à exécuter pour rafraîchir les modèles",
+    )
+
+
 DAG_ID_TO_CONFIG_MODEL = {
     "enrich_acteurs_closed": EnrichActeursClosedConfig,
     "enrich_acteurs_rgpd": EnrichActeursRGPDConfig,
+    "enrich_dbt_models_refresh": EnrichDbtModelsRefreshConfig,
 }

--- a/dags/enrich/dags/enrich_dbt_models_refresh.py
+++ b/dags/enrich/dags/enrich_dbt_models_refresh.py
@@ -1,0 +1,55 @@
+"""DAG to refresh DBT models needed for enrich DAGs"""
+
+import re
+
+from airflow import DAG
+from airflow.models.baseoperator import chain
+from airflow.operators.bash import BashOperator
+from airflow.utils.trigger_rule import TriggerRule
+from enrich.config import EnrichDbtModelsRefreshConfig
+from shared.config import CATCHUPS, SCHEDULES, START_DATES, config_to_airflow_params
+
+with DAG(
+    dag_id="enrich_dbt_models_refresh",
+    dag_display_name="🔄 Enrichir - Rafraîchir les modèles DBT",
+    default_args={
+        "owner": "airflow",
+        "depends_on_past": False,
+        "email_on_failure": False,
+        "email_on_retry": False,
+        "retries": 0,
+    },
+    description=(
+        "Un DAG pour rafraîchir les modèles DBT nécessaires"
+        "à l'enrichissement des acteurs"
+    ),
+    tags=["dbt", "models", "refresh", "enrich"],
+    schedule=SCHEDULES.DAILY,
+    catchup=CATCHUPS.AWLAYS_FALSE,
+    start_date=START_DATES.YESTERDAY,
+    params=config_to_airflow_params(
+        EnrichDbtModelsRefreshConfig(
+            dbt_models_refresh_commands=[
+                "dbt build --select +int_ae_unite_legale",
+                "dbt build --select +int_ae_etablissement",
+                "dbt build --select +int_ban_adresses",
+                "dbt build --select int_ban_villes",
+            ],
+        )
+    ),
+) as dag:
+    tasks = []
+    for cmd in dag.params.get("dbt_models_refresh_commands", []):
+        cmd = cmd.strip()
+        if not cmd:
+            continue
+        cmd_id = re.sub(r"__+", "_", re.sub(r"[^a-zA-Z0-9]+", "_", cmd))
+        cmd += " --debug --threads 1"
+        tasks.append(
+            BashOperator(
+                task_id=f"enrich_{cmd_id}",
+                bash_command=cmd,
+                trigger_rule=TriggerRule.ALL_DONE,
+            )
+        )
+    chain(*tasks)

--- a/dags/shared/config/models.py
+++ b/dags/shared/config/models.py
@@ -7,6 +7,7 @@ PYDANTIC_TYPE_TO_AIRFLOW_TYPE = {
     bool: "boolean",
     str: "string",
     typing.Optional[str]: ["null", "string"],
+    list[str]: "array",
 }
 
 
@@ -27,7 +28,7 @@ def config_to_airflow_params(model_instance: BaseModel) -> dict[str, Param]:
     model_cls = model_instance.__class__
     for field_name, field_info in model_cls.model_fields.items():
         field_value = getattr(model_instance, field_name)  # Get value from instance
-
+        assert field_info.annotation is not None
         params[field_name] = Param(
             field_value,
             type=PYDANTIC_TYPE_TO_AIRFLOW_TYPE[field_info.annotation],

--- a/dags_unit_tests/shared/config/test_shared_config_models.py
+++ b/dags_unit_tests/shared/config/test_shared_config_models.py
@@ -23,6 +23,10 @@ class MyModel(BaseModel):
         default=None,
         description="OPT STRING CHANGED",
     )
+    some_list: list[str] = Field(
+        default=["foo", "bar"],
+        description="SOME LIST",
+    )
 
 
 class TestConfigModelToAirflowParams:
@@ -44,6 +48,11 @@ class TestConfigModelToAirflowParams:
         param = params["some_string"]
         assert param.value == "foo"
         assert param.schema["type"] == "string"
+
+    def test_list(self, params):
+        param = params["some_list"]
+        assert param.value == ["foo", "bar"]
+        assert param.schema["type"] == "array"
 
     def test_opt_string_untouched(self, params):
         param = params["opt_string_untouched"]


### PR DESCRIPTION
# 🔄 [ENRICH] - DAG de rafraichissment DBT

**🗺️ contexte**: on a plusieurs DAG d'enrichissement qui se reposent sur des modèles `dbt` de **marts**, ces DAG **rafraichissent uniquement les modèles de marts** pour avoir des suggestions fraiches **🔴 mais pas les modèles sous-jacents (ex: `int_`) car ceci prendrait trop de temps**.

**💡 quoi**: un DAG pour rafraichir les modèles dbt

**🎯 pourquoi**: mettre à jours les modèles sous-jacents continuellement pour **avoir au pire 1 jour de retard au niveau des marts** quand la data ou le code des modèles < marts changent.

**🤔 comment**:
  - le DAG prend une liste de commandes DBT et les exécutent
  - 🔮 **J'ai déja spécifié les modèles à venir** pour PR https://github.com/incubateur-ademe/quefairedemesobjets/pull/1534 (pour l'instant = pas de modèle trouvé MAIS pas d'erreur, une fois PR mergée les nouveaux modèles DBT seront pris en compte automatiquement)