### PR TITLE
Correction du libelle dans les groupes d'action affichées dans la carte de l'assistant

### DIFF
--- a/qfdmd/models.py
+++ b/qfdmd/models.py
@@ -134,7 +134,7 @@ class Produit(index.Indexed, AbstractBaseProduit):
 
     @cached_property
     def url_carte_bon_etat(self):
-        actions = "preter|emprunter|louer|mettreenlocation|donner|echanger|revendre"
+        actions = "preter|louer|mettreenlocation|donner|echanger|revendre"
         return self.get_url_carte(actions)
 
     @cached_property

--- a/qfdmo/models/action.py
+++ b/qfdmo/models/action.py
@@ -136,9 +136,12 @@ class GroupeAction(CodeAsNaturalKeyModel):
         help_text="Icône du badge à choisir dans le <a href='https://www.systeme-de-design.gouv.fr/elements-d-interface/fondamentaux-techniques/icones' rel='noopener' target='_blank'>DSFR</a>",  # noqa E501
     )
 
+    def get_libelle_from(self, actions):
+        return ", ".join({a.libelle_groupe for a in actions}).capitalize()
+
     @property
     def libelle(self):
-        return ", ".join({a.libelle_groupe for a in self.actions.all()}).capitalize()
+        return self.get_libelle_from(self.actions.all())
 
 
 class Action(CodeAsNaturalKeyModel):

--- a/qfdmo/views/adresses.py
+++ b/qfdmo/views/adresses.py
@@ -501,7 +501,11 @@ class SearchActeursView(
             libelle = ""
             if groupe.icon:
                 libelle = render_to_string(
-                    "forms/widgets/groupe_action_label.html", {"groupe_action": groupe}
+                    "forms/widgets/groupe_action_label.html",
+                    {
+                        "groupe_action": groupe,
+                        "libelle": groupe.get_libelle_from(groupe_displayed_actions),
+                    },
                 )
 
             code = "|".join([a.code for a in groupe_displayed_actions])
@@ -690,9 +694,9 @@ def acteur_detail(request, uuid):
     if latitude and longitude and not displayed_acteur.is_digital:
         context.update(
             itineraire_url="https://www.google.com/maps/dir/?api=1&origin="
-            f"{latitude},{ longitude }"
-            f"&destination={ displayed_acteur.latitude },"
-            f"{ displayed_acteur.longitude }&travelMode=WALKING"
+            f"{latitude},{longitude}"
+            f"&destination={displayed_acteur.latitude},"
+            f"{displayed_acteur.longitude}&travelMode=WALKING"
         )
 
     return render(request, "qfdmo/acteur.html", context)

--- a/templates/forms/widgets/groupe_action_label.html
+++ b/templates/forms/widgets/groupe_action_label.html
@@ -6,5 +6,9 @@
         {% else %}qf-text-{{ groupe_action.primary }} qf-bg-white{% endif %}
         qf-border-{{ groupe_action.primary }} qf-border-2 qf-border-solid"
         aria-hidden="true"></span>
+        {% if libelle %}
+        {{ libelle }}
+        {% else %}
         {{ groupe_action.libelle }}
+        {% endif %}
 </p>


### PR DESCRIPTION
# Description succincte du problème résolu

Régression suite à #1464 

**🗺️ contexte**: carte sur mesure

**💡 quoi**: les actions affichées ne respectent pas la configuration souhaitée

**🎯 pourquoi**:

- Dans les carte sur mesure, on affiche la légende en réutilisant un composant utilisant les formulaires django plutôt que réimplémenter la logique manuellement
- Cependant, ce n'est pas 100% possible car le champ ChoiceField utilisé tient compte du contexte pour afficher les libelle


**🤔 comment**: 

- Ici je propose de permettre d'overrider la variable rendue par le template dans ce cas précis, afin de garder de la flexibilité

## Exemple résultats / UI / Data

<img width="1159" alt="image" src="https://github.com/user-attachments/assets/f5d07142-695f-4e39-b451-680ea41dc9e6" />


## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
