### PR TITLE
SOREN et OpeningHours : interpreter les opening_hours

### DIFF
--- a/dags/sources/config/airflow_params.py
+++ b/dags/sources/config/airflow_params.py
@@ -7,6 +7,7 @@ from sources.tasks.transform.transform_column import (
     clean_acteur_type_code,
     clean_code_list,
     clean_code_postal,
+    clean_horaires_osm,
     clean_public_accueilli,
     clean_reprise,
     clean_siren,
@@ -33,6 +34,7 @@ from sources.tasks.transform.transform_df import (
     merge_and_clean_sous_categorie_codes,
     merge_sous_categories_columns,
 )
+
 from utils.django import django_setup_full
 
 PATH_NOMENCLARURE_DECHET = (
@@ -48,6 +50,7 @@ TRANSFORM_COLUMN_MAPPING = {
     "clean_acteur_type_code": clean_acteur_type_code,
     "clean_code_list": clean_code_list,
     "clean_code_postal": clean_code_postal,
+    "clean_horaires_osm": clean_horaires_osm,
     "clean_public_accueilli": clean_public_accueilli,
     "clean_reprise": clean_reprise,
     "clean_siren": clean_siren,

--- a/dags/sources/dags/source_soren.py
+++ b/dags/sources/dags/source_soren.py
@@ -52,6 +52,11 @@ with DAG(
             },
             {
                 "origin": "horaires_douverture",
+                "transformation": "clean_horaires_osm",
+                "destination": "horaires_osm",
+            },
+            {
+                "origin": "horaires_osm",
                 "transformation": "convert_opening_hours",
                 "destination": "horaires_description",
             },

--- a/dags/sources/tasks/business_logic/source_data_normalize.py
+++ b/dags/sources/tasks/business_logic/source_data_normalize.py
@@ -17,6 +17,7 @@ from sources.tasks.airflow_logic.config_management import (
 from sources.tasks.transform.transform_df import compute_location, merge_duplicates
 from sqlalchemy import text
 from tenacity import retry, stop_after_attempt, wait_fixed
+
 from utils import logging_utils as log
 
 logger = logging.getLogger(__name__)
@@ -73,7 +74,7 @@ def _transform_columns(df: pd.DataFrame, dag_config: DAGConfig) -> pd.DataFrame:
         df[column_to_transform.destination] = df[column_to_transform.origin].apply(
             normalisation_function
         )
-        if column_to_transform.destination != column_to_transform.origin:
+        if column_to_transform.origin not in dag_config.get_expected_columns():
             df.drop(columns=[column_to_transform.origin], inplace=True)
     return df
 

--- a/dags/sources/tasks/transform/opening_hours.py
+++ b/dags/sources/tasks/transform/opening_hours.py
@@ -1,0 +1,106 @@
+from datetime import time
+from typing import Any, Dict, List, Tuple
+
+from opening_hours import OpeningHours
+
+OPENED_24_7 = {
+    "Mo": [(time(0, 0), time(23, 59))],
+    "Tu": [(time(0, 0), time(23, 59))],
+    "We": [(time(0, 0), time(23, 59))],
+    "Th": [(time(0, 0), time(23, 59))],
+    "Fr": [(time(0, 0), time(23, 59))],
+    "Sa": [(time(0, 0), time(23, 59))],
+    "Su": [(time(0, 0), time(23, 59))],
+}
+
+DAYS_OF_WEEK = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]
+
+
+def merge_consecutive_tuples(tuples: list[tuple[Any, Any]]) -> list[tuple[Any, Any]]:
+    result = []
+    if tuples:
+        current_start, current_end = tuples[0]
+        for next_start, next_end in tuples[1:]:
+            if current_end == next_start:
+                current_end = next_end
+            else:
+                result.append((current_start, current_end))
+                current_start, current_end = next_start, next_end
+        result.append((current_start, current_end))
+    return result
+
+
+def split_and_clean(value: str) -> List[str]:
+    """
+    Divise une chaîne par ', ' ou '; ' et nettoie chaque valeur.
+    """
+    parts = []
+    for part in value.split("; "):
+        parts.extend(part.split(", "))
+    return [part.strip() for part in parts if part.strip()]
+
+
+def interprete_opening_hours(opening_hours: str | None):
+    """
+    Interprete les heures d'ouverture d'un lieu.
+    """
+
+    if not opening_hours:
+        return {}
+
+    opening_hours_normalized = str(OpeningHours(opening_hours).normalize())
+
+    if opening_hours_normalized == "24/7":
+        return OPENED_24_7
+
+    opening_hours_by_day_of_week: Dict[str, List[Tuple[time, time]]] = {
+        day: [] for day in DAYS_OF_WEEK
+    }
+
+    def get_opening_hours(hours: str):
+        hours_list = hours.split(",")
+        result_hours = []
+        for hour in hours_list:
+            open, close = hour.split("-")
+            open_hour, open_minute = map(int, open.split(":"))
+            close_hour, close_minute = map(int, close.split(":"))
+            result_hours.append(
+                (time(open_hour, open_minute), time(close_hour, close_minute))
+            )
+        return result_hours
+
+    def get_opening_days(days: str):
+        days_list = days.split(",")
+        result_days = []
+        for ds in days_list:
+            d = ds.split("-")
+            if len(d) == 2:
+                start_day, end_day = d
+                start_day_index = DAYS_OF_WEEK.index(start_day)
+                end_day_index = DAYS_OF_WEEK.index(end_day)
+                result_days.extend(DAYS_OF_WEEK[start_day_index : end_day_index + 1])
+            else:
+                result_days.extend(d)
+        return result_days
+
+    opening_hours_blocks = split_and_clean(opening_hours_normalized)
+    for opening_hours_block in opening_hours_blocks:
+        opening_hours_block_parts = opening_hours_block.split(" ")
+        if len(opening_hours_block_parts) == 1:
+            # only hours, for all days
+            days = DAYS_OF_WEEK
+            hours = get_opening_hours(opening_hours_block_parts[0])
+        elif len(opening_hours_block_parts) == 2:
+            # days and hours
+            days = get_opening_days(opening_hours_block_parts[0])
+            hours = get_opening_hours(opening_hours_block_parts[1])
+        else:
+            raise ValueError(f"Invalid interval: {opening_hours_block}")
+
+        for day in days:
+            opening_hours_by_day_of_week[day].extend(hours)
+
+    for day, hours in opening_hours_by_day_of_week.items():
+        opening_hours_by_day_of_week[day] = merge_consecutive_tuples(hours)
+
+    return opening_hours_by_day_of_week

--- a/dags/sources/tasks/transform/transform_column.py
+++ b/dags/sources/tasks/transform/transform_column.py
@@ -3,6 +3,7 @@ import re
 from typing import Any
 
 import pandas as pd
+from opening_hours import OpeningHours, ParserError
 from sources.config import shared_constants as constants
 from sources.tasks.airflow_logic.config_management import DAGConfig
 from sources.tasks.transform.opening_hours import interprete_opening_hours
@@ -172,7 +173,13 @@ def clean_horaires_osm(horaires_osm: str | None, _) -> str:
         return ""
     # sometimes, hours are writen HHhMM instead of HH:MM
     # replace h using regex
-    return re.sub(r"(\d{2})h(\d{2})", r"\1:\2", horaires_osm)
+    horaires_osm = re.sub(r"(\d{2})h(\d{2})", r"\1:\2", horaires_osm)
+    try:
+        OpeningHours(horaires_osm)
+    except ParserError as e:
+        logger.warning(f"Error parsing opening hours: {e}")
+        return ""
+    return horaires_osm
 
 
 def clean_code_list(codes: str | None, _) -> list[str]:

--- a/dags/sources/tasks/transform/transform_column.py
+++ b/dags/sources/tasks/transform/transform_column.py
@@ -5,9 +5,13 @@ from typing import Any
 import pandas as pd
 from sources.config import shared_constants as constants
 from sources.tasks.airflow_logic.config_management import DAGConfig
+from sources.tasks.transform.opening_hours import interprete_opening_hours
+
 from utils.formatter import format_libelle_to_code
 
 logger = logging.getLogger(__name__)
+
+CLOSED_THIS_DAY = "Fermé"
 
 
 def cast_eo_boolean_or_string_to_boolean(value: str | bool, _) -> bool:
@@ -19,7 +23,10 @@ def cast_eo_boolean_or_string_to_boolean(value: str | bool, _) -> bool:
 
 
 def convert_opening_hours(opening_hours: str | None, _) -> str:
-    french_days = {
+    opening_hours_by_day_of_week = interprete_opening_hours(opening_hours)
+    displayed_opening_hours = []
+
+    days = {
         "Mo": "lundi",
         "Tu": "mardi",
         "We": "mercredi",
@@ -28,28 +35,22 @@ def convert_opening_hours(opening_hours: str | None, _) -> str:
         "Sa": "samedi",
         "Su": "dimanche",
     }
+    for day, hours in opening_hours_by_day_of_week.items():
+        displayed_opening_hours_day = f"{days[day]}: "
+        displayed_opening_hours_hours = []
 
-    def translate_hour(hour):
-        return hour.replace(":", "h").zfill(5)
+        if hours:
+            for hour in hours:
+                displayed_opening_hours_hours.append(
+                    f"{hour[0].strftime('%H:%M')} - {hour[1].strftime('%H:%M')}"
+                )
+            displayed_opening_hours_day += "; ".join(displayed_opening_hours_hours)
+        else:
+            displayed_opening_hours_day += CLOSED_THIS_DAY
 
-    def process_schedule(schedule):
-        parts = schedule.split(",")
-        translated = []
-        for part in parts:
-            start, end = part.split("-")
-            translated.append(f"de {translate_hour(start)} à {translate_hour(end)}")
-        return " et ".join(translated)
+        displayed_opening_hours.append(displayed_opening_hours_day)
 
-    def process_entry(entry):
-        days, hours = entry.split(" ")
-        day_range = " au ".join(french_days[day] for day in days.split("-"))
-        hours_translated = process_schedule(hours)
-        return f"du {day_range} {hours_translated}"
-
-    if pd.isna(opening_hours) or not opening_hours:
-        return ""
-
-    return process_entry(opening_hours)
+    return "\n".join(displayed_opening_hours)
 
 
 def clean_siren(siren: int | str | None) -> str:
@@ -164,6 +165,14 @@ def clean_code_postal(cp: str | None, _) -> str:
         return ""
     # cast en str et ajout de 0 si le code postal est inférieur à 10000
     return f"0{cp}" if cp and len(str(cp)) == 4 else str(cp)
+
+
+def clean_horaires_osm(horaires_osm: str | None, _) -> str:
+    if not horaires_osm:
+        return ""
+    # sometimes, hours are writen HHhMM instead of HH:MM
+    # replace h using regex
+    return re.sub(r"(\d{2})h(\d{2})", r"\1:\2", horaires_osm)
 
 
 def clean_code_list(codes: str | None, _) -> list[str]:

--- a/dags_unit_tests/sources/tasks/transform/test_transform_column.py
+++ b/dags_unit_tests/sources/tasks/transform/test_transform_column.py
@@ -55,23 +55,68 @@ class TestConvertOpeningHours:
             # chaine vide ou Nulle
             ("", ""),
             (None, ""),
-            (pd.NA, ""),
-            (np.nan, ""),
             # chaines valides
-            ("Mo-Fr 09:00-16:00", "du lundi au vendredi de 09h00 à 16h00"),
+            (
+                "Mo-Fr 09:00-16:00",
+                """lundi: 09:00 - 16:00
+mardi: 09:00 - 16:00
+mercredi: 09:00 - 16:00
+jeudi: 09:00 - 16:00
+vendredi: 09:00 - 16:00
+samedi: Fermé
+dimanche: Fermé""",
+            ),
             (
                 "Mo-Fr 09:00-12:00,14:00-17:00",
-                "du lundi au vendredi de 09h00 à 12h00 et de 14h00 à 17h00",
+                """lundi: 09:00 - 12:00; 14:00 - 17:00
+mardi: 09:00 - 12:00; 14:00 - 17:00
+mercredi: 09:00 - 12:00; 14:00 - 17:00
+jeudi: 09:00 - 12:00; 14:00 - 17:00
+vendredi: 09:00 - 12:00; 14:00 - 17:00
+samedi: Fermé
+dimanche: Fermé""",
             ),
-            # TODO : à implémenter
-            # (
-            #     "Mo,Fr 09:00-12:00,15:00-17:00",
-            #     "le lundi et le vendredi de 09h00 à 12h00 et de 15h00 à 17h00"
-            # ),
-            # (
-            #     "Mo,Tu,We 09:00-12:00",
-            #     "le lundi, mardi et le mercredi de 09h00 à 12h00"
-            # ),
+            (
+                "Mo,Fr 09:00-12:00,15:00-17:00",
+                """lundi: 09:00 - 12:00; 15:00 - 17:00
+mardi: Fermé
+mercredi: Fermé
+jeudi: Fermé
+vendredi: 09:00 - 12:00; 15:00 - 17:00
+samedi: Fermé
+dimanche: Fermé""",
+            ),
+            (
+                "Mo,Tu,We 09:00-12:00",
+                """lundi: 09:00 - 12:00
+mardi: 09:00 - 12:00
+mercredi: 09:00 - 12:00
+jeudi: Fermé
+vendredi: Fermé
+samedi: Fermé
+dimanche: Fermé""",
+            ),
+            (
+                "24/7",
+                """lundi: 00:00 - 23:59
+mardi: 00:00 - 23:59
+mercredi: 00:00 - 23:59
+jeudi: 00:00 - 23:59
+vendredi: 00:00 - 23:59
+samedi: 00:00 - 23:59
+dimanche: 00:00 - 23:59""",
+            ),
+            (
+                "Mo 10:00-12:00,12:30-15:00; Tu-Fr 08:00-12:00,12:30-15:00;"
+                " Sa 08:00-12:00",
+                """lundi: 10:00 - 12:00; 12:30 - 15:00
+mardi: 08:00 - 12:00; 12:30 - 15:00
+mercredi: 08:00 - 12:00; 12:30 - 15:00
+jeudi: 08:00 - 12:00; 12:30 - 15:00
+vendredi: 08:00 - 12:00; 12:30 - 15:00
+samedi: 08:00 - 12:00
+dimanche: Fermé""",
+            ),
         ],
     )
     def test_convert_opening_hours(self, input_value, expected_output):

--- a/dags_unit_tests/sources/tasks/transform/test_transform_column.py
+++ b/dags_unit_tests/sources/tasks/transform/test_transform_column.py
@@ -6,6 +6,7 @@ from sources.tasks.transform.transform_column import (
     clean_acteur_type_code,
     clean_code_list,
     clean_code_postal,
+    clean_horaires_osm,
     clean_number,
     clean_public_accueilli,
     clean_reprise,
@@ -336,6 +337,24 @@ class TestCleanCodePostal:
     )
     def test_clean_code_postal(self, cp, expected_cp):
         assert clean_code_postal(cp, None) == expected_cp
+
+
+class TestCleanHorairesOsm:
+    @pytest.mark.parametrize(
+        "horaires_osm, expected_horaires_osm",
+        [
+            ("", ""),
+            ("12h30-15h30", "12:30-15:30"),
+            ("Mo-Fr 12h30-15h30,16h30-18h30", "Mo-Fr 12:30-15:30,16:30-18:30"),
+            (
+                "Mo-Fr 12h30-15h30,16h30-18h30 ; We 12h30-15h30",
+                "Mo-Fr 12:30-15:30,16:30-18:30 ; We 12:30-15:30",
+            ),
+            ("fake", ""),
+        ],
+    )
+    def test_clean_horaires_osm(self, horaires_osm, expected_horaires_osm):
+        assert clean_horaires_osm(horaires_osm, None) == expected_horaires_osm
 
 
 class TestCleanSousCategorieCodes:

--- a/jinja2/qfdmo/acteur/tabs/sections/horaires.html
+++ b/jinja2/qfdmo/acteur/tabs/sections/horaires.html
@@ -16,6 +16,6 @@ Horaires
         {% include "qfdmo/acteur/tabs/_separator.html" %}
     {% endif %}
 
-    {{ object.horaires_description|safe }}
+    {{ object.horaires_description|replace("\n", "<br>")|safe }}
 </div>
 {% endblock content %}


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [SOREN](https://www.notion.so/accelerateur-transition-ecologique-ademe/Importer-le-fichier-Soren-v8-14-04-25-1bb6523d57d780e0af01dcae7cbd1a18?pvs=4)


**🗺️ contexte**: Airflow - Source

**💡 quoi**: Les horaires sous forme opening_hours de OSM ne sont pas bien interprété

**🎯 pourquoi**: Nouveau cas de SOREN : il y a maintenant plusieurs plages horaires

**🤔 comment**: 

Implémentation correct de l'interprétation des opening_hours de OSM
transformation en horaires par jour
implémentation dans le DAG Soren

## Exemple résultats / UI / Data

![CleanShot 2025-04-29 at 12 45 47@2x](https://github.com/user-attachments/assets/38f8c64a-2ec4-4449-94cf-52c12305e3ea)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] ajout du control du format OpeningHours dans `clean_horaires_osm`
- [ ] test `clean_horaires_osm`

## 📆 A faire (prochaine PR)

- [ ] Créer une librairie pour la transformation en horaire par jour ?
