### PR TITLE
Ajouter le tiret comme separateur possible dans une adresse BAN

### DIFF
--- a/dags/sources/tasks/transform/transform_df.py
+++ b/dags/sources/tasks/transform/transform_df.py
@@ -34,7 +34,8 @@ MANDATORY_COLUMNS_AFTER_NORMALISATION = [
     "acteur_type_code",
     "statut",
 ]
-REGEX_BAN_SEPARATORS = r"\s,;"
+REGEX_BAN_SEPARATORS = r"\s,;-"
+STRIP_BAN = REGEX_BAN_SEPARATORS.replace("\\s", " ")
 
 
 def merge_duplicates(
@@ -385,16 +386,16 @@ def _address_details_extract(
     # Pattern pour capturer les codes postaux sans adresse
     pattern2 = re.compile(rf"(\d{{4,5}})[{REGEX_BAN_SEPARATORS}]*(.*)")
     if match := pattern1.search(address_str):
-        address = match.group(1).strip() if match.group(1) else ""
-        postal_code = match.group(2).strip() if match.group(2) else ""
-        city = match.group(3).strip() if match.group(3) else ""
+        address = match.group(1).strip(STRIP_BAN) if match.group(1) else ""
+        postal_code = match.group(2).strip(STRIP_BAN) if match.group(2) else ""
+        city = match.group(3).strip(STRIP_BAN) if match.group(3) else ""
     elif match := pattern2.search(address_str):
-        postal_code = match.group(1).strip() if match.group(1) else ""
-        city = match.group(2).strip() if match.group(2) else ""
+        postal_code = match.group(1).strip(STRIP_BAN) if match.group(1) else ""
+        city = match.group(2).strip(STRIP_BAN) if match.group(2) else ""
 
     if city:
         city = city.title()
-        city = city.replace("*", "").strip()
+        city = city.replace("*", "").strip(STRIP_BAN)
 
     # Ajouter un zéro si le code postal a quatre chiffres
     postal_code = clean_code_postal(postal_code, None)

--- a/dags/tests/sources/tasks/transform/test_transform_df.py
+++ b/dags/tests/sources/tasks/transform/test_transform_df.py
@@ -621,6 +621,14 @@ class TestCleanAdresse:
                     "ville": "Heyrieux",
                 },
             ),
+            (
+                "Rue des Balmes - 38540 - HEYRIEUX",
+                {
+                    "adresse": "Rue des Balmes",
+                    "code_postal": "38540",
+                    "ville": "Heyrieux",
+                },
+            ),
         ],
     )
     def test_clean_adresse_without_ban(


### PR DESCRIPTION
# Description succincte du problème résolu

Mattermost : [Peux-tu gérer ce formating d'adresses OCAB dans une future PR, @nicoo stp ?](https://mattermost.incubateur.net/betagouv/pl/13obtzq8fp8j7ymusrfej6upea)

**🗺️ contexte**: Airflow Source

**💡 quoi**: Permettre d'utiliser le tiret `-` comme séparateur dans l'adresse BAN

**🎯 pourquoi**: OCAB l'utilise

**🤔 comment**: 

- Ajout du tiret
- Strip les chaines de caractères adresse, CP, ville avec la liste des séparateurs

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
