### PR TITLE
fix DBT acteur qui fait appelle à des tables vueacteur plutôt qu'à int_acteur

### DIFF
--- a/dbt/macros/table/macro_acteur_acteur_services.sql
+++ b/dbt/macros/table/macro_acteur_acteur_services.sql
@@ -2,18 +2,18 @@
 
 WITH nochild_acteur_acteur_services AS (
     SELECT
-        aas.vueacteur_id AS acteur_id,
+        aas.acteur_id AS acteur_id,
         aas.acteurservice_id AS acteurservice_id
-    FROM qfdmo_vueacteur_acteur_services aas
-    INNER JOIN {{ ref(ephemeral_filtered_acteur) }} AS a ON aas.vueacteur_id = a.identifiant_unique AND a.parent_id is null
-    GROUP BY aas.vueacteur_id, aas.acteurservice_id
+    FROM {{ ref( 'int_acteur_acteur_services' )}} AS aas
+    INNER JOIN {{ ref(ephemeral_filtered_acteur) }} AS a ON aas.acteur_id = a.identifiant_unique AND a.parent_id is null
+    GROUP BY aas.acteur_id, aas.acteurservice_id
 ),
 parentacteur_acteur_services AS (
     SELECT
         a.parent_id AS acteur_id,
         aas.acteurservice_id AS acteurservice_id
-    FROM qfdmo_vueacteur_acteur_services aas
-    INNER JOIN {{ ref(ephemeral_filtered_acteur) }} AS a ON aas.vueacteur_id = a.identifiant_unique AND a.parent_id is not null
+    FROM {{ ref( 'int_acteur_acteur_services' )}} AS aas
+    INNER JOIN {{ ref(ephemeral_filtered_acteur) }} AS a ON aas.acteur_id = a.identifiant_unique AND a.parent_id is not null
     GROUP BY a.parent_id, aas.acteurservice_id
 ),
 acteur_acteur_services AS (

--- a/dbt/macros/table/macro_acteur_labels.sql
+++ b/dbt/macros/table/macro_acteur_labels.sql
@@ -2,18 +2,18 @@
 
 WITH nochild_acteur_labels AS (
     SELECT
-        al.vueacteur_id AS acteur_id,
+        al.acteur_id AS acteur_id,
         al.labelqualite_id AS labelqualite_id
-    FROM qfdmo_vueacteur_labels al
-    INNER JOIN {{ ref(ephemeral_filtered_acteur) }} AS a ON al.vueacteur_id = a.identifiant_unique AND a.parent_id is null
-    GROUP BY al.vueacteur_id, al.labelqualite_id
+    FROM {{ ref( 'int_acteur_labels' )}} AS al
+    INNER JOIN {{ ref(ephemeral_filtered_acteur) }} AS a ON al.acteur_id = a.identifiant_unique AND a.parent_id is null
+    GROUP BY al.acteur_id, al.labelqualite_id
 ),
 parentacteur_labels AS (
     SELECT
         a.parent_id AS acteur_id,
         al.labelqualite_id AS labelqualite_id
-    FROM qfdmo_vueacteur_labels al
-    INNER JOIN {{ ref(ephemeral_filtered_acteur) }} AS a ON al.vueacteur_id = a.identifiant_unique AND a.parent_id is not null
+    FROM {{ ref( 'int_acteur_labels' )}} AS al
+    INNER JOIN {{ ref(ephemeral_filtered_acteur) }} AS a ON al.acteur_id = a.identifiant_unique AND a.parent_id is not null
     GROUP BY a.parent_id, al.labelqualite_id
 ),
 acteur_labels AS (


### PR DESCRIPTION
# Description succincte du problème résolu

Un raté qui fait que le calcule des acteurs via DBT est cassé car in se base sur des tables finales plutôt que sur les tables qu'il vient de construire

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Airflow DBT Source

**💡 quoi**: DBT acteur carte cassé

**🎯 pourquoi**: les tables référencées dans les macros sont les tables cibles : donc on ne peut pas grantir qu'elle existent et en plus la données rique d'être fausse

**🤔 comment**: changement des tables utilisées par les macro

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
