### PR TITLE
Gestion des retour à la ligne de la descriptiion : solution temporaire

### DIFF
--- a/core/jinja2_handler.py
+++ b/core/jinja2_handler.py
@@ -4,8 +4,8 @@ from django.conf import settings
 from django.http import HttpRequest
 from django.templatetags.static import static
 from django.urls import reverse
+from django.utils.html import linebreaks
 
-from core.templatetags.custom_filters import nl2br
 from core.templatetags.seo_tags import get_sharer_content
 from core.utils import get_direction
 from jinja2 import Environment
@@ -78,5 +78,5 @@ def environment(**options):
             ),
         }
     )
-    env.filters.update({"nl2br": nl2br})
+    env.filters.update({"linebreaks": linebreaks})
     return env

--- a/core/jinja2_handler.py
+++ b/core/jinja2_handler.py
@@ -5,6 +5,7 @@ from django.http import HttpRequest
 from django.templatetags.static import static
 from django.urls import reverse
 
+from core.templatetags.custom_filters import nl2br
 from core.templatetags.seo_tags import get_sharer_content
 from core.utils import get_direction
 from jinja2 import Environment
@@ -77,4 +78,5 @@ def environment(**options):
             ),
         }
     )
+    env.filters.update({"nl2br": nl2br})
     return env

--- a/core/templatetags/custom_filters.py
+++ b/core/templatetags/custom_filters.py
@@ -27,3 +27,10 @@ def valuetype(value):
 @register.filter(name="quote")
 def quote_filter(value):
     return quote(value)
+
+
+@register.filter(name="nl2br")
+def nl2br(value):
+    if value is None:
+        return ""
+    return mark_safe(value.replace("\n", "<br>"))

--- a/core/templatetags/custom_filters.py
+++ b/core/templatetags/custom_filters.py
@@ -27,10 +27,3 @@ def valuetype(value):
 @register.filter(name="quote")
 def quote_filter(value):
     return quote(value)
-
-
-@register.filter(name="nl2br")
-def nl2br(value):
-    if value is None:
-        return ""
-    return mark_safe(value.replace("\n", "<br>"))

--- a/jinja2/qfdmo/acteur/tabs/sections/description.html
+++ b/jinja2/qfdmo/acteur/tabs/sections/description.html
@@ -5,5 +5,5 @@ Description
 {% endblock title %}
 
 {% block content %}
-{{ object.description|replace("\n", "<br>")|safe }}
+{{ object.description|nl2br }}
 {% endblock content %}

--- a/jinja2/qfdmo/acteur/tabs/sections/description.html
+++ b/jinja2/qfdmo/acteur/tabs/sections/description.html
@@ -5,5 +5,5 @@ Description
 {% endblock title %}
 
 {% block content %}
-{{ object.description }}
+{{ object.description|replace("\n", "<br>")|safe }}
 {% endblock content %}

--- a/jinja2/qfdmo/acteur/tabs/sections/description.html
+++ b/jinja2/qfdmo/acteur/tabs/sections/description.html
@@ -5,5 +5,5 @@ Description
 {% endblock title %}
 
 {% block content %}
-{{ object.description|nl2br }}
+{{ object.description|linebreaks|safe }}
 {% endblock content %}

--- a/jinja2/qfdmo/acteur/tabs/sections/horaires.html
+++ b/jinja2/qfdmo/acteur/tabs/sections/horaires.html
@@ -16,6 +16,6 @@ Horaires
         {% include "qfdmo/acteur/tabs/_separator.html" %}
     {% endif %}
 
-    {{ object.horaires_description|replace("\n", "<br>")|safe }}
+    {{ object.horaires_description|nl2br }}
 </div>
 {% endblock content %}

--- a/jinja2/qfdmo/acteur/tabs/sections/horaires.html
+++ b/jinja2/qfdmo/acteur/tabs/sections/horaires.html
@@ -12,10 +12,10 @@ Horaires
     </p>
     {% endif %}
 
-    {% if object.uniquement_sur_rdv and object.horaires_description|safe %}
+    {% if object.uniquement_sur_rdv and object.horaires_description %}
         {% include "qfdmo/acteur/tabs/_separator.html" %}
     {% endif %}
 
-    {{ object.horaires_description|nl2br }}
+    {{ object.horaires_description|linebreaks|safe }}
 </div>
 {% endblock content %}


### PR DESCRIPTION
# Description succincte du problème résolu

Gestion des retours à la ligne.
Quand on édit le paragraphe description dans django admin, les retours à la ligne ne sont pas appliqués dans la fiche acteur.
En solution temporaire en attendant une meilleur gestion (rich text), on remplace les \n par des <br>
même comportement que horaires_description pour débloquer Christian

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Django - Fiche acteur

**💡 quoi**: Affichage, retour à la ligne dans la description

**🎯 pourquoi**: meilleur mise en page même si c'est pas top

**🤔 comment**: remplacer les \n par de <br> lors de l'affichage de la description

## Exemple résultats / UI / Data

![CleanShot 2025-04-29 at 21 33 14@2x](https://github.com/user-attachments/assets/1c0c5cd7-cef5-43aa-9876-b5efb1fee0b6)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code


## 📆 A faire (prochaine PR)

- [ ] Gestion des textarea comme des rich text
