### PR TITLE
Ne pas prendre en compte le point de localisation pour centrer la carte

### DIFF
--- a/static/to_compile/js/solution_map.ts
+++ b/static/to_compile/js/solution_map.ts
@@ -150,12 +150,6 @@ export class SolutionMap {
         points.push([actor.location.coordinates[1], actor.location.coordinates[0]])
       }
     }, this)
-    if (
-      this.#location.latitude !== undefined &&
-      this.#location.longitude !== undefined
-    ) {
-      points.push([this.#location.latitude, this.#location.longitude])
-    }
     this.fitBounds(points, bboxValue)
   }
 


### PR DESCRIPTION
# Description succincte du problème résolu

## Proposition

Pour éviter ce type de carte quand on explorer avec "Rechercher dans cette zone"
![CleanShot 2025-06-02 at 11 10 28](https://github.com/user-attachments/assets/db2d1b23-4734-43d3-bab2-860f02f7af77)

je propose de ne pas prendre en compte le point de localisation lors du centrage de la carte

![CleanShot 2025-06-02 at 11 12 05](https://github.com/user-attachments/assets/cc495bdc-f9a5-4e62-b6ec-d6dd58c2b556)

Effet de bord possible (mais à mon avis rarisime), le point de localisation peut e pas être présent sur la partie visible de la carte si toute les propositions faites à l'utilisateur sont du même coté 

**🗺️ contexte**: Carte

**💡 quoi**: Ne pas prendre en compte le point de localisation pour centrer la carte

**🎯 pourquoi**: Lors de l'exploration grace au bouton "Rechercher dans cette zone", l'affichage du point de localisation est parfois très ditant et n'apporte pas grand chose puisse que l'utilisateur est en train de parcourir la carte (en tout cas moi ça m'irrite :) )

**🤔 comment**: Suppression du point de localisation quand on fait le fitBounce sur l'ensemble des points de la carte

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
