### PR TITLE
Mettre l'option `Autour de moi` en dernière position

### DIFF
--- a/static/to_compile/controllers/carte/address_autocomplete_controller.ts
+++ b/static/to_compile/controllers/carte/address_autocomplete_controller.ts
@@ -31,7 +31,7 @@ class AdresseAutocompleteController extends AutocompleteController {
     this.autocompleteList = this.createAutocompleteList()
     this.allAvailableOptions = data
     for (let i = 0; i < this.allAvailableOptions.length; i++) {
-      if (countResult >= this.maxOptionDisplayedValue) break
+      if (countResult >= this.maxOptionDisplayedValue + 1) break
       countResult++
       this.addOption(regexPattern, this.allAvailableOptions[i])
     }
@@ -161,15 +161,16 @@ class AdresseAutocompleteController extends AutocompleteController {
     return await fetch(`https://api-adresse.data.gouv.fr/search/?q=${value}`)
       .then((response) => response.json())
       .then((data) => {
-        let labels = [["Autour de moi", 9999, 9999].join(SEPARATOR)].concat(
-          data.features.map((feature: any) => {
+        let labels = data.features
+          .slice(0, this.maxOptionDisplayedValue)
+          .map((feature: any) => {
             return [
               feature.properties.label,
               feature.geometry.coordinates[1],
               feature.geometry.coordinates[0],
             ].join(SEPARATOR)
-          }),
-        )
+          })
+          .concat([["Autour de moi", 9999, 9999].join(SEPARATOR)])
         return labels
       })
       .catch((error) => {


### PR DESCRIPTION
# Description succincte du problème résolu

## Proposition :

Quand je tape une adresse et que je tape sur la touche "entrer", l'application cherche à me localiser. En mettant l'option `Autour de moi`à la fin de la liste, il prendra le premier element de la liste qui match ma recherche

![CleanShot 2025-06-02 at 10 24 47](https://github.com/user-attachments/assets/06ed2243-4df4-4ecf-8047-a1841eab2fbe)

**🗺️ contexte**: Carte

**💡 quoi**: Mettre l'option `Autour de moi` en dernière position

**🎯 pourquoi**: Eviter que la touche `Entrer` cherche à nous localiser alors qu'on est en train de chercher une adresse 

**🤔 comment**: `Autour de moi` en dernière position, par défaut, l'appuie sur la touche `entrer` prend le premier de la liste, soit la recherche en cours

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
