### PR TITLE
DEPENDABOT : grouper les mises à jour de jest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,9 @@ updates:
         patterns:
           - "@parcel/*"
           - "parcel"
+      jest:
+        patterns:
+          - "*jest*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
# Description succincte du problème résolu

A cause de dependabot, mise à jour de `jest` qui fini en erreur : https://github.com/incubateur-ademe/quefairedemesobjets/pull/1679

**🗺️ contexte**: Dependabot

**💡 quoi**: Grouper les mise à jour des librairies JEST

**🎯 pourquoi**: Car sinon, elles finnissent en erreur

**🤔 comment**: Config dependabot

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
