### PR TITLE
Résolution des erreur SSL quand une tache dure trop longtemps

### DIFF
--- a/dags/.env.template
+++ b/dags/.env.template
@@ -40,6 +40,7 @@ AIRFLOW__SCHEDULER__ENABLE_HEALTH_CHECK='true'
 
 ## DATABASE
 AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@airflow-db/airflow # pragma: allowlist secret
+AIRFLOW__DATABASE__SQL_ALCHEMY_CONNECT_ARGS=airflow_local_settings.keepalive_kwargs
 
 ### CONNECTOR
 AIRFLOW_CONN_QFDMO_DJANGO_DB='postgres://qfdmo:qfdmo@lvao-db:5432/qfdmo' # pragma: allowlist secret

--- a/dags/airflow_local_settings.py
+++ b/dags/airflow_local_settings.py
@@ -1,0 +1,6 @@
+keepalive_kwargs = {
+    "keepalives": 1,  # enable keepalive
+    "keepalives_idle": 60,  # idle time before sending keepalive
+    "keepalives_interval": 60,  # interval between keepalive packets
+    "keepalives_count": 5,  # number of keepalive packets to send before closing
+}


### PR DESCRIPTION
# Description succincte du problème résolu

Erreur :
![CleanShot 2025-05-27 at 09 10 25@2x](https://github.com/user-attachments/assets/f7e97f86-855a-4141-8c1d-3edc847b2a6e)

Préconisation Airflow : 
https://airflow.apache.org/docs/apache-airflow/stable/howto/set-up-database.html
https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html cf. AIRFLOW__DATABASE__SQL_ALCHEMY_CONNECT_ARGS

Chargement de la configuration dans les logs : 

```
airflow-scheduler-1  | [2025-05-27T07:07:15.104+0000] {settings.py:771} INFO - Loaded airflow_local_settings from /opt/airflow/dags/airflow_local_settings.py .
```

On espère que ça va résoudre le problème 🤞 

**🗺️ contexte**: Airflow

**💡 quoi**: Erreur SSL en fin de tache lors de la connexion à la DB

**🎯 pourquoi**: la connexion n'est pas restée ouverte

**🤔 comment**: Ajout de configuration pour garder la connexion ouverte

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
