### PR TITLE
Toujours définir l'url canonique, même si c'est la même url

### DIFF
--- a/qfdmd/templatetags/qfdmd_tags.py
+++ b/qfdmd/templatetags/qfdmd_tags.py
@@ -31,11 +31,7 @@ def canonical_url(context: dict) -> dict:
     if "request" in context:
         request = context["request"]
         path = request.build_absolute_uri(request.path)
-        canonical_url = (
-            path.replace(request.get_host(), settings.CANONICAL_HOST)
-            if settings.CANONICAL_HOST != request.get_host()
-            else None
-        )
+        canonical_url = path.replace(request.get_host(), settings.CANONICAL_HOST)
 
     return {"canonical_url": canonical_url}
 


### PR DESCRIPTION
# Description succincte du problème résolu

Alert Search console

**🗺️ contexte**: SEO

**💡 quoi**: forcer l'URL canonique

**🎯 pourquoi**: petite embrouille lors du passage en prod qui fait qu'on est indexé à moité sur quefairedemesdechets et quefairedemesobjets

**🤔 comment**: toujours définir une url canonique

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
