### PR TITLE
Exporter les données Open Data depuis le schema warehouse

### DIFF
--- a/dags/acteurs/dags/export_opendata.py
+++ b/dags/acteurs/dags/export_opendata.py
@@ -35,6 +35,7 @@ with DAG(
         "bucket_name": "lvao-opendata",
         "remote_dir": "acteurs" if ENVIRONMENT == "prod" else f"acteurs-{ENVIRONMENT}",
         "s3_connection_id": "s3data",
+        "opendata_schema": "warehouse",
         "opendata_table": "exposure_opendata_acteur",
     },
     schedule=SCHEDULES.WEEKLY_AT_1AM,

--- a/dags/acteurs/tasks/airflow_logic/config_management.py
+++ b/dags/acteurs/tasks/airflow_logic/config_management.py
@@ -5,4 +5,5 @@ class ExportOpendataConfig(BaseModel):
     bucket_name: str
     remote_dir: str
     s3_connection_id: str
+    opendata_schema: str
     opendata_table: str

--- a/dags/acteurs/tasks/business_logic/export_opendata_csv_to_s3.py
+++ b/dags/acteurs/tasks/business_logic/export_opendata_csv_to_s3.py
@@ -30,7 +30,8 @@ def export_opendata_csv_to_s3(export_opendata_config: ExportOpendataConfig):
                     "-d",
                     os.environ.get("POSTGRES_DB") or "",
                     "-c",
-                    f"COPY {export_opendata_config.opendata_table}"
+                    f"COPY {export_opendata_config.opendata_schema}."
+                    f"{export_opendata_config.opendata_table}"
                     " TO STDOUT WITH CSV HEADER",
                 ],
                 env={"PGPASSWORD": os.environ.get("POSTGRES_PASSWORD") or ""},


### PR DESCRIPTION
# Description succincte du problème résolu

Retour de Delphine : la fonctonnalité des sous-cat en colonne n'est pas disp en prod.
En fait, c'est l'export qui est cassé car il ne lit pas dans la table du schema `warehouse`

**🗺️ contexte**: Airflow Export opendata

**💡 quoi**: Correction de l'export cassé

**🎯 pourquoi**: Car il ne marche plus depuis que la tables est sur le schema warehouse

**🤔 comment**: Ajout du schema à la config du DAG e utilisation de ce schema pour l'export


## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
