### PR TITLE
🤖 DBT: script de gestion de schemas

### DIFF
--- a/dags/utils/django.py
+++ b/dags/utils/django.py
@@ -53,6 +53,21 @@ def django_setup_full() -> None:
     django.setup()
 
 
+def django_conn_to_sqlalchemy_engine(using="default"):
+    """Return a SQLAlchemy engine from a Django connection"""
+    from django.db import connections
+    from sqlalchemy import create_engine
+
+    conn = connections[using]
+    conn.ensure_connection()
+    db_settings = conn.settings_dict
+    url = (
+        f"postgresql://{db_settings['USER']}:{db_settings['PASSWORD']}@"
+        f"{db_settings['HOST']}:{db_settings['PORT']}/{db_settings['NAME']}"
+    )
+    return create_engine(url)
+
+
 def django_model_fields_get(model_class, include_properties=True) -> list[str]:
     """Returns fields from Django model matching certain criteria
     to help us:

--- a/dbt/models/base/ae_annuaire_entreprises/base_ae_unite_legale.sql
+++ b/dbt/models/base/ae_annuaire_entreprises/base_ae_unite_legale.sql
@@ -8,7 +8,7 @@ Notes:
 {{
   config(
     materialized = 'view',
-    tags=['intermediate', 'ae', 'annuaire_entreprises', 'unite_legale'],
+    tags=['base', 'ae', 'annuaire_entreprises', 'unite_legale'],
   )
 }}
 

--- a/dbt/models/base/ae_annuaire_entreprises/schema.yml
+++ b/dbt/models/base/ae_annuaire_entreprises/schema.yml
@@ -1,77 +1,74 @@
 version: 2
-
 models:
   - name: base_ae_unite_legale
-    description: "Unités légales de l'Annuaire Entreprises (AE)"
+    description: Unités légales de l'Annuaire Entreprises (AE)
     columns:
       - name: siren
-        description: "Numéro SIREN"
+        description: Numéro SIREN
         data_type: varchar(9)
-        data_tests:
-          - not_null
-          - unique
-      - name: etat_administratif
-        description: "État administratif: A = Active, C = Cessée"
-        data_type: varchar(1)
-        data_tests:
-          - not_null
-          - accepted_values:
-              values: ["A", "C"]
       - name: activite_principale
-        description: "Code NAF Rev2"
-        # Test failing on 2025-03-17 due to missing data in source table
-        # data_tests:
-        #   - not_null
+        description: Code NAF Rev2
+        data_type: string
+      - name: etat_administratif
+        description: 'État administratif: A = Active, C = Cessée'
+        data_type: varchar(1)
       - name: denomination
-        description: "Dénomination"
-        # Test failing on 2025-03-17 due to missing data in source table
-        # data_tests:
-        #   - not_null
+        description: Dénomination
+        data_type: string
       - name: prenom1
-        description: "Prénom 1 du dirigeant"
+        description: Prénom 1 du dirigeant
+        data_type: string
       - name: prenom2
-        description: "Prénom 2 du dirigeant"
+        description: Prénom 2 du dirigeant
+        data_type: string
       - name: prenom3
-        description: "Prénom 3 du dirigeant"
+        description: Prénom 3 du dirigeant
+        data_type: string
       - name: prenom4
-        description: "Prénom 4 du dirigeant"
+        description: Prénom 4 du dirigeant
+        data_type: string
       - name: prenom_usuel
-        description: "Prénom usuel du dirigeant"
+        description: Prénom usuel du dirigeant
+        data_type: string
       - name: pseudonyme
-        description: "Pseudonyme du dirigeant"
+        description: Pseudonyme du dirigeant
+        data_type: string
       - name: nom
-        description: "Nom du dirigeant"
+        description: Nom du dirigeant
+        data_type: string
       - name: nom_usage
-        description: "Nom d'usage du dirigeant"
+        description: Nom d'usage du dirigeant
+        data_type: string
   - name: base_ae_etablissement
-    description: "Établissements de l'Annuaire Entreprises (AE)"
+    description: Établissements de l'Annuaire Entreprises (AE)
     columns:
       - name: siret
-        description: "Numéro SIRET"
+        description: Numéro SIRET
         data_type: varchar(14)
-        data_tests:
-          - not_null
-          - unique
       - name: activite_principale
-        description: "Code NAF Rev2"
+        description: Code NAF Rev2
+        data_type: string
       - name: denomination_usuelle
-        description: "Nom de l'établissement"
+        description: Nom de l'établissement
+        data_type: string
       - name: etat_administratif
-        description: "A = Actif, F = Fermé"
+        description: A = Actif, F = Fermé
         data_type: varchar(1)
-        data_tests:
-          - not_null
-          - accepted_values:
-              values: ["A", "F"]
       - name: numero_voie
-        description: "Numéro de voie"
+        description: Numéro de voie
+        data_type: string
       - name: complement_adresse
-        description: "Complement d'adresse (ex: étage, bâtiment)"
+        description: 'Complement d''adresse (ex: étage, bâtiment)'
+        data_type: string
       - name: type_voie
-        description: "Type de voie (ex: rue, avenue)"
+        description: 'Type de voie (ex: rue, avenue)'
+        data_type: string
       - name: libelle_voie
-        description: "Nom de la voie"
+        description: Nom de la voie
+        data_type: string
       - name: code_postal
-        description: "Postal code"
+        description: Postal code
+        data_type: string
       - name: libelle_commune
-        description: "Nom de la ville"
+        description: Nom de la ville
+        data_type: string

--- a/dbt/models/base/ban/schema.yml
+++ b/dbt/models/base/ban/schema.yml
@@ -1,0 +1,73 @@
+version: 2
+models:
+  # No tests for base BAN models as they take forever
+  # to run and we will have the same on int_
+  - name: base_ban_adresses
+    description: ''
+    columns:
+      - name: adresse
+        description: adresse
+        data_type: string
+      - name: adresse_numero
+        description: adresse_numero
+        data_type: string
+      - name: ville
+        description: ville
+        data_type: string
+      - name: ville_ancienne
+        description: ville_ancienne
+        data_type: string
+      - name: code_postal
+        description: code_postal
+        data_type: string
+      - name: code_departement
+        description: code_departement
+        data_type: string
+      - name: latitude
+        description: latitude
+        data_type: string
+      - name: longitude
+        description: longitude
+        data_type: string
+  - name: base_ban_lieux_dits
+    description: ''
+    columns:
+      - description: Identifiant
+        data_type: string
+        name: id
+      - name: nom_lieu_dit
+        description: nom_lieu_dit
+        data_type: string
+      - name: code_postal
+        description: code_postal
+        data_type: string
+      - name: code_insee
+        description: code_insee
+        data_type: string
+      - name: nom_commune
+        description: nom_commune
+        data_type: string
+      - name: code_insee_ancienne_commune
+        description: code_insee_ancienne_commune
+        data_type: string
+      - name: nom_ancienne_commune
+        description: nom_ancienne_commune
+        data_type: string
+      - name: x
+        description: x
+        data_type: string
+      - name: y
+        description: y
+        data_type: string
+      - name: lon
+        description: lon
+        data_type: string
+      - name: lat
+        description: lat
+        data_type: string
+      - name: source_position
+        description: source_position
+        data_type: string
+      - name: source_nom_voie
+        description: source_nom_voie
+        data_type: string

--- a/scripts/dbt/conf/columns.py
+++ b/scripts/dbt/conf/columns.py
@@ -1,0 +1,67 @@
+"""Constants and utilities for columns"""
+
+import re
+from collections import OrderedDict
+from re import Pattern
+
+# Mapping of column patterns and definitions
+COLUMNS: dict[Pattern[str], dict] = {
+    re.compile(r"etat_administratif"): {
+        "description": "Etat administratif (A = Actif, C = Cessé d'activité)",
+        "data_type": "varchar(1)",
+        "data_tests": [
+            "not_null",
+            {"name": "accepted_values", "config": {"values": ["A", "C"]}},
+        ],
+    },
+    # Boolean columns
+    re.compile(r"((^|_)is_|(^|_)has_)"): {
+        "description": "Boolean",
+        "data_type": "boolean",
+        "data_tests": [
+            "not_null",
+            {"name": "accepted_values", "config": {"values": ["true", "false"]}},
+        ],
+    },
+    # Id columns
+    re.compile(r"(^id$|_id$|identifiant_unique)"): {
+        "description": "Identifiant",
+        "data_type": "string",
+        "data_tests": ["not_null"],
+    },
+    re.compile(r"siret"): {
+        "description": "Siret",
+        "data_type": "varchar(14)",
+        "data_tests": ["not_null"],
+    },
+    re.compile(r"siren"): {
+        "description": "Siren",
+        "data_type": "varchar(9)",
+        "data_tests": ["not_null"],
+    },
+    re.compile(r"statut"): {
+        "description": "Statut",
+        "data_type": "string",
+        "data_tests": [
+            {
+                "name": "accepted_values",
+                "config": {"values": ["ACTIF", "INACTIF"]},
+            }
+        ],
+    },
+}
+
+
+def db_column_to_dbt_column(model_name: str, column: dict) -> dict:
+    """Convert a column to a dbt schema"""
+    col = next((v for k, v in COLUMNS.items() if k.search(column["name"])), None)
+    if col is None:
+        return OrderedDict(
+            {
+                "name": column["name"],
+                "description": column["name"],
+                "data_type": "string",
+            }
+        )
+    col = OrderedDict([("name", column["name"])] + list(col.items()))
+    return col

--- a/scripts/dbt/conf/schemas.py
+++ b/scripts/dbt/conf/schemas.py
@@ -1,0 +1,102 @@
+"""Constants and utilities for schemas"""
+
+import re
+from re import Pattern
+
+# oyaml = wrapper around pyyaml to preserve dict order
+import oyaml as yaml
+import pydash
+
+from scripts.dbt.conf.columns import db_column_to_dbt_column
+
+# Models we don't want tests on, for instance
+# base models for large datasets (e.g. BAN, AE)
+# for which we will have the same tests on int_
+MODELS_TO_SKIP_TESTS: list[Pattern[str]] = [
+    re.compile(r"base_ban"),
+    re.compile(r"base_ae"),
+]
+
+
+def schemas_new_generate(model: dict, db_columns: list[dict]) -> dict:
+    """Create a new schema from a model"""
+    dbt_columns = [db_column_to_dbt_column(model["name"], x) for x in db_columns]
+    schema_new = {
+        "version": 2,
+        "models": [{"name": model["name"], "description": "", "columns": dbt_columns}],
+    }
+    return schema_new
+
+
+def deep_merge_by_name(target, source) -> dict:
+    """Merge two dictionaries, leveraging the "name" key" when
+    present in dicts to determine identity"""
+    if isinstance(target, dict) and isinstance(source, dict):
+        for key, value in source.items():
+            if key in target:
+                target[key] = deep_merge_by_name(target[key], value)
+            else:
+                target[key] = value
+        return target
+
+    elif isinstance(target, list) and isinstance(source, list):
+        # Merge lists of dicts with "name" keys
+        if all(isinstance(x, dict) and "name" in x for x in target + source):
+            merged = {d["name"]: d.copy() for d in target}
+            for item in source:
+                name = item["name"]
+                if name in merged:
+                    merged[name] = deep_merge_by_name(merged[name], item)
+                else:
+                    merged[name] = item.copy()
+            return list(merged.values())  # type: ignore
+        else:
+            # If not dicts with "name", replace the list
+            return source  # type: ignore
+
+    else:
+        # Scalar or incompatible types: source overwrites target
+        return source
+
+
+def schemas_merge(old: dict, new: dict) -> dict:
+    """Merge two dictionaries of schemas"""
+    merged = deep_merge_by_name(old.copy(), new.copy())
+    return merged
+
+
+def schemas_contract_enforce(schema: dict) -> dict:
+    """Enforce DBT contract on a schema"""
+    for model in schema["models"]:
+        pydash.objects.set_(model, "config.contract.enforced", True)
+    return schema
+
+
+def schemas_remove_unwanted_data_tests(schema: dict) -> dict:
+    """Remove unwanted data tests from a schema"""
+    for model in schema["models"]:
+        if any(pattern.search(model["name"]) for pattern in MODELS_TO_SKIP_TESTS):
+            for column in model["columns"]:
+                if "data_tests" in column:
+                    del column["data_tests"]
+    return schema
+
+
+class IndentListDumper(yaml.SafeDumper):
+    """Ensures extra indentation for lists
+    https://medium.com/@reorx/tips-that-may-save-you-from-the-hell-of-pyyaml-572cde7e1d6f
+    """
+
+    def increase_indent(self, flow=False, indentless=False):
+        return super().increase_indent(flow, indentless=False)
+
+
+def schema_to_yaml(schema: dict) -> str:
+    """Convert a schema to a YAML string"""
+    return yaml.dump(
+        schema,
+        sort_keys=False,
+        default_flow_style=False,
+        Dumper=IndentListDumper,
+        allow_unicode=True,
+    )

--- a/scripts/dbt/schemas_generate_validate.py
+++ b/scripts/dbt/schemas_generate_validate.py
@@ -1,0 +1,100 @@
+"""Script to help generate and validate dbt schemas"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import yaml
+from rich import print
+from rich.prompt import Prompt
+from rich.traceback import install
+from sqlalchemy import inspect
+
+install()
+
+# Paths
+DIR_ROOT = Path(__file__).parent.parent.parent
+DIR_DBT = DIR_ROOT / "dbt"
+DIR_DBT_MODELS = DIR_DBT / "models"
+DIR_DAGS = DIR_ROOT / "dags"
+FP_DBT_MANIFEST = DIR_DBT / "target" / "manifest.json"
+sys.path.append(str(DIR_ROOT))
+sys.path.append(str(DIR_DAGS))
+
+# Django setup
+from utils.django import (  # noqa: E402
+    django_conn_to_sqlalchemy_engine,
+    django_setup_full,
+)
+
+from scripts.dbt.conf.schemas import (  # noqa: E402
+    schema_to_yaml,
+    schemas_merge,
+    schemas_new_generate,
+    schemas_remove_unwanted_data_tests,
+)
+
+django_setup_full()
+
+
+def dbt_manifest_to_models() -> list[dict]:
+    """Return a list of models from the manifest file"""
+    with open(FP_DBT_MANIFEST, "r") as f:
+        manifest = json.load(f)
+
+    return [
+        node
+        for node in manifest.get("nodes", {}).values()
+        if node["resource_type"] == "model"
+    ]
+
+
+def dbt_model_schema_process(engine, model: dict):
+    """Generate, validate and update a dbt model schema"""
+
+    # Get DB columns
+    inspector = inspect(engine)
+    try:
+        db_columns = inspector.get_columns(model["name"])  # type: ignore
+    except Exception as e:
+        print(f"Error getting columns for model {model['name']}: {e}")
+        return
+
+    # Generate new schema
+    schema_new = schemas_new_generate(model, db_columns)
+
+    # Validate
+    path_schemas = (
+        DIR_DBT_MODELS / "/".join(model["path"].split("/")[:-1]) / "schema.yml"
+    )
+    # TODO: below could be replaced with automation to create schema w/ template
+    assert path_schemas.exists(), f"Schema manquant: {path_schemas}"
+    if path_schemas.exists():
+        assert "models" in path_schemas.read_text(), "Need to create schema template"
+
+    # Generate new schema
+    schema_old = yaml.safe_load(path_schemas.read_text())
+    schema_new = schemas_merge(schema_old, schema_new)
+    schema_new = schemas_remove_unwanted_data_tests(schema_new)
+    # schema_new = schemas_contract_enforce(schema_new)
+
+    # Update schema file: thanks to merge, will only update current
+    # model and leave other models unchanged
+    path_schemas.write_text(schema_to_yaml(schema_new))
+
+
+if __name__ == "__main__":
+    # Ensuring DB connection OK before doing anything else
+    engine = django_conn_to_sqlalchemy_engine()
+
+    # Getting (and optionally filtering) DBT models
+    ask = "dbt model name pattern (none=*)"
+    model_pattern = Prompt.ask(ask, default="base_ban")
+    models = dbt_manifest_to_models()
+    if model_pattern:
+        models = [x for x in models if re.search(model_pattern, x["name"])]
+
+    # Processing each model
+    for model in models:
+        dbt_model_schema_process(engine, model)

--- a/scripts/dbt/tests/test_schemas.py
+++ b/scripts/dbt/tests/test_schemas.py
@@ -1,0 +1,47 @@
+from scripts.dbt.conf.schemas import schema_to_yaml, schemas_merge
+
+SCHEMA_OLD = {
+    "version": 2,
+    "models": [
+        # Not present in new, will be kept as-is
+        {"name": "foo1"},
+        # Present in new with columns, columns be added
+        {"name": "foo2"},
+        {"name": "foo4", "columns": [{"name": "test1"}]},
+    ],
+}
+SCHEMA_NEW = {
+    "models": [
+        {"name": "foo2", "columns": [{"name": "test", "data_type": "integer"}]},
+        # Not present in old, will be added
+        {"name": "foo3"},
+        {"name": "foo4", "columns": [{"name": "test2"}]},
+    ],
+}
+
+SCHEMA_MERGED = {
+    "models": [
+        {"name": "foo1"},
+        {"name": "foo2", "columns": [{"name": "test", "data_type": "integer"}]},
+        {"name": "foo4", "columns": [{"name": "test1"}, {"name": "test2"}]},
+        {"name": "foo3"},
+    ],
+    "version": 2,
+}
+
+
+def test_schemas_merge():
+    assert schemas_merge(SCHEMA_OLD, SCHEMA_NEW) == SCHEMA_MERGED
+
+
+def test_schema_to_yaml():
+    yaml = schema_to_yaml(SCHEMA_OLD)
+    expected = """version: 2
+models:
+  - name: foo1
+  - name: foo2
+  - name: foo4
+    columns:
+      - name: test1
+"""
+    assert yaml == expected


### PR DESCRIPTION
# 🤖 DBT: script de gestion de schemas

Carte Notion: [dbt: ré-écrire les schemas](https://www.notion.so/accelerateur-transition-ecologique-ademe/dbt-r-crire-les-schemas-1e46523d57d780a688d3c35fd4ed6922)

**🗺️ contexte**: on utilise dbt pour compiler des modèles, :red_circle: la gestion des **fichiers schema.yml** est **manuelle** et **chronophage**

**💡 quoi**: un script pour générer les schemas automatiquement

**🎯 pourquoi**: gagner en temps et consistence

**🤔 comment**:
 1. **modèles**: lit le fichier `dbt/target/manifest.json` pour la liste des modèles compilés
 2. **filtre** utilisateur (regex) sur des modèles en particulier (optionnel)
 3. **inspection db**: pour voir les champs réels compilés
 4. **merge recursif** avec le schema d'origine (pour pas perdre l'existant)
 5. **mise à jour du `schema.yaml`** correspondant aux modèles

Avec des conf pour décider de comment gérer nos colonnes et schemas

## :framed_picture: Exemple

![image](https://github.com/user-attachments/assets/b0be4d81-005d-4e53-816a-18473b9ab887)

## 📆 A faire (prochaine PR)

- [ ] **Continuer de tester/étendre** le script en fonction des besoins jusqu'a **maturité** (notamment les fichiers `conf/`)
- [ ] **Ajout fonctionalité de nettoyage**: pour l'instant je fais un deep merge pour être safe et rien perdre, mais on devrait supprimer les colonnes/modèles qui n'existent pas dans la DB (réalité)
- [ ] **Faire exécuter via la CI**: similaire au test qui vérifie qu'on a pas de nouvelles migrations django, on devrait pas avoir de changement de schema DBT au niveau de la CI
- [ ] **Modèles django / pydantic**: si on veut utiliser **programatiquement** les modèles `dbt` dans `python` pour nos DAG Airflow, on peut facilement étendre le script et utiliser `schema_new` pour générer des classes python
