### PR TITLE
Correction des tests e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
           cp .env.template .env
           echo LVAO_BASE_URL=http://localhost:8000 >> .env
           echo ASSISTANT_BASE_URL=http://127.0.0.1:8000 >> .env
-          echo ASSISTANT_HOSTS=127.0.0.1 >> .env
+          echo ASSISTANT_HOSTS=127.0.0.1:8000 >> .env
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,7 @@ jobs:
   e2e:
     name: tests de bout-en-bout
     runs-on: ubuntu-latest
-    # if: ${{ github.ref_name == 'main' || (github.event_name ==  'pull_request' && contains( github.event.pull_request.labels.*.name, 'frontend')) }}
-    if: ${{ (github.event_name ==  'pull_request' && contains( github.event.pull_request.labels.*.name, 'frontend')) }}
+    if: ${{ github.ref_name == 'main' || (github.event_name ==  'pull_request' && contains( github.event.pull_request.labels.*.name, 'frontend')) }}
     strategy:
       matrix:
         shard: [1/5, 2/5, 3/5, 4/5, 5/5]

--- a/e2e_tests/accessibility.spec.ts
+++ b/e2e_tests/accessibility.spec.ts
@@ -29,9 +29,9 @@ test.describe("WCAG Compliance Tests", () => {
     expect(accessibilityScanResults.violations).toEqual([]);
   });
 
-  test("Assistant Homepage | Desktop", async ({ page }) => {
+  test("Assistant Homepage | Desktop", async ({ page,assistantUrl }) => {
     // TODO: Update the route for production
-    await page.goto(`/`, { waitUntil: "networkidle" });
+    await page.goto(`${assistantUrl}/`, { waitUntil: "networkidle" });
 
     const accessibilityScanResults = await new AxeBuilder({ page })
       .exclude("[data-disable-axe]")


### PR DESCRIPTION
# Description succincte du problème résolu

Depuis #1540, les tests e2e se lance avec la carte au lieu de l'assistant pour les tests d'accessibilité. 

**🗺️ contexte**: CI/CD

**💡 quoi**: correction d'une regression qui empêche de lancer les tests e2e

**🎯 pourquoi**: car l'environnement défini dans la github action était mal fait :) 


## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
