### PR TITLE
Permettre de décocher la case d'un groupe d'action + afficher la légende en mobile

### DIFF
--- a/jinja2/qfdmo/carte/panels/legend_mobile.html
+++ b/jinja2/qfdmo/carte/panels/legend_mobile.html
@@ -1,5 +1,5 @@
 {# Panel «Légende» affiché uniquement en mobile #}
-{% if not carte_config and not carte_config.hide_legend %}
+{% if not carte_config or not carte_config.hide_legend %}
 <div class='fr-container qf-px-0 qf-absolute qf-inset-0 qf-font-black qf-z-[10010] qf-flex qf-flex-col qf-hidden'
      data-search-solution-form-target="legendMainPanel"
     data-testid="carte-legend-mobile"

--- a/jinja2/qfdmo/carte/panels/legend_mobile.html
+++ b/jinja2/qfdmo/carte/panels/legend_mobile.html
@@ -1,5 +1,5 @@
 {# Panel «Légende» affiché uniquement en mobile #}
-{% if carte_config and not carte_config.hide_legend %}
+{% if not carte_config and not carte_config.hide_legend %}
 <div class='fr-container qf-px-0 qf-absolute qf-inset-0 qf-font-black qf-z-[10010] qf-flex qf-flex-col qf-hidden'
      data-search-solution-form-target="legendMainPanel"
     data-testid="carte-legend-mobile"

--- a/qfdmo/views/adresses.py
+++ b/qfdmo/views/adresses.py
@@ -322,14 +322,15 @@ class SearchActeursView(
         """
         Get the action to include in the request
         """
+        # FIXME : est-ce possible d'optimiser en accédant au valeur initial du form ?
+
         # selection from interface
-        selected_user_actions = self.get_data_from_request_or_bounded_form(
-            "grouped_action"
-        ) or self.get_data_from_request_or_bounded_form("legend_grouped_action")
-        if selected_user_actions:
+        if self.get_data_from_request_or_bounded_form("grouped_action"):
             return [
                 code
-                for new_groupe_action in selected_user_actions
+                for new_groupe_action in self.get_data_from_request_or_bounded_form(
+                    "grouped_action"
+                )
                 for code in new_groupe_action.split("|")
             ]
         # Selection is not set in interface, get all available from
@@ -354,13 +355,10 @@ class SearchActeursView(
 
         codes = []
         # selection from interface
-        selected_user_actions = self.request.GET.getlist(
-            "grouped_action"
-        ) or self.request.GET.getlist("legend_grouped_action")
-        if selected_user_actions:
+        if self.request.GET.get("grouped_action"):
             codes = [
                 code
-                for new_groupe_action in selected_user_actions
+                for new_groupe_action in self.request.GET.getlist("grouped_action")
                 for code in new_groupe_action.split("|")
             ]
         # Selection is not set in interface, get all available from
@@ -692,9 +690,9 @@ def acteur_detail(request, uuid):
     if latitude and longitude and not displayed_acteur.is_digital:
         context.update(
             itineraire_url="https://www.google.com/maps/dir/?api=1&origin="
-            f"{latitude},{longitude}"
-            f"&destination={displayed_acteur.latitude},"
-            f"{displayed_acteur.longitude}&travelMode=WALKING"
+            f"{latitude},{ longitude }"
+            f"&destination={ displayed_acteur.latitude },"
+            f"{ displayed_acteur.longitude }&travelMode=WALKING"
         )
 
     return render(request, "qfdmo/acteur.html", context)

--- a/qfdmo/views/adresses.py
+++ b/qfdmo/views/adresses.py
@@ -322,15 +322,14 @@ class SearchActeursView(
         """
         Get the action to include in the request
         """
-        # FIXME : est-ce possible d'optimiser en accédant au valeur initial du form ?
-
         # selection from interface
-        if self.get_data_from_request_or_bounded_form("grouped_action"):
+        selected_user_actions = self.get_data_from_request_or_bounded_form(
+            "grouped_action"
+        ) or self.get_data_from_request_or_bounded_form("legend_grouped_action")
+        if selected_user_actions:
             return [
                 code
-                for new_groupe_action in self.get_data_from_request_or_bounded_form(
-                    "grouped_action"
-                )
+                for new_groupe_action in selected_user_actions
                 for code in new_groupe_action.split("|")
             ]
         # Selection is not set in interface, get all available from
@@ -355,10 +354,13 @@ class SearchActeursView(
 
         codes = []
         # selection from interface
-        if self.request.GET.get("grouped_action"):
+        selected_user_actions = self.request.GET.getlist(
+            "grouped_action"
+        ) or self.request.GET.getlist("legend_grouped_action")
+        if selected_user_actions:
             codes = [
                 code
-                for new_groupe_action in self.request.GET.getlist("grouped_action")
+                for new_groupe_action in selected_user_actions
                 for code in new_groupe_action.split("|")
             ]
         # Selection is not set in interface, get all available from
@@ -690,9 +692,9 @@ def acteur_detail(request, uuid):
     if latitude and longitude and not displayed_acteur.is_digital:
         context.update(
             itineraire_url="https://www.google.com/maps/dir/?api=1&origin="
-            f"{latitude},{ longitude }"
-            f"&destination={ displayed_acteur.latitude },"
-            f"{ displayed_acteur.longitude }&travelMode=WALKING"
+            f"{latitude},{longitude}"
+            f"&destination={displayed_acteur.latitude},"
+            f"{displayed_acteur.longitude}&travelMode=WALKING"
         )
 
     return render(request, "qfdmo/acteur.html", context)


### PR DESCRIPTION
**🗺️ contexte**: Ajout de carte sur mesure pour un éco organisme

**💡 quoi**: Correction de plusieurs régression suite à #1464 

**🎯 pourquoi**: pour mettre en prod pardi !

Le HTML de légende mobile n'était pas rendu dans le DOM, et c'est celle ci qui hydrate le formulaire côté python  lors de la soumission d'une adresse. 

Comme on hydrate pas le formulaire, on ne tient pas compte des cases cochées / décochées 

Cela venait d'une logique mal implémentée qui masquait le html de la légende en mobile. 

**🤔 comment**: 

J'ai adapté la logique 🤯 
- si pas de carte config
- OU si pas de carte_config.hide_legend #1023 

ALORS on masque la légende 


## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
