### PR TITLE
Grouper les mises à jour de la ligrairie parcel par dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,11 @@ updates:
       interval: "weekly"
       day: "tuesday"
       time: "06:00" # UTC
+    groups:
+      parcel:
+        patterns:
+          - "@parcel/*"
+          - "parcel"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
# Description succincte du problème résolu

Tenter une configuration de dependabot pour grouper les mise à jour des librairies parcel

**🗺️ contexte**: Github Action - Dependabot

**💡 quoi**: Grouper les mises à jour de la ligrairie parcel par dependabot

**🎯 pourquoi**: Eviter les PR dependabot qui sont en erreur à cause des mise à jour Parcel

**🤔 comment**: ajout du paramètre `groups` dans a config npm de dependabot

cf. https://docs.github.com/fr/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
