### PR TITLE
♼ Passer l'infotri en image décorative

### DIFF
--- a/templates/components/produit/_infotri.html
+++ b/templates/components/produit/_infotri.html
@@ -5,7 +5,7 @@
         <ul class="qf-list-none qf-flex md:qf-flex-row qf-flex-col qf-gap-2w qf-m-0">
             {% for infotri in produit.infotri %}
                 <li class="qf-h-[80px]">
-                {% image infotri.value original preserve-svg height="80" width="auto" class="qf-object-left qf-max-w-full" %}
+                {% image infotri.value original preserve-svg height="80" width="auto" class="qf-object-left qf-max-w-full" alt="" %}
                 </li>
             {% endfor %}
         </ul>


### PR DESCRIPTION
# Description succincte du problème résolu

Embarqué dans #1587

Cf https://www.notion.so/accelerateur-transition-ecologique-ademe/Passer-les-info-tris-en-image-d-corative-sur-l-assistant-1f36523d57d7809bbd34dac0228a170c?source=copy_link

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: accessibilité

**💡 quoi**: on ne met pas de alt sur l'infotri suite aux recos de ethic first

**🎯 pourquoi**: pour être plsu accessible

**🤔 comment**: on définit l'attribut alt à `""`

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
