### PR TITLE
Correction de la synchro de la base de données

### DIFF
--- a/scripts/restore_prod_to_preprod.sh
+++ b/scripts/restore_prod_to_preprod.sh
@@ -31,8 +31,10 @@ tar --extract --verbose --file="${ARCHIVE_NAME}"
 
 # 8. Restore the data:
 #   Drop and create the public schema
-psql -d "${PREPROD_DATABASE_URL}" -c "DROP SCHEMA IF EXISTS public CASCADE;"
 psql -d "${PREPROD_DATABASE_URL}" -c "CREATE SCHEMA IF NOT EXISTS public;"
+for table in $(psql "${PREPROD_DATABASE_URL}" -t -c "SELECT \"tablename\" FROM pg_tables WHERE schemaname='public'"); do
+     psql "${PREPROD_DATABASE_URL}" -c "DROP TABLE IF EXISTS \"${table}\" CASCADE;"
+done
 
 #   Create extensions because they are not restored by pg_restore
 psql -d "${PREPROD_DATABASE_URL}" -f scripts/sql/create_extensions.sql


### PR DESCRIPTION
# Description succincte du problème résolu

Sentry : [RevisionActeur.MultipleObjectsReturned](https://sentry.incubateur.net/organizations/betagouv/issues/174682/?environment=staging&project=115&query=is%3Aunresolved&referrer=issue-stream&stream_index=0)

**🗺️ contexte**: Github action

**💡 quoi**: Correction synchro de la base de prod vers la preprod

**🎯 pourquoi**: c'est cassé

**🤔 comment**: suppression de toutes les tables du schema `public` au lieu de supprimer le schema car on a pas le droit

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
