### PR TITLE
⚒️ BAN: fix acteur_statut manquant

### DIFF
--- a/dags/enrich/tasks/business_logic/enrich_dbt_model_read.py
+++ b/dags/enrich/tasks/business_logic/enrich_dbt_model_read.py
@@ -4,7 +4,7 @@ import logging
 
 import numpy as np
 import pandas as pd
-from utils import logging_utils as log
+from utils.dataframes import df_filter
 from utils.django import django_setup_full
 
 django_setup_full()
@@ -18,41 +18,20 @@ def enrich_dbt_model_read(
     """Reads necessary QFDMO acteurs and AE entries from DB"""
     from django.db import connection
 
+    logger.info(f"Lecture des données de {dbt_model_name}")
+
     # Execute SQL query and get data
     with connection.cursor() as cursor:
         cursor.execute(f"SELECT * FROM {dbt_model_name}")
         columns = [col[0] for col in cursor.description]
         data = cursor.fetchall()
 
-    # Create DataFrame and preview
+    # Create DF from Django data
+    logger.info("Création du DF")
     df = pd.DataFrame(data, columns=columns, dtype="object").replace({np.nan: None})
-    log.preview_df_as_markdown(f"Données de {dbt_model_name} SANS filtre", df)
 
-    # Filtering if needed
-    filter_applied = False
-    if not df.empty:
-        for filter in filters:
-
-            # Assignment & info
-            filter_applied = True
-            field = filter["field"]
-            operator = filter["operator"]
-            value = filter["value"]
-            logger.info(f"\n🔽 Filtre sur {field=} {operator=} {value=}")
-            logger.info(f"Avant filtre : {df.shape[0]} lignes")
-
-            # Filtering
-            if filter["operator"] == "equals":
-                logger.info(f"Filtre sur {field} EQUALS {value}")
-                df = df[df[field] == value].copy()
-            elif filter["operator"] == "contains":
-                df = df[df[field].str.contains(value, regex=True, case=False)].copy()
-            else:
-                raise NotImplementedError(f"{filter['operator']=} non implémenté")
-
-            logger.info(f"Après filtre : {df.shape[0]} lignes")
-
-    if filter_applied:
-        log.preview_df_as_markdown(f"Données de {dbt_model_name} APRES filtre(s)", df)
+    # Filtering
+    logger.info("Filtre sur les données")
+    df = df_filter(df, filters)
 
     return df

--- a/dags/utils/dataframes.py
+++ b/dags/utils/dataframes.py
@@ -9,6 +9,39 @@ from utils import logging_utils as log
 logger = logging.getLogger(__name__)
 
 
+def df_filter(df: pd.DataFrame, filters: list[dict]) -> pd.DataFrame:
+    """Filters a dataframe given some filters"""
+    log.preview_df_as_markdown("Données SANS filtre", df)
+    log.preview("Filtres", filters)
+    filter_applied = False
+    if not df.empty:
+        for filter in filters:
+            filter_applied = True
+            field = filter["field"]
+            operator = filter["operator"]
+            value = filter["value"]
+            logger.info(f"\n🔽 Filtre sur {field=} {operator=} {value=}")
+            logger.info(f"Avant filtre : {df.shape[0]} lignes")
+
+            # Filtering
+            if filter["operator"] == "equals":
+                logger.info(f"Filtre sur {field} EQUALS {value}")
+                df = df[df[field] == value].copy()
+            elif filter["operator"] == "contains":
+                df = df[df[field].str.contains(value, regex=True, case=False)].copy()
+            else:
+                raise NotImplementedError(f"{filter['operator']=} non implémenté")
+
+            logger.info(f"Après filtre : {df.shape[0]} lignes")
+
+    if filter_applied:
+        log.preview_df_as_markdown("Données APRES filtre(s)", df)
+    else:
+        logger.info("Aucun filtre appliqué")
+
+    return df
+
+
 def df_sort(
     df: pd.DataFrame, sort_rows: list[str] = [], sort_cols: list[str] = []
 ) -> pd.DataFrame:

--- a/dags_unit_tests/enrich/tasks/test_enrich_suggestions_cities.py
+++ b/dags_unit_tests/enrich/tasks/test_enrich_suggestions_cities.py
@@ -21,6 +21,7 @@ class TestEnrichSuggestionsCities:
     def df_new(self):
         return pd.DataFrame(
             {
+                # last entry is INACTIF to test acteur status filter
                 COLS.SUGGEST_COHORT: [COHORTS.VILLES_NEW] * 3,
                 COLS.SUGGEST_VILLE: ["new town 1", "new town 2", "closed"],
                 COLS.ACTEUR_ID: ["new1", "new2", "closed 1"],
@@ -33,6 +34,7 @@ class TestEnrichSuggestionsCities:
     def df_typo(self):
         return pd.DataFrame(
             {
+                # last entry is INACTIF to test acteur status filter
                 COLS.SUGGEST_COHORT: [COHORTS.VILLES_TYPO] * 3,
                 COLS.SUGGEST_VILLE: ["Paris", "Laval", "closed"],
                 COLS.ACTEUR_ID: ["typo1", "typo2", "closed 2"],
@@ -43,10 +45,12 @@ class TestEnrichSuggestionsCities:
 
     @pytest.fixture
     def df_new_filtered(self, df_new, config):
+        # To test that config works (e.g. filter_equals__acteur_statut)
         return df_filter(df_new, config.filters)
 
     @pytest.fixture
     def df_typo_filtered(self, df_typo, config):
+        # To test that config works (e.g. filter_equals__acteur_statut)
         return df_filter(df_typo, config.filters)
 
     @pytest.fixture

--- a/dbt/models/marts/enrich/marts_enrich_acteurs_villes_candidates.sql
+++ b/dbt/models/marts/enrich/marts_enrich_acteurs_villes_candidates.sql
@@ -9,6 +9,7 @@ SELECT
   acteurs.identifiant_unique AS acteur_id,
   acteurs.ville AS acteur_ville,
   acteurs.code_postal AS acteur_code_postal,
+  acteurs.statut AS acteur_statut,
   ban.ville_ancienne AS ban_ville_ancienne,
   ban.ville AS ban_ville,
   ban.code_postal AS ban_code_postal,


### PR DESCRIPTION
# ⚒️ BAN: fix acteur_statut manquant

**🗺️ contexte**: je teste les DAGs en PREPROD

**💡 quoi**: bug fix

**🎯 pourquoi**: le champ `acteur_statut` est manquant sur les modèles de suggestions BAN

**🤔 comment**:
 - **df_filter**: nouvelle fonction pour pouvoir l'utiliser dans les tests
 - **tests** améliorés

## 📆 A faire (prochaine PR)

- [ ] **Tests unitaires cross-modèles pour dbt**: rajouter des tests unitaires du genre "tous les modèles de suggestions doivent contenir le champ `acteur_statut`", on peut le faire via:
   - en utilisant les [DBT artifacts](https://docs.getdbt.com/reference/artifacts/dbt-artifacts) post-dbt-build via Python
   - en utilisant **[on-run-end](https://docs.getdbt.com/reference/project-configs/on-run-start-on-run-end) + des macros** via le [graph](https://docs.getdbt.com/reference/dbt-jinja-functions/graph#accessing-models)
