### PR TITLE
Gestion du hash de la lib GH action peaceiris/actions-gh-pages

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -35,7 +35,7 @@ jobs:
         poetry run make build-docs
 
     - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v4
+      uses: peaceiris/actions-gh-pages@e9c66a37f080288a11235e32cbe2dc5fb3a679cc # v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./_build/html  # Path to your built HTML files
+        publish_dir: ./_build  # Path to your built HTML files


### PR DESCRIPTION
# Description succincte du problème résolu

GitHub Security : [Unpinned tag for a non-immutable Action in workflow](https://github.com/incubateur-ademe/quefairedemesobjets/security/code-scanning/103)

**🗺️ contexte**: Github action

**💡 quoi**: Correction faille de sécurité

**🎯 pourquoi**: c'est mieux de pin les lib GA avec un hash de commit

**🤔 comment**: 

- Pin avec un hash de commit
- On en profite pour modifier un tout petit peu la publication car on ne lit pas dans le bon repertoire après compilation de la doc

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
