### PR TITLE
🛑 DBT: ne pas dropper en cascade nos UDFs

### DIFF
--- a/dbt/macros/udf/udf_ae_string_cleanup.sql
+++ b/dbt/macros/udf/udf_ae_string_cleanup.sql
@@ -6,8 +6,7 @@
     to NULL for easier processing whenever we consider
     it to be empty.
 */
-DROP FUNCTION IF EXISTS {{ target.schema }}.udf_ae_string_cleanup CASCADE;
-CREATE FUNCTION {{ target.schema }}.udf_ae_string_cleanup(val TEXT)
+CREATE OR REPLACE FUNCTION {{ target.schema }}.udf_ae_string_cleanup(val TEXT)
 RETURNS TEXT AS $$
 BEGIN
     IF TRIM(val) = '' OR TRIM(val) = '[ND]' THEN

--- a/dbt/macros/udf/udf_columns_concat_unique_non_empty.sql
+++ b/dbt/macros/udf/udf_columns_concat_unique_non_empty.sql
@@ -2,8 +2,7 @@
 /*
     Concatenate strings from various columns while only retaining non-empty values
 */
-DROP FUNCTION IF EXISTS {{ target.schema }}.udf_columns_concat_unique_non_empty CASCADE;
-CREATE FUNCTION {{ target.schema }}.udf_columns_concat_unique_non_empty(VARIADIC input_columns TEXT[])
+CREATE OR REPLACE FUNCTION {{ target.schema }}.udf_columns_concat_unique_non_empty(VARIADIC input_columns TEXT[])
 RETURNS TEXT AS $$
 DECLARE
     unique_values TEXT;

--- a/dbt/macros/udf/udf_columns_words_in_common_count.sql
+++ b/dbt/macros/udf/udf_columns_words_in_common_count.sql
@@ -2,8 +2,7 @@
 /*
     Count number of words in common between 2 columns
 */
-DROP FUNCTION IF EXISTS {{ target.schema }}.udf_columns_words_in_common_count CASCADE;
-CREATE FUNCTION {{ target.schema }}.udf_columns_words_in_common_count(col1 text, col2 text)
+CREATE OR REPLACE FUNCTION {{ target.schema }}.udf_columns_words_in_common_count(col1 text, col2 text)
 RETURNS integer AS $$
 DECLARE
     word text;

--- a/dbt/macros/udf/udf_encode_base57.sql
+++ b/dbt/macros/udf/udf_encode_base57.sql
@@ -1,7 +1,6 @@
 {% macro create_udf_encode_base57() %}
 
-DROP FUNCTION IF EXISTS {{ target.schema }}.encode_base57 CASCADE;
-CREATE FUNCTION {{ target.schema }}.encode_base57(uuid UUID)
+CREATE OR REPLACE FUNCTION {{ target.schema }}.encode_base57(uuid UUID)
 RETURNS varchar(22) AS $$
 DECLARE
     alphabet text := '23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'; -- pragma: allowlist secret

--- a/dbt/macros/udf/udf_normalize_string_alpha_for_match.sql
+++ b/dbt/macros/udf/udf_normalize_string_alpha_for_match.sql
@@ -9,8 +9,7 @@
     E.g. to test this function:
     SELECT udf_normalize_string_for_match(' Héllo-Wørld! Ça va? 123 ');
  */
-DROP FUNCTION IF EXISTS {{ target.schema }}.udf_normalize_string_for_match CASCADE;
-CREATE FUNCTION {{ target.schema }}.udf_normalize_string_for_match(input_text TEXT, remove_words_smaller_size INTEGER DEFAULT 2) RETURNS TEXT AS $$
+CREATE OR REPLACE FUNCTION {{ target.schema }}.udf_normalize_string_for_match(input_text TEXT, remove_words_smaller_size INTEGER DEFAULT 2) RETURNS TEXT AS $$
 DECLARE
     normalized TEXT;
     words TEXT[];

--- a/dbt/macros/udf/udf_safe_divmod.sql
+++ b/dbt/macros/udf/udf_safe_divmod.sql
@@ -1,6 +1,5 @@
 {% macro create_udf_safe_divmod() %}
-DROP FUNCTION IF EXISTS {{ target.schema }}.safe_divmod CASCADE;
-CREATE FUNCTION {{ target.schema }}.safe_divmod(n numeric, d numeric)
+CREATE OR REPLACE FUNCTION {{ target.schema }}.safe_divmod(n numeric, d numeric)
 RETURNS TABLE(quotient numeric, remainder numeric) AS $$
 DECLARE
     q numeric;

--- a/dbt/macros/udf/udf_uuid_to_int.sql
+++ b/dbt/macros/udf/udf_uuid_to_int.sql
@@ -1,6 +1,5 @@
 {% macro create_udf_uuid_to_int() %}
-DROP FUNCTION IF EXISTS {{ target.schema }}.uuid_to_int CASCADE;
-CREATE FUNCTION {{ target.schema }}.uuid_to_int(uuid UUID)
+CREATE OR REPLACE FUNCTION {{ target.schema }}.uuid_to_int(uuid UUID)
 RETURNS numeric AS $$
 DECLARE
     uuid_str text;


### PR DESCRIPTION
# 🛑 DBT: ne pas dropper en cascade nos UDFs

Carte Notion: [🔴 DBT: échec intermittent de creation de vues](https://www.notion.so/accelerateur-transition-ecologique-ademe/DBT-chec-intermittent-de-creation-de-vues-1e56523d57d780c0b754c2b91cf8053e)

**🗺️ contexte**: on utilise des fonctions custom dans PG (udf). J'avais mis un `DROP ... CASCADE` car quand les changaient de manière trop substentielles, PG refusait le changement, mais ceci a engendré le problème d'échet intermittent.

**💡 quoi**: je rebascule les fonctions en `CREATE OR REPLACE`

**🎯 pourquoi**: éviter le problème d'échec intermittent de création des vues

**🤔 comment**: <!-- Descrire l'ensemble des tâches réalisées (bullet points) -->

## Récaputulatif des options

 - `CREATE OR REPLACE` = 
    - :yellow_circle: **créer fonction**: ne fonctionne pas SI fonction trop différente, **ma recommendation est un légé changement de nom de fonction si les changements sont trop substentiels**
    - **on pourrait ajouter un suffixe version** (ex: `_v1`, `_v2` etc...) qui servirait aussi de désambiguation
    - :green_circle: **stabilité vues**: pas de problème
 - `DROP` = 
    - :yellow_circle: **créer fonction**: ne fonctionne pas SI la fonction est utilisée dans une vue (dépendence, besoin cascade), même topo que ci-dessus
    - :green_circle: **stabilité vues**: pas de problème
 - `DROP ... CASCADE` =
    - :green_circle: : **créer fonction**: fonctionne toujours
    - :red_circle: : **stabilité vues**: cause le problème d'échet intermittent de création des vues

## 🔎 Explication détaillé du problème

![dbt_fails](https://github.com/user-attachments/assets/d88bef0f-2700-4641-ba81-c6cf12f73607)

- https://github.com/dbt-labs/dbt-core/issues/4030
    
    > Is there any chance you're running out-of-band **drop... cascade** statements during a dbt run, such as in project or model **hooks**?
    > 
- J'avais rajouté du CASCADE au DROP de fonction pour s'assurer de leur recréation "brutale/totale" sans obstacle
- Mais ceci vient dropper les vues correspondantes pendant le `on-run-start`:
- **Scénario 1: aucune vue**: dbt se lance, pas de vue, OK je recréer tout = ça marche
- **Scénario 2: vues existantes**: dbt se lance, vois que certaines but existents déjà, adaptent ses commandes en fonction, `on-run-start` arrive qui dégage des vues, et du coup les commandes SQL ne sont plus iso avec l'état de la DB

## :green_circle: Problème résolu

![dbt_works](https://github.com/user-attachments/assets/44ca896f-c01d-404e-a7fa-d71c1aa97316)

## 📆 A faire (prochaine PR)

- [ ] **Documenter tout ceci** dans notre doc DBT
