### PR TITLE
Ajout du context dans les réponses quand on cherche une ville

### DIFF
--- a/static/to_compile/controllers/carte/address_autocomplete_controller.ts
+++ b/static/to_compile/controllers/carte/address_autocomplete_controller.ts
@@ -2,7 +2,6 @@ import AutocompleteController from "./autocomplete_controller"
 
 class AdresseAutocompleteController extends AutocompleteController {
   controllerName: string = "address-autocomplete"
-  allAvailableOptions: Array<object> = []
 
   static targets = AutocompleteController.targets.concat([
     "longitude",
@@ -27,10 +26,10 @@ class AdresseAutocompleteController extends AutocompleteController {
     this.hideAutocompleteList()
     this.autocompleteList = this.createAutocompleteList()
     this.allAvailableOptions = data
-    for (let i = 0; i < this.allAvailableOptions.length; i++) {
+    for (let i = 0; i < data.length; i++) {
       if (countResult >= this.maxOptionDisplayedValue + 1) break
       countResult++
-      this.addOption(regexPattern, this.allAvailableOptions[i])
+      this.addOption(regexPattern, data[i])
     }
     if (this.autocompleteList.childElementCount > 0) {
       this.currentFocusedOptionIndexValue = 0

--- a/static/to_compile/controllers/carte/address_autocomplete_controller.ts
+++ b/static/to_compile/controllers/carte/address_autocomplete_controller.ts
@@ -1,10 +1,8 @@
 import AutocompleteController from "./autocomplete_controller"
 
-const SEPARATOR = "||"
-
 class AdresseAutocompleteController extends AutocompleteController {
   controllerName: string = "address-autocomplete"
-  allAvailableOptions: Array<string> = []
+  allAvailableOptions: Array<object> = []
 
   static targets = AutocompleteController.targets.concat([
     "longitude",

--- a/static/to_compile/controllers/carte/autocomplete_controller.ts
+++ b/static/to_compile/controllers/carte/autocomplete_controller.ts
@@ -174,7 +174,31 @@ export default abstract class extends Controller<HTMLElement> {
   }
 
   addOption(regexPattern: RegExp, option: any) {
-    // Implement this method in your controller
+    let b = document.createElement("DIV")
+    b.classList.add("qf-flex", "qf-flex-col", "sm:qf-flex-row", "sm:qf-justify-between")
+
+    let label = document.createElement("span")
+
+    /*make the matching letters bold:*/
+    const label_text = option.label
+    const newText = label_text.replace(regexPattern, "<strong>$&</strong>")
+    label.innerHTML = newText
+    b.appendChild(label)
+
+    if (option.sub_label != null) {
+      const sub_label = document.createElement("span")
+      sub_label.classList.add("fr-text--sm", "fr-m-0", "qf-italic")
+      sub_label.innerHTML = option.sub_label
+      b.appendChild(sub_label)
+    }
+
+    const input = document.createElement("input")
+    input.setAttribute("type", "hidden")
+    input.setAttribute("value", JSON.stringify(option))
+    b.appendChild(input)
+    b.setAttribute("data-action", "click->" + this.controllerName + "#selectOption")
+    b.setAttribute("data-on-focus", "true")
+    this.autocompleteList.appendChild(b)
   }
 
   createAutocompleteList() {

--- a/static/to_compile/controllers/carte/autocomplete_controller.ts
+++ b/static/to_compile/controllers/carte/autocomplete_controller.ts
@@ -3,12 +3,10 @@ import debounce from "lodash/debounce"
 
 export default abstract class extends Controller<HTMLElement> {
   controllerName: string = "autocomplete"
-  allAvailableOptions: Array<object> = []
   autocompleteList: HTMLElement
   nbCharToSearchDefault: number = 3
 
-  static targets = ["allAvailableOptions", "input", "option", "spinner"]
-  declare readonly allAvailableOptionsTarget: HTMLScriptElement
+  static targets = ["input", "option", "spinner"]
   declare readonly inputTarget: HTMLInputElement
   declare readonly optionTargets: Array<HTMLElement>
   declare readonly spinnerTarget: HTMLElement
@@ -23,9 +21,6 @@ export default abstract class extends Controller<HTMLElement> {
   declare currentFocusedOptionIndexValue: number
 
   connect() {
-    if (this.allAvailableOptionsTarget.textContent != null) {
-      this.allAvailableOptions = JSON.parse(this.allAvailableOptionsTarget.textContent)
-    }
     if (!this.nbCharToSearchValue) this.nbCharToSearchValue = this.nbCharToSearchDefault
   }
 
@@ -53,14 +48,13 @@ export default abstract class extends Controller<HTMLElement> {
     return this.#getOptionCallback(inputTargetValue)
       .then((data) => {
         this.hideAutocompleteList()
-        this.allAvailableOptions = data
-        if (this.allAvailableOptions.length == 0) return
+        if (data.length == 0) return
 
         this.autocompleteList = this.createAutocompleteList()
-        for (let i = 0; i < this.allAvailableOptions.length; i++) {
+        for (let i = 0; i < data.length; i++) {
           if (countResult >= this.maxOptionDisplayedValue) break
           countResult++
-          this.addOption(regexPattern, this.allAvailableOptions[i])
+          this.addOption(regexPattern, data[i])
         }
         if (this.autocompleteList.childElementCount > 0) {
           this.currentFocusedOptionIndexValue = 0

--- a/static/to_compile/controllers/carte/autocomplete_controller.ts
+++ b/static/to_compile/controllers/carte/autocomplete_controller.ts
@@ -3,7 +3,7 @@ import debounce from "lodash/debounce"
 
 export default abstract class extends Controller<HTMLElement> {
   controllerName: string = "autocomplete"
-  allAvailableOptions = []
+  allAvailableOptions: Array<object> = []
   autocompleteList: HTMLElement
   nbCharToSearchDefault: number = 3
 

--- a/static/to_compile/controllers/carte/ss_cat_object_autocomplete_controller.ts
+++ b/static/to_compile/controllers/carte/ss_cat_object_autocomplete_controller.ts
@@ -1,6 +1,6 @@
+import posthog from "posthog-js"
 import AutocompleteController from "./autocomplete_controller"
 import { SSCatObject } from "./types"
-import posthog from "posthog-js"
 
 export default class extends AutocompleteController {
   controllerName: string = "ss-cat-object-autocomplete"
@@ -60,22 +60,12 @@ export default class extends AutocompleteController {
     while (target && target.nodeName !== "DIV") {
       target = target.parentNode as HTMLElement
     }
+    const option = JSON.parse(target.getElementsByTagName("input")[0].value)
+    const labelValue = option.label
+    const subLabelValue = option.sub_label
+    const identifierValue = option.identifier
 
-    const labelElement = target.querySelector(
-      '[data-type-name="label"]',
-    ) as HTMLInputElement
-    const labelValue = labelElement ? labelElement.value : ""
     this.inputTarget.value = labelValue
-
-    const subLabelElement = target.querySelector(
-      '[data-type-name="subLabel"]',
-    ) as HTMLInputElement
-    const subLabelValue = subLabelElement ? subLabelElement.value : ""
-
-    const identifierElement = target.querySelector(
-      '[data-type-name="identifier"]',
-    ) as HTMLInputElement
-    const identifierValue = identifierElement ? identifierElement.value : undefined
     this.ssCatTarget.value = identifierValue
 
     posthog.capture("object_select", {
@@ -88,48 +78,6 @@ export default class extends AutocompleteController {
     this.hideAutocompleteList()
     // Call outlet
     this.dispatch("optionSelected")
-  }
-
-  addOption(regexPattern: RegExp, option: SSCatObject) {
-    //option : this.#allAvailableOptions[i]
-    /*create a DIV element for each matching element:*/
-    let b = document.createElement("DIV")
-    b.classList.add("qf-flex", "qf-flex-col", "sm:qf-flex-row", "sm:qf-justify-between")
-    /*make the matching letters bold:*/
-    // const [data, longitude, latitude] = option.split("||")
-
-    let label = document.createElement("span")
-    const data = option.label
-    const newText = data.replace(regexPattern, "<strong>$&</strong>")
-    label.innerHTML = newText
-    b.appendChild(label)
-
-    if (option.sub_label != null) {
-      const sub_label = document.createElement("span")
-      sub_label.classList.add("fr-text--sm", "fr-m-0", "qf-italic")
-      sub_label.innerHTML = option.sub_label
-      b.appendChild(sub_label)
-    }
-
-    // Input hidden
-    const labelInput = document.createElement("input")
-    labelInput.setAttribute("type", "hidden")
-    labelInput.setAttribute("data-type-name", "label")
-    labelInput.setAttribute("value", option.label)
-    b.appendChild(labelInput)
-    const identifierInput = document.createElement("input")
-    identifierInput.setAttribute("type", "hidden")
-    identifierInput.setAttribute("data-type-name", "identifier")
-    identifierInput.setAttribute("value", option.identifier)
-    b.appendChild(identifierInput)
-    const input = document.createElement("input")
-    input.setAttribute("type", "hidden")
-    input.setAttribute("data-type-name", "subLabel")
-    input.setAttribute("value", option.sub_label ? option.sub_label : "")
-    b.appendChild(input)
-    b.setAttribute("data-action", "click->" + this.controllerName + "#selectOption")
-    b.setAttribute("data-on-focus", "true")
-    this.autocompleteList.appendChild(b)
   }
 
   keydownEnter(event: KeyboardEvent): boolean {

--- a/static/to_compile/controllers/carte/ss_cat_object_autocomplete_controller.ts
+++ b/static/to_compile/controllers/carte/ss_cat_object_autocomplete_controller.ts
@@ -1,10 +1,9 @@
 import posthog from "posthog-js"
 import AutocompleteController from "./autocomplete_controller"
-import { SSCatObject } from "./types"
 
 export default class extends AutocompleteController {
   controllerName: string = "ss-cat-object-autocomplete"
-  allAvailableOptions: Array<SSCatObject> = []
+  allAvailableOptions: Array<object> = []
 
   static targets = AutocompleteController.targets.concat(["ssCat"])
   declare readonly ssCatTarget: HTMLInputElement
@@ -88,7 +87,7 @@ export default class extends AutocompleteController {
     return toSubmit
   }
 
-  async #getOptionCallback(value: string): Promise<SSCatObject[]> {
+  async #getOptionCallback(value: string): Promise<object[]> {
     if (value.trim().length < this.nbCharToSearchValue) {
       this.ssCatTarget.value = ""
       return []

--- a/static/to_compile/controllers/carte/ss_cat_object_autocomplete_controller.ts
+++ b/static/to_compile/controllers/carte/ss_cat_object_autocomplete_controller.ts
@@ -3,7 +3,6 @@ import AutocompleteController from "./autocomplete_controller"
 
 export default class extends AutocompleteController {
   controllerName: string = "ss-cat-object-autocomplete"
-  allAvailableOptions: Array<object> = []
 
   static targets = AutocompleteController.targets.concat(["ssCat"])
   declare readonly ssCatTarget: HTMLInputElement
@@ -20,14 +19,13 @@ export default class extends AutocompleteController {
     return this.#getOptionCallback(inputTargetValue)
       .then((data) => {
         this.hideAutocompleteList()
-        this.allAvailableOptions = data
-        if (this.allAvailableOptions.length == 0) return
+        if (data.length == 0) return
 
         this.autocompleteList = this.createAutocompleteList()
-        for (let i = 0; i < this.allAvailableOptions.length; i++) {
+        for (let i = 0; i < data.length; i++) {
           if (countResult >= this.maxOptionDisplayedValue) break
           countResult++
-          this.addOption(regexPattern, this.allAvailableOptions[i])
+          this.addOption(regexPattern, data[i])
         }
         if (this.autocompleteList.childElementCount > 0) {
           this.currentFocusedOptionIndexValue = 0
@@ -35,15 +33,9 @@ export default class extends AutocompleteController {
 
         posthog.capture("object_input", {
           object_requested: inputTargetValue,
-          object_list: this.allAvailableOptions
-            ? this.allAvailableOptions.slice(0, this.maxOptionDisplayedValue)
-            : undefined,
-          first_object: this.allAvailableOptions
-            ? this.allAvailableOptions[0]["label"]
-            : undefined,
-          first_subcategory: this.allAvailableOptions
-            ? this.allAvailableOptions[0]["sub_label"]
-            : undefined,
+          object_list: data ? data.slice(0, this.maxOptionDisplayedValue) : undefined,
+          first_object: data ? data[0]["label"] : undefined,
+          first_subcategory: data ? data[0]["sub_label"] : undefined,
         })
       })
       .then(() => {

--- a/templates/forms/widgets/autocomplete.html
+++ b/templates/forms/widgets/autocomplete.html
@@ -29,11 +29,6 @@
                 {% include "django/forms/widgets/attrs.html" %}
             >
             {% include "forms/widgets/_spinner.html" %}
-            {% block choices %}
-                <script type="application/json" data-{{ widget.data_controller }}-target="allAvailableOptions">
-                    {{ widget.optgroups|options_in_json }}
-                </script>
-            {% endblock choices %}
         </div>
     </div>
     <p data-address-autocomplete-target="displayError" class="fr-error-text fr-mt-1w" style="display:none;">


### PR DESCRIPTION
# Description succincte du problème résolu

## Proposition

Quand on cherche une ville, on n'a pas de précision quand à la région ou au département. je propose d'ajouter le contexte aux résultats de recherche dans ce cas uniquement : ville == label

<img width="519" height="468" alt="CleanShot 2025-08-26 at 18 52 21" src="https://github.com/user-attachments/assets/62032172-396c-4c41-a6cd-52812495fb4d" />

**🗺️ contexte**: Carte

**💡 quoi**: Ajout du context dans les réponses quand on cherche une ville

**🎯 pourquoi**: Savoir quelle ville on sélectionne

**🤔 comment**: 

- Ajout du context à coté du résultat
- Simplification : la fonction "AddOption" est désormais la même pour sousCat et BAN
- Suppression du target AllAvailableOption : je n'ai pas trouvé à quoi il sert, c'est surement du legacy

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
