### PR TITLE
Dédupliquer les lignes qui ont plusieurs EO et prefixé ocab

### DIFF
--- a/dags/sources/dags/source_ocab.py
+++ b/dags/sources/dags/source_ocab.py
@@ -24,8 +24,8 @@ with DAG(
                 "destination": "nom",
             },
             {
-                "origin": "enseigne_commerciale",
-                "destination": "nom_commercial",
+                "origin": "consignes_dacces",
+                "destination": "description",
             },
             {
                 "origin": "longitudewgs84",
@@ -55,6 +55,11 @@ with DAG(
                 "origin": "produitsdechets_acceptes",
                 "transformation": "clean_sous_categorie_codes",
                 "destination": "sous_categorie_codes",
+            },
+            {
+                "origin": "horaires_douverture",
+                "transformation": "clean_horaires_osm",
+                "destination": "horaires_osm",
             },
             # 3. Ajout des colonnes avec une valeur par défaut
             {
@@ -95,9 +100,14 @@ with DAG(
                 "destination": ["adresse", "code_postal", "ville"],
             },
             {
+                "origin": ["telephone", "code_postal"],
+                "transformation": "clean_telephone",
+                "destination": ["telephone"],
+            },
+            {
                 "origin": [
-                    # "point_dapport_de_service_reparation",
-                    # "point_de_reparation",
+                    "point_dapport_de_service_reparation",
+                    "point_de_reparation",
                     "point_dapport_pour_reemploi",
                     "point_de_collecte_ou_de_reprise_des_dechets",
                 ],
@@ -106,8 +116,8 @@ with DAG(
             },
             {
                 "origin": [
-                    # "point_dapport_de_service_reparation",
-                    # "point_de_reparation",
+                    "point_dapport_de_service_reparation",
+                    "point_de_reparation",
                     "point_dapport_pour_reemploi",
                     "point_de_collecte_ou_de_reprise_des_dechets",
                 ],
@@ -131,6 +141,8 @@ with DAG(
             {"remove": "id_point_apport_ou_reparation"},
             {"remove": "point_de_collecte_ou_de_reprise_des_dechets"},
             {"remove": "point_dapport_pour_reemploi"},
+            {"remove": "point_de_reparation"},
+            {"remove": "point_dapport_de_service_reparation"},
             # 6. Colonnes à garder (rien à faire, utilisé pour le controle)
         ],
         "endpoint": (

--- a/dags/sources/dags/source_ocab.py
+++ b/dags/sources/dags/source_ocab.py
@@ -149,6 +149,10 @@ with DAG(
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-ocab/lines?size=10000"
         ),
+        "oca": {
+            "prefix": "ocab",
+            "deduplication_source": True,
+        },
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config(),
     },

--- a/dags/sources/tasks/airflow_logic/config_management.py
+++ b/dags/sources/tasks/airflow_logic/config_management.py
@@ -43,6 +43,11 @@ class NormalizationColumnKeep(BaseModel):
     keep: str
 
 
+class OCAConfig(BaseModel):
+    prefix: str | None = None
+    deduplication_source: bool = False
+
+
 class DAGConfig(BaseModel):
     normalization_rules: list[
         Union[
@@ -62,6 +67,7 @@ class DAGConfig(BaseModel):
     product_mapping: dict
     source_code: Optional[str] = None
     validate_address_with_ban: bool = False
+    oca: OCAConfig | None = None
 
     @field_validator("endpoint")
     def validate_endpoint(cls, endpoint):
@@ -111,6 +117,22 @@ class DAGConfig(BaseModel):
         ]
         columns -= set(removed_columns)
         return columns
+
+    @property
+    def oca_deduplication_source(self) -> bool:
+        if self.oca is None:
+            return False
+        return bool(self.oca.deduplication_source)
+
+    @property
+    def is_oca(self) -> bool:
+        return bool(self.oca)
+
+    @property
+    def oca_prefix(self) -> str | None:
+        if self.oca is None:
+            return None
+        return self.oca.prefix
 
 
 # DEPRECATED

--- a/dags/sources/tasks/business_logic/source_data_normalize.py
+++ b/dags/sources/tasks/business_logic/source_data_normalize.py
@@ -214,7 +214,7 @@ def _manage_oca_config(df: pd.DataFrame, dag_config: DAGConfig) -> pd.DataFrame:
         df["source_code"] = df["source_code"].apply(
             lambda x: oca_prefix + "_" + x.strip().lower()
         )
-    # Recalcule de l'identifiant unique
+    # Recalcul de l'identifiant unique
     normalisation_function = get_transformation_function(
         "clean_identifiant_unique", dag_config
     )

--- a/dags/sources/tasks/business_logic/source_data_normalize.py
+++ b/dags/sources/tasks/business_logic/source_data_normalize.py
@@ -205,6 +205,25 @@ def _display_warning_about_missing_location(df: pd.DataFrame) -> None:
             log.preview("Acteurs sans localisation", df_acteur_sans_loc)
 
 
+def _manage_oca_config(df: pd.DataFrame, dag_config: DAGConfig) -> pd.DataFrame:
+    if dag_config.oca_deduplication_source:
+        df = df.assign(source_code=df["source_code"].str.split("|")).explode(
+            "source_code"
+        )
+    if oca_prefix := dag_config.oca_prefix:
+        df["source_code"] = df["source_code"].apply(
+            lambda x: oca_prefix + "_" + x.strip().lower()
+        )
+    # Recalcule de l'identifiant unique
+    normalisation_function = get_transformation_function(
+        "clean_identifiant_unique", dag_config
+    )
+    df[["identifiant_unique"]] = df[["identifiant_externe", "source_code"]].apply(
+        normalisation_function, axis=1
+    )
+    return df
+
+
 def source_data_normalize(
     df_acteur_from_source: pd.DataFrame,
     dag_config: DAGConfig,
@@ -240,20 +259,8 @@ def source_data_normalize(
     df, metadata = _remove_undesired_lines(df, dag_config)
 
     # deduplication_on_source_code
-    if dag_id == "eo-ocab":
-        df = df.assign(source_code=df["source_code"].str.split("|")).explode(
-            "source_code"
-        )
-        df["source_code"] = df["source_code"].apply(
-            lambda x: "ocab_" + x.strip().lower()
-        )
-        # Recalcule de l'identifiant unique
-        normalisation_function = get_transformation_function(
-            "clean_identifiant_unique", dag_config
-        )
-        df[["identifiant_unique"]] = df[["identifiant_externe", "source_code"]].apply(
-            normalisation_function, axis=1
-        )
+    if dag_config.is_oca:
+        df = _manage_oca_config(df, dag_config)
 
     # Check that the dataframe has the expected columns
     expected_columns = dag_config.get_expected_columns()

--- a/dags/sources/tasks/business_logic/source_data_normalize.py
+++ b/dags/sources/tasks/business_logic/source_data_normalize.py
@@ -239,6 +239,22 @@ def source_data_normalize(
     # Merge and delete undesired lines
     df, metadata = _remove_undesired_lines(df, dag_config)
 
+    # deduplication_on_source_code
+    if dag_id == "eo-ocab":
+        df = df.assign(source_code=df["source_code"].str.split("|")).explode(
+            "source_code"
+        )
+        df["source_code"] = df["source_code"].apply(
+            lambda x: "ocab_" + x.strip().lower()
+        )
+        # Recalcule de l'identifiant unique
+        normalisation_function = get_transformation_function(
+            "clean_identifiant_unique", dag_config
+        )
+        df[["identifiant_unique"]] = df[["identifiant_externe", "source_code"]].apply(
+            normalisation_function, axis=1
+        )
+
     # Check that the dataframe has the expected columns
     expected_columns = dag_config.get_expected_columns()
 


### PR DESCRIPTION
# Description succincte du problème résolu

Notion !

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Airflow Source

**💡 quoi**: OCAB est en conflig avec les source fournit aussi par ses adhérents : Valdelia, Ecomaison

**🎯 pourquoi**: Identifier les Acteur qui ont été fournit par l'OCAB et ceux fournit directement par les adhérents. Supprimer les interférence des acteurs du même EO mais qui ont plusieurs source : Valdelia, Ecomaison fournissent leur prore point mais OCAB fournissent des acteurs pour ces 2 EO aussi

**🤔 comment**: 

- On Crée des nouvelles sources prefixées par le cod de l'OCA (ici : ocab) pour qu'il n'y ait pas d'interférence avec les acteurs fournit par l'EcoOrganisame directement
- On gère les acteur qui sont données pour plusieurs Eco-organisame : dans le fichier séraré par un |. On crée un acteur par Eco-organisme pour la ligne qui a plusieurs eco-organisme
- Adaptation des paramètres pour la source OCAB

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] Créer un paramètre pour pouvoir le configurer
- [ ] Tester l'application de cette déduplication

## 📆 A faire Lors de la mise en prod

Comme le nouveau fichier OCAB créer des nouveaux identifiants, on n'a pas besoin de gérer de migration.

A faire lors de la mise en prod:

1. Créer les sources `ocab_valobat`, `ocab_ecominero`, `ocab_valdelia`, `ocab_ecomaison` copie de `valobat`, `ecominero`, `valdelia`, `ecomaison` sauf le code
1. Faire tourner le DAG source OCAB
1. Valider les suggestions OCAB
1. supprimer les sources `ecominero` et `valobat`
1. Pour vérifier que ecomaison est aligné avec le fichier sur koumoul, faire à nouveau tourner la source `ecomaison`

La source `valdelia` ayant tournée récemment, je ne pense pas qu'il soit nécessaire de faire tourner cette source à nouveau
