### PR TITLE
Ignorer le dossier script lors de la collecte des tests par pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "core.test_settings"
 env_files = [".env.template"]
-addopts = "--reuse-db"
+addopts = "--reuse-db --ignore=scripts"
 filterwarnings = [
   # Because of django-ninja package, cf. https://github.com/vitalik/django-ninja/issues/1266
   "ignore::pydantic.warnings.PydanticDeprecatedSince20",


### PR DESCRIPTION
# Description succincte du problème résolu

Vu ensemble pour permettre d'executer `pytest` sans options et sans planter

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Test

**💡 quoi**: `pytest` sans options et sans planter

**🎯 pourquoi**: ça plante car des lib sont chargée dans scripts mais pas nécessaire dans les tests et as besoin au quotidien

**🤔 comment**: ajout de l'option `--ignore` dans `pyproject.toml` 

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
