### PR TITLE
Ajout de context pour les suggestions d'acteur fermé

### DIFF
--- a/dags/enrich/tasks/business_logic/enrich_dbt_model_to_suggestions.py
+++ b/dags/enrich/tasks/business_logic/enrich_dbt_model_to_suggestions.py
@@ -78,10 +78,20 @@ def changes_prepare_rgpd(
         )
     )
     contexte = {
-        "statut": row[COLS.ACTEUR_STATUT],
         "noms d'origine": row[COLS.ACTEUR_NOMS_ORIGINE],
+        "statut": row[COLS.ACTEUR_STATUT],
     }
     return changes, contexte
+
+
+def _get_closed_row_contexte(row: dict) -> dict:
+    return {
+        "nom": row[COLS.ACTEUR_NOM],
+        "statut": row[COLS.ACTEUR_STATUT],
+        "adresse": row[COLS.ACTEUR_ADRESSE],
+        "code_postal": row[COLS.ACTEUR_CODE_POSTAL],
+        "ville": row[COLS.ACTEUR_VILLE],
+    }
 
 
 def changes_prepare_closed_not_replaced(
@@ -113,7 +123,7 @@ def changes_prepare_closed_not_replaced(
             reason="SIRET & SIREN fermés, 0 remplacement trouvé",
         )
     )
-    contexte = {}  # changes are self-explanatory
+    contexte = _get_closed_row_contexte(row)
     return changes, contexte
 
 
@@ -148,7 +158,7 @@ def changes_prepare_closed_replaced(
         )
     ]
 
-    contexte = {}  # changes are self-explanatory
+    contexte = _get_closed_row_contexte(row)
     return changes, contexte
 
 

--- a/dags_unit_tests/enrich/tasks/test_enrich_suggestions_closed.py
+++ b/dags_unit_tests/enrich/tasks/test_enrich_suggestions_closed.py
@@ -40,6 +40,10 @@ class TestEnrichActeursClosedSuggestions:
                 COLS.ACTEUR_ID_EXTERNE: ["ext_a01", "ext_a02"],
                 COLS.ACTEUR_SIRET: ["00000000000001", "00000000000002"],
                 COLS.ACTEUR_NOM: ["AVANT a01", "AVANT a02"],
+                COLS.ACTEUR_STATUT: ["ACTIF", "ACTIF"],
+                COLS.ACTEUR_ADRESSE: ["1 rue Nantes", "2 rue Nantes"],
+                COLS.ACTEUR_CODE_POSTAL: ["35001", "35002"],
+                COLS.ACTEUR_VILLE: ["Rennes", "Rennes"],
                 COLS.ACTEUR_TYPE_ID: [atype.pk, atype.pk],
                 COLS.ACTEUR_SOURCE_ID: [source.pk, source.pk],
                 COLS.SUGGEST_COHORT: [COHORTS.CLOSED_NOT_REPLACED] * 2,
@@ -52,6 +56,11 @@ class TestEnrichActeursClosedSuggestions:
             {
                 # Acteurs data
                 COLS.ACTEUR_ID: ["a1", "a2", "a3"],
+                COLS.ACTEUR_NOM: ["nom 1", "nom 2", "nom 3"],
+                COLS.ACTEUR_STATUT: ["ACTIF", "ACTIF", "ACTIF"],
+                COLS.ACTEUR_ADRESSE: ["1 rue Nantes", "2 rue Nantes", "3 rue Nantes"],
+                COLS.ACTEUR_CODE_POSTAL: ["35001", "35002", "35003"],
+                COLS.ACTEUR_VILLE: ["Rennes", "Rennes", "Rennes"],
                 COLS.ACTEUR_ID_EXTERNE: ["ext_a1", "ext_a2", "ext_a3"],
                 # We test 1 acteur of each cohort with a parent, and
                 # the case with no parent


### PR DESCRIPTION
# Description succincte du problème résolu

Mattermost : demande de @chrischarousset -> https://mattermost.incubateur.net/fabnum-mte/pl/e8me3e3w5389jj4jd4ed4gpyko


**🗺️ contexte**: Admin - Suggestion

**💡 quoi**: Ajouter le nom de l'acteur et quelques informations lors de la proposition de fermeture d'acteur

**🎯 pourquoi**: aider à la prise de décision

**🤔 comment**: Ajout d'information dans la colonne "données initiales"

## Exemple résultats / UI / Data

![CleanShot 2025-05-20 at 12 38 33@2x](https://github.com/user-attachments/assets/71e9fe12-e1f4-4082-9beb-bc198ddab2ec)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
