### PR TITLE
Supression de la metadata des pro filtrés et ajout du nombre d'acteurs impactés

### DIFF
--- a/dags/sources/dags/source_valdelia.py
+++ b/dags/sources/dags/source_valdelia.py
@@ -51,11 +51,11 @@ with DAG(
                 "transformation": "clean_public_accueilli",
                 "destination": "public_accueilli",
             },
-            {
-                "origin": "uniquement_sur_rdv",
-                "transformation": "cast_eo_boolean_or_string_to_boolean",
-                "destination": "uniquement_sur_rdv",
-            },
+            # {
+            #     "origin": "uniquement_sur_rdv",
+            #     "transformation": "cast_eo_boolean_or_string_to_boolean",
+            #     "destination": "uniquement_sur_rdv",
+            # },
             {
                 "origin": "exclusivite_de_reprisereparation",
                 "transformation": "cast_eo_boolean_or_string_to_boolean",
@@ -76,6 +76,9 @@ with DAG(
                 "column": "statut",
                 "value": constants.ACTEUR_ACTIF,
             },
+            {"column": "point_dapport_de_service_reparation", "value": False},
+            {"column": "point_de_reparation", "value": False},
+            {"column": "point_dapport_pour_reemploi", "value": False},
             # 4. Transformation du dataframe
             {
                 "origin": ["latitude", "longitude"],

--- a/dags/sources/dags/source_valdelia.py
+++ b/dags/sources/dags/source_valdelia.py
@@ -51,11 +51,11 @@ with DAG(
                 "transformation": "clean_public_accueilli",
                 "destination": "public_accueilli",
             },
-            # {
-            #     "origin": "uniquement_sur_rdv",
-            #     "transformation": "cast_eo_boolean_or_string_to_boolean",
-            #     "destination": "uniquement_sur_rdv",
-            # },
+            {
+                "origin": "uniquement_sur_rdv",
+                "transformation": "cast_eo_boolean_or_string_to_boolean",
+                "destination": "uniquement_sur_rdv",
+            },
             {
                 "origin": "exclusivite_de_reprisereparation",
                 "transformation": "cast_eo_boolean_or_string_to_boolean",
@@ -76,9 +76,6 @@ with DAG(
                 "column": "statut",
                 "value": constants.ACTEUR_ACTIF,
             },
-            {"column": "point_dapport_de_service_reparation", "value": False},
-            {"column": "point_de_reparation", "value": False},
-            {"column": "point_dapport_pour_reemploi", "value": False},
             # 4. Transformation du dataframe
             {
                 "origin": ["latitude", "longitude"],

--- a/dags/sources/tasks/airflow_logic/db_data_prepare_task.py
+++ b/dags/sources/tasks/airflow_logic/db_data_prepare_task.py
@@ -3,6 +3,7 @@ import logging
 from airflow import DAG
 from airflow.operators.python import PythonOperator
 from sources.tasks.business_logic.db_data_prepare import db_data_prepare
+
 from utils import logging_utils as log
 
 logger = logging.getLogger(__name__)
@@ -27,7 +28,20 @@ def db_data_prepare_wrapper(**kwargs):
     log.preview("df_acteur", df_acteur_from_source)
     log.preview("df_acteur_from_db", df_acteur_from_db)
 
-    return db_data_prepare(
+    result = db_data_prepare(
         df_acteur=df_acteur_from_source,
         df_acteur_from_db=df_acteur_from_db,
     )
+
+    kwargs["ti"].xcom_push(
+        key="df_acteur_to_create", value=result["df_acteur_to_create"]
+    )
+    kwargs["ti"].xcom_push(
+        key="df_acteur_to_update", value=result["df_acteur_to_update"]
+    )
+    kwargs["ti"].xcom_push(
+        key="df_acteur_to_delete", value=result["df_acteur_to_delete"]
+    )
+    kwargs["ti"].xcom_push(key="metadata_to_update", value=result["metadata_to_update"])
+    kwargs["ti"].xcom_push(key="metadata_to_create", value=result["metadata_to_create"])
+    kwargs["ti"].xcom_push(key="metadata_to_delete", value=result["metadata_to_delete"])

--- a/dags/sources/tasks/business_logic/db_data_prepare.py
+++ b/dags/sources/tasks/business_logic/db_data_prepare.py
@@ -4,6 +4,7 @@ import logging
 import numpy as np
 import pandas as pd
 from sources.config import shared_constants as constants
+
 from utils import logging_utils as log
 
 logger = logging.getLogger(__name__)
@@ -78,4 +79,13 @@ def db_data_prepare(
         "df_acteur_to_create": df_acteur_to_create,
         "df_acteur_to_update": df_acteur_to_update,
         "df_acteur_to_delete": df_acteur_to_delete,
+        "metadata_to_update": {
+            "nb acteur à mettre à jour": len(df_acteur_to_update),
+        },
+        "metadata_to_create": {
+            "nb acteur à créer": len(df_acteur_to_create),
+        },
+        "metadata_to_delete": {
+            "nb acteur à supprimer": len(df_acteur_to_delete),
+        },
     }

--- a/dags/sources/tasks/business_logic/source_data_normalize.py
+++ b/dags/sources/tasks/business_logic/source_data_normalize.py
@@ -4,7 +4,6 @@ import logging
 import pandas as pd
 import requests
 from shared.tasks.database_logic.db_manager import PostgresConnectionManager
-from sources.config import shared_constants as constants
 from sources.config.airflow_params import TRANSFORMATION_MAPPING
 from sources.tasks.airflow_logic.config_management import (
     DAGConfig,
@@ -141,10 +140,7 @@ def _remove_undesired_lines(
                 .sum()
             )
         )
-    if "public_accueilli" in df.columns:
-        metadata["nb acteurs filtrés car professionnels uniquement"] = str(
-            df["public_accueilli"].str.contains(constants.PUBLIC_PRO).sum()
-        )
+
     if "sous_categorie_codes" in df.columns:
         if (
             nb_empty_sous_categorie := df["sous_categorie_codes"]


### PR DESCRIPTION
# Description succincte du problème résolu

Mattermost : retour de christian -> «nb acteurs filtrés car proffessionnels»

**🗺️ contexte**: Django Admin - Cohorte

**💡 quoi**: metadata sur le nombre de pro filtrés caduque

**🎯 pourquoi**: car il ne sont plus filtrés lors de l'ingestion de source mais plus tard

**🤔 comment**: suppression des metadata sur les nb d'acteurs filtrés car pro

## Screenshot

![CleanShot 2025-05-05 at 14 21 28](https://github.com/user-attachments/assets/c3ca752a-0662-409c-af3c-cde396474fb5)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
