### PR TITLE
Option permettant de garder les données du parent lors d'un clustering avec parent existant

### DIFF
--- a/dags/cluster/config/model.py
+++ b/dags/cluster/config/model.py
@@ -2,6 +2,7 @@
 
 from cluster.config.constants import FIELDS_PROTECTED
 from pydantic import BaseModel, Field, field_validator, model_validator
+
 from utils.airflow_params import airflow_params_dropdown_selected_to_ids
 
 
@@ -50,6 +51,7 @@ class ClusterConfig(BaseModel):
     dedup_enrich_priority_sources: list[str]
     dedup_enrich_priority_source_ids: list[int]  # to calculate from above
     dedup_enrich_keep_empty: bool
+    dedup_enrich_keep_parent_data_by_default: bool
 
     # ---------------------------------------
     # Listings & Mappings

--- a/dags/cluster/dags/cluster_acteur_suggestions.py
+++ b/dags/cluster/dags/cluster_acteur_suggestions.py
@@ -269,9 +269,20 @@ PARAMS = {
     "dedup_enrich_keep_empty": Param(
         False,
         type="boolean",
-        description_md=r"""**🗋 CONSERVER LE VIDE**: si OUI et qu'une valeur
+        description_md=r"""**∅ CONSERVER LE VIDE**: si OUI et qu'une valeur
         vide est rencontrée sur une source prioritaire, alors elle sera
         conservée""",
+    ),
+    "dedup_enrich_keep_parent_data_by_default": Param(
+        True,
+        type="boolean",
+        description_md=r"""
+** CONSERVER LES DONNÉES DU PARENT**: si OUI, les données du parent seront conservées.
+
+Lorsque l'option `dedup_enrich_keep_empty` est:
+ - VRAI, toutes les données du parent même vides sont conservées
+ - FAUX, seules les données non-vides du parent sont conservées
+""",
     ),
 }
 

--- a/dags/cluster/tasks/airflow_logic/cluster_acteurs_parents_choose_data_task.py
+++ b/dags/cluster/tasks/airflow_logic/cluster_acteurs_parents_choose_data_task.py
@@ -9,6 +9,7 @@ from cluster.config.xcoms import XCOMS, xcom_pull
 from cluster.tasks.business_logic.cluster_acteurs_parents_choose_data import (
     cluster_acteurs_parents_choose_data,
 )
+
 from utils import logging_utils as log
 
 logger = logging.getLogger(__name__)
@@ -51,6 +52,7 @@ def cluster_acteurs_parents_choose_data_wrapper(ti) -> None:
         exclude_source_ids=config.dedup_enrich_exclude_source_ids,
         prioritize_source_ids=config.dedup_enrich_priority_source_ids,
         keep_empty=config.dedup_enrich_keep_empty,
+        keep_parent_data_by_default=config.dedup_enrich_keep_parent_data_by_default,
     )
 
     logging.info(log.banner_string("🏁 Résultat final de cette tâche"))

--- a/dags/cluster/tasks/business_logic/cluster_acteurs_parents_choose_data.py
+++ b/dags/cluster/tasks/business_logic/cluster_acteurs_parents_choose_data.py
@@ -3,17 +3,10 @@ from typing import Any
 
 import pandas as pd
 from cluster.config.constants import COL_PARENT_DATA_NEW, FIELDS_PARENT_DATA_EXCLUDED
-from django.forms.models import model_to_dict
+
 from utils.django import django_setup_full
 
 django_setup_full()
-
-from data.models.change import COL_CHANGE_MODEL_NAME  # noqa: E402
-from data.models.changes import (  # noqa: E402
-    ChangeActeurCreateAsParent,
-    ChangeActeurKeepAsParent,
-)
-from qfdmo.models.acteur import Acteur, DisplayedActeur, RevisionActeur  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -71,77 +64,84 @@ def field_pick_value(
     return None
 
 
-def parent_choose_data(
-    parent_data_before: dict,
-    acteurs_revision: list[dict],
-    acteurs_base: list[dict],
-    fields_to_include: list[str],
-    exclude_source_ids: list[int],
-    prioritize_source_ids: list[int],
-    keep_empty: bool = False,
-) -> dict:
-    """Selects and assigns data for a parent. Since the data is
-    intended to create or enrich a revision, we ensure that the chosen data
-    satisfies the RevisionActor model.
-
-    Args:
-        acteurs (list[dict]): list of acteurs to consider = Priority 1
-        fields_to_include (list[str]): fields to include in the result = Fallback
-        exclusion_always_sources (list[str]): sources to exclude for all fields
-        priority_always_sources (list[str]): sources to prioritize for all fields
-        keep_empty (bool): if True, keep None values in the result if they come
-            from priority sources
-    """
-
-    # Priority = as per priority list OR rest by default
-    def source_priority(a):
-        return (
-            prioritize_source_ids.index(a["source_id"])
-            if a["source_id"] in prioritize_source_ids
-            else float("inf")
-        )
-
-    # Acteurs to consider: first revisions, then base, but not from excluded sources
-    acteurs = []
-    acteurs += [a for a in acteurs_revision if a["source_id"] not in exclude_source_ids]
-    acteurs.sort(key=source_priority)
-    acteurs += [a for a in acteurs_base if a["source_id"] not in exclude_source_ids]
-    acteurs.sort(key=source_priority)
-
-    # Fields: make sure we don't include unwanted fields
-    fields = fields_to_include_clean(fields_to_include)
-
-    result = {}
-    for field in fields:
-        value_old = parent_data_before.get(field)
-        values = [a.get(field) for a in acteurs]
-        value_new = field_pick_value(
-            field,
-            values,
-            keep_empty,
-        )
-        if value_new == value_old:
-            continue
-        if value_new is None and not keep_empty:
-            continue
-        result[field] = value_new
-
-    return result
-
-
 def cluster_acteurs_parents_choose_data(
     df_clusters: pd.DataFrame,
     fields_to_include: list[str],
     exclude_source_ids: list[int],
     prioritize_source_ids: list[int],
     keep_empty: bool = False,
+    keep_parent_data_by_default: bool = True,
 ) -> pd.DataFrame:
+
+    from django.db.models import QuerySet
+
+    from data.models.change import COL_CHANGE_MODEL_NAME
+    from data.models.changes import ChangeActeurCreateAsParent, ChangeActeurKeepAsParent
+    from qfdmo.models.acteur import Acteur, RevisionActeur
+
+    def parent_choose_data(
+        parent: RevisionActeur | None,
+        acteurs_revision: QuerySet[RevisionActeur],
+        acteurs_base: QuerySet[Acteur],
+        fields_to_include: list[str],
+        exclude_source_ids: list[int],
+        prioritize_source_ids: list[int],
+        keep_empty: bool = False,
+        keep_parent_data_by_default: bool = True,
+    ) -> dict:
+        """Selects and assigns data for a parent. Since the data is
+        intended to create or enrich a revision, we ensure that the chosen data
+        satisfies the RevisionActor model.
+
+        Args:
+            acteurs (list[dict]): list of acteurs to consider = Priority 1
+            fields_to_include (list[str]): fields to include in the result = Fallback
+            exclusion_always_sources (list[str]): sources to exclude for all fields
+            priority_always_sources (list[str]): sources to prioritize for all fields
+            keep_empty (bool): if True, keep None values in the result if they come
+                from priority sources
+        """
+
+        # Priority = as per priority list OR rest by default
+        def source_priority(a):
+            return (
+                prioritize_source_ids.index(a.source.id)
+                if a.source and a.source.id in prioritize_source_ids
+                else float("inf")
+            )
+
+        # Acteurs to consider: first revisions, then base, but not from excluded sources
+        acteurs = list(acteurs_revision) + list(acteurs_base)
+        acteurs.sort(key=source_priority)
+        if parent and keep_parent_data_by_default:
+            acteurs = [parent] + acteurs
+
+        # Fields: make sure we don't include unwanted fields
+        fields = fields_to_include_clean(fields_to_include)  # TODO : check which
+
+        result = {}
+        for field in fields:
+            value_old = getattr(parent, field) if parent else None
+            values = [getattr(a, field) for a in acteurs]
+            value_new = field_pick_value(
+                field,
+                values,
+                keep_empty,
+            )
+            if value_new == value_old:
+                continue
+            if value_new is None and not keep_empty:
+                continue
+            result[field] = value_new
+
+        return result
+
     """For all selected parents in clusters, select the data to use"""
     fields = fields_to_include_clean(fields_to_include)
     fields += ["source_id"]
 
     df_clusters[COL_PARENT_DATA_NEW] = None
-    for cluster_id, df_cluster in df_clusters.groupby("cluster_id"):
+    for _, df_cluster in df_clusters.groupby("cluster_id"):
         filter_parent = df_cluster[COL_CHANGE_MODEL_NAME].isin(
             [
                 ChangeActeurCreateAsParent.name(),
@@ -156,38 +156,40 @@ def cluster_acteurs_parents_choose_data(
         assert len(df_parents) == 1, "Should have 1 parent per cluster"
         parent_iloc = df_parents.index[0]
         parent_id = df_parents["identifiant_unique"].iloc[0]
-        parent_data_before = {}
 
         df_acteurs = df_cluster[~filter_parent]
         acteur_ids = df_acteurs["identifiant_unique"].unique()
 
         # We only need to get the parent's before data IF
         # it was an existing one (i.e. one to keep)
+        parent = None
         if (
             df_parents[COL_CHANGE_MODEL_NAME].values[0]
             == ChangeActeurKeepAsParent.name()
         ):
             try:
-                parent = DisplayedActeur.objects.get(pk=parent_id)
-            except DisplayedActeur.DoesNotExist:
+                parent = RevisionActeur.objects.get(pk=parent_id)
+            except RevisionActeur.DoesNotExist:
                 ptype = df_parents[COL_CHANGE_MODEL_NAME].values[0]
-                raise ValueError(f"Parent {ptype} {parent_id} pas dans displayed!!!")
-            parent_data_before = model_to_dict(parent)
+                raise ValueError(f"Parent {ptype} {parent_id} pas dans revision!!!")
 
         # We construct a list of acteurs, 1st from revision (higher prio
         # as might contain business-approved changes) and then from base
-        acteurs_revision = RevisionActeur.objects.filter(pk__in=acteur_ids).values(
-            *fields
+        acteurs_revision = RevisionActeur.objects.filter(pk__in=acteur_ids).exclude(
+            source__id__in=exclude_source_ids
         )
-        acteurs_base = Acteur.objects.filter(pk__in=acteur_ids).values(*fields)
+        acteurs_base = Acteur.objects.filter(pk__in=acteur_ids).exclude(
+            source__id__in=exclude_source_ids
+        )
         parent_data_new = parent_choose_data(
-            parent_data_before=parent_data_before,
-            acteurs_revision=list(acteurs_revision),
-            acteurs_base=list(acteurs_base),
+            parent=parent,
+            acteurs_revision=acteurs_revision,
+            acteurs_base=acteurs_base,
             fields_to_include=fields,
             exclude_source_ids=exclude_source_ids,
             prioritize_source_ids=prioritize_source_ids,
             keep_empty=keep_empty,
+            keep_parent_data_by_default=keep_parent_data_by_default,
         )
 
         df_clusters.at[parent_iloc, COL_PARENT_DATA_NEW] = parent_data_new

--- a/dags/tests/cluster/config/test_model.py
+++ b/dags/tests/cluster/config/test_model.py
@@ -29,6 +29,7 @@ class TestClusterConfigModel:
             "dedup_enrich_exclude_sources": ["source1 (id=1)"],
             "dedup_enrich_priority_sources": ["source1 (id=1)"],
             "dedup_enrich_keep_empty": False,
+            "dedup_enrich_keep_parent_data_by_default": True,
             "mapping_sources": {"source1": 1, "source2": 2, "source3": 3},
             "mapping_acteur_types": {"atype1": 1, "atype2": 2, "atype3": 3},
         }

--- a/dags/tests/cluster/tasks/business_logic/test_cluster_acteurs_parents_choose_data.py
+++ b/dags/tests/cluster/tasks/business_logic/test_cluster_acteurs_parents_choose_data.py
@@ -1,32 +1,77 @@
-import numpy as np
 import pandas as pd
 import pytest
 from django.contrib.gis.geos import Point
 
-from dags.cluster.config.constants import COL_PARENT_DATA_NEW
 from dags.cluster.tasks.business_logic.cluster_acteurs_parents_choose_data import (
     cluster_acteurs_parents_choose_data,
     field_pick_value,
-    parent_choose_data,
+    fields_to_include_clean,
+    value_is_empty,
+)
+from data.models.changes.acteur_create_as_parent import ChangeActeurCreateAsParent
+from data.models.changes.acteur_keep_as_parent import ChangeActeurKeepAsParent
+from data.models.changes.acteur_update_parent_id import ChangeActeurUpdateParentId
+from data.models.changes.acteur_verify_in_revision import ChangeActeurVerifyRevision
+from qfdmo.models.acteur import RevisionActeur
+from unit_tests.qfdmo.acteur_factory import (
+    ActeurFactory,
+    ActeurTypeFactory,
+    RevisionActeurFactory,
+    SourceFactory,
 )
 from utils.django import django_setup_full
 
 django_setup_full()
 
-EMPTY_KEEP = True
-EMPTY_IGNORE = False
+
+@pytest.fixture
+def acteur_type():
+    return ActeurTypeFactory(code="t1")
 
 
 @pytest.fixture
-def acteurs_revision():
-    # TODO: once we have fixed data validation in field_pick_value
-    # replace below values with a mix of good/bad ones and expect
-    # the tests to pick the good ones.
+def sources():
+    return [SourceFactory() for _ in range(4)]
 
-    # ❌ = excluded source values
 
-    # Intentionally sorting acteurs with exclusion first and
-    # random order vs. prio to test exclusion and picking
+@pytest.fixture
+def acteurs(acteur_type, sources):
+    ids = ["a1", "a2", "a3"]
+    noms = ["❌", "prio 2", "prio 1"]
+    sirets = ["❌", "", ""]
+    emails = ["email.acteur@source.1", "email.acteur@source.2", "email.acteur@source.3"]
+    locations = [Point(0, 0), Point(1, 1), Point(2, 2)]
+    return [
+        ActeurFactory(
+            identifiant_unique=i,
+            nom=n,
+            siret=s,
+            email=e,
+            source=source,
+            location=loc,
+            acteur_type=acteur_type,
+        )
+        for i, n, s, e, source, loc in zip(
+            ids, noms, sirets, emails, sources[:3], locations
+        )
+    ]
+
+
+@pytest.fixture
+def parent(acteur_type):
+    return RevisionActeur(
+        identifiant_unique="p1",
+        nom="my name",
+        siret="11111111111111",
+        email="",  # empty value
+        acteur_type=acteur_type,
+        adresse="my place",
+        source=None,
+    ).save_as_parent()
+
+
+@pytest.fixture
+def revision_acteurs(acteur_type, sources, parent, acteurs):
     ids = ["a1", "a2", "a3", "a4"]
     noms = ["❌", "prio 2", "prio 1", "prio 3"]
     # With SIRET we are testing picking that data won't be
@@ -34,75 +79,64 @@ def acteurs_revision():
     sirets = ["❌", "11111111111111", "", ""]
     # With emails we are testing the fallback to base acteurs
     emails = ["", "", "", ""]
-    source_ids = [5, 20, 10, 30]
     locations = [Point(0, 0), Point(1, 1), Point(2, 2), Point(3, 3)]
+    parents = [parent, parent, None, None]
     return [
-        {
-            "identifiant_unique": i,
-            "nom": n,
-            "siret": s,
-            "email": e,
-            "source_id": sid,
-            "location": loc,
-            "acteur_type_id": 1,
-        }
-        for i, n, s, e, sid, loc in zip(
-            ids, noms, sirets, emails, source_ids, locations
+        RevisionActeurFactory(
+            identifiant_unique=i,
+            nom=n,
+            siret=s,
+            email=e,
+            source=source,
+            location=loc,
+            parent=parent,
+            acteur_type=acteur_type,
+        )
+        for i, n, s, e, source, loc, parent in zip(
+            ids, noms, sirets, emails, sources[:4], locations, parents
         )
     ]
 
 
-@pytest.fixture
-def acteurs_base():
-    ids = ["a1", "a2", "a3"]
-    noms = ["❌", "prio 2", "prio 1"]
-    sirets = ["❌", "", ""]
-    emails = ["❌", "prio2@fallback.base", "prio1@fallback.base"]
-    source_ids = [5, 20, 10]
-    locations = [Point(0, 0), Point(1, 1), Point(2, 2)]
-    return [
-        {
-            "identifiant_unique": i,
-            "nom": n,
-            "siret": s,
-            "email": e,
-            "source_id": sid,
-            "location": loc,
-            "acteur_type_id": 1,
-        }
-        for i, n, s, e, sid, loc in zip(
-            ids, noms, sirets, emails, source_ids, locations
-        )
-    ]
-
-
-@pytest.fixture
-def parent():
-    return {
-        "identifiant_unique": "p1",
-        "nom": "my name",
-        "siret": "11111111111111",
-        "email": "i@me.com",
-        # With adresse we are testing fields
-        # not included in fields_to_include
-        "adresse": "my place",
-        "acteur_type_id": 1,
-        "source_id": None,
-    }
-
-
-@pytest.fixture
-def data_empty_ignore(parent, acteurs_revision, acteurs_base) -> dict:
-    data = parent_choose_data(
-        parent_data_before=parent,
-        acteurs_revision=acteurs_revision,
-        acteurs_base=acteurs_base,
-        fields_to_include=["nom", "siret", "email"],
-        prioritize_source_ids=[10, 20],
-        exclude_source_ids=[5],
-        keep_empty=EMPTY_IGNORE,
+class TestFieldsToIncludeClean:
+    @pytest.mark.parametrize(
+        "fields_to_include, expected",
+        [
+            (["nom", "siret", "email"], ["nom", "siret", "email"]),
+            (
+                [
+                    "nom",
+                    "siret",
+                    "proposition_services",
+                    "source",
+                    "source_id",
+                    "statut",
+                    "cree_le",
+                    "modifie_le",
+                    "identifiant_unique",
+                    "identifiant_externe",
+                    "email",
+                ],
+                ["nom", "siret", "email"],
+            ),
+        ],
     )
-    return data
+    def test_fields_to_include_clean(self, fields_to_include, expected):
+        assert fields_to_include_clean(fields_to_include) == expected
+
+
+class TestValueIsEmpty:
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            (None, True),
+            ("", True),
+            (" ", True),
+            ("i@me.com", False),
+        ],
+    )
+    def test_value_is_empty(self, value, expected):
+        assert value_is_empty(value) == expected
 
 
 @pytest.mark.django_db
@@ -111,16 +145,9 @@ class TestFieldPickValue:
     @pytest.mark.parametrize(
         "field, values, keep_empty,expected",
         [
-            # Currently there is no validation because of .full_clean mess
-            # AND métier confirming they want clustering ASAP and are OK
-            # with suggestions proposing bad data
-            # 💩 = bad data
-            # TODO: once validation fixed in field_pick_value, replace
-            # below tests to confirm ONLY valid data is ever picked no
-            # matter the configuration
-            ("email", ["💩", "i@me.com", "💩"], EMPTY_IGNORE, "💩"),
-            ("email", [" ", None, "i@me.com", "💩"], EMPTY_IGNORE, "i@me.com"),
-            ("email", [" ", None, "i@me.com", "💩"], EMPTY_KEEP, " "),
+            ("email", ["💩", "i@me.com", "💩"], False, "💩"),
+            ("email", [" ", None, "i@me.com", "💩"], False, "i@me.com"),
+            ("email", [" ", None, "i@me.com", "💩"], True, " "),
         ],
     )
     def test_acteurs_get_one_field(self, field, values, keep_empty, expected):
@@ -135,171 +162,85 @@ class TestFieldPickValue:
 
 
 @pytest.mark.django_db
-class TestParentChooseData:
-
-    def test_no_values_picked_from_excluded_sources(self, data_empty_ignore):
-        assert all(x != "❌" for x in data_empty_ignore.values())
-
-    def test_internal_fields_not_in_data(self, data_empty_ignore):
-        internals = ["acteur_type_id", "acteur_type", "source_id", "source"]
-        assert all(x not in data_empty_ignore for x in internals)
-
-    def test_nom_from_prio1_as_present(self, data_empty_ignore):
-        # It was non-null on prio 1 so we took it
-        assert data_empty_ignore["nom"] == "prio 1"
-
-    def test_siret_not_proposed(self, data_empty_ignore):
-        # The only good value was on prio 2 BUT it's the
-        # same as original so we don't propose it again
-        assert "siret" not in data_empty_ignore
-
-    def test_email_fallback_to_base_acteurs(self, data_empty_ignore):
-        # All revision acteurs had None emails, so we fallback to base
-        # were we picked from 1st prio
-        assert data_empty_ignore["email"] == "prio1@fallback.base"
-
-    def test_fields_not_specified_not_included(self, data_empty_ignore):
-        # We didn't say we wanted the adresse so we shouldn't have it
-        assert "adresse" not in data_empty_ignore
-
-
-@pytest.mark.django_db
 class TestClusterActeursParentsChooseData:
 
     @pytest.fixture
-    def df_clusters_parent_keep(self, parent, acteurs_revision, acteurs_base):
-        # TODO: throughout tests we spend WAY too much time defining
-        # data, and data is getting progressively more complex throughout
-        # pipeline. We should probably use factories or centralise data/fixtures
-        from data.models.change import COL_CHANGE_MODEL_NAME
-        from data.models.changes import (
-            ChangeActeurKeepAsParent,
-            ChangeActeurUpdateParentId,
+    def df_clusters_parent_keep(self, acteurs, parent, revision_acteurs):
+
+        return pd.DataFrame(
+            {
+                "cluster_id": ["c1"] * 5,
+                "change_order": [1, 2, 2, 2, 2],
+                "change_reason": ["", "", "", "", ""],
+                "change_model_name": [
+                    ChangeActeurKeepAsParent.name(),
+                    ChangeActeurVerifyRevision.name(),
+                    ChangeActeurVerifyRevision.name(),
+                    ChangeActeurUpdateParentId.name(),
+                    ChangeActeurUpdateParentId.name(),
+                ],
+                "identifiant_unique": ["p1", "a1", "a2", "a3", "a4"],
+                "parent_id": [None, "p1", "p1", None, None],
+            }
         )
 
-        acteurs = [parent] + acteurs_revision + acteurs_base
-        df = pd.DataFrame(acteurs, dtype="object").replace({np.nan: None})
-        df[COL_CHANGE_MODEL_NAME] = None
-        filter_parent = df["identifiant_unique"] == "p1"
-        df.loc[filter_parent, COL_CHANGE_MODEL_NAME] = ChangeActeurKeepAsParent.name()
-        df.loc[~filter_parent, COL_CHANGE_MODEL_NAME] = (
-            ChangeActeurUpdateParentId.name()
-        )
-        df["cluster_id"] = "c1"
-        return df.drop_duplicates(subset=["identifiant_unique"], keep="first")
-
     @pytest.fixture
-    def df_clusters_parent_create(self, parent, acteurs_revision, acteurs_base):
-        # TODO: throughout tests we spend WAY too much time defining
-        # data, and data is getting progressively more complex throughout
-        # pipeline. We should probably use factories or centralise data/fixtures
-        from data.models.change import COL_CHANGE_MODEL_NAME
-        from data.models.changes import (
-            ChangeActeurCreateAsParent,
-            ChangeActeurUpdateParentId,
+    def df_clusters_parent_create(self, parent, revision_acteurs, acteurs):
+        return pd.DataFrame(
+            {
+                "cluster_id": ["c2"] * 3,
+                "change_order": [1, 2, 2],
+                "change_reason": ["", "", ""],
+                "change_model_name": [
+                    ChangeActeurCreateAsParent.name(),
+                    ChangeActeurUpdateParentId.name(),
+                    ChangeActeurUpdateParentId.name(),
+                ],
+                "identifiant_unique": ["p1", "a3", "a4"],
+                "parent_id": [None, None, None],
+            }
         )
 
-        acteurs = [parent] + acteurs_revision + acteurs_base
-        df = pd.DataFrame(acteurs, dtype="object").replace({np.nan: None})
-        df[COL_CHANGE_MODEL_NAME] = None
-        filter_parent = df["identifiant_unique"] == "p1"
-        df.loc[filter_parent, COL_CHANGE_MODEL_NAME] = ChangeActeurCreateAsParent.name()
-        df.loc[~filter_parent, COL_CHANGE_MODEL_NAME] = (
-            ChangeActeurUpdateParentId.name()
-        )
-        df["cluster_id"] = "c1"
-        df = df.drop_duplicates(subset=["identifiant_unique"], keep="first")
-        return df
-
-    @pytest.fixture
-    def atype(self):
-        from qfdmo.models import ActeurType
-
-        ActeurType(id=1, code="t1").save()
-
-    @pytest.fixture
-    def sources(self, acteurs_revision, acteurs_base):
-        from qfdmo.models import Source
-
-        for id in set([a["source_id"] for a in acteurs_revision + acteurs_base]):
-            Source(id=id, code=f"s{id}").save()
-
-    @pytest.fixture
-    def acteurs_revision_to_db(self, acteurs_revision, sources, atype):
-        from qfdmo.models import RevisionActeur
-
-        for acteur in acteurs_revision:
-            RevisionActeur(**acteur).save()
-
-    @pytest.fixture
-    def acteurs_base_to_db(self, acteurs_base, sources, atype):
-        from qfdmo.models import Acteur
-
-        for acteur in acteurs_base:
-            Acteur(**acteur).save()
-
-    @pytest.mark.parametrize("scenario", ["parent_keep", "parent_create"])
-    def test_cluster_acteurs_parents_choose_data(
+    def test_cluster_acteurs_parents_choose_data_parent_keep(
         self,
         df_clusters_parent_keep,
-        df_clusters_parent_create,
-        parent,
-        acteurs_revision_to_db,
-        acteurs_base_to_db,
-        data_empty_ignore,
-        scenario,
+        sources,
     ):
-        from qfdmo.models import DisplayedActeur
-
-        dfs = {
-            "parent_keep": df_clusters_parent_keep,
-            "parent_create": df_clusters_parent_create,
-        }
-        df_before = dfs[scenario]
-
-        DisplayedActeur(**parent).save()
-        df_after = cluster_acteurs_parents_choose_data(
-            df_clusters=df_before,
+        df = cluster_acteurs_parents_choose_data(
+            df_clusters=df_clusters_parent_keep,
             fields_to_include=["nom", "siret", "email"],
-            exclude_source_ids=[5],
-            prioritize_source_ids=[10, 20],
-            keep_empty=EMPTY_IGNORE,
+            exclude_source_ids=[],
+            prioritize_source_ids=[sources[0].id, sources[1].id],
+            keep_empty=False,
         )
-        filter_parent = df_after["identifiant_unique"] == "p1"
-        parent_data = df_after[filter_parent][COL_PARENT_DATA_NEW].values[0]
-        df_children = df_after[~filter_parent]
-        if scenario == "parent_create":
-            # Since this parent is to create, it doesn't have a siret so we expect
-            # to have it
-            data_empty_ignore["siret"] = "11111111111111"
-        assert parent_data == data_empty_ignore
-        assert df_children[COL_PARENT_DATA_NEW].isnull().sum() == len(df_children)
 
-    def test_parent_create(
+        # Retrieve parent data
+        assert df.loc[df["identifiant_unique"] == "p1", "parent_data_new"].values[
+            0
+        ] == {"email": "email.acteur@source.1"}
+        # tester que tous les autres sont None
+        assert (
+            df.loc[df["identifiant_unique"] != "p1", "parent_data_new"].isnull().all()
+        )
+
+    def test_cluster_acteurs_parents_choose_data_parent_create(
         self,
         df_clusters_parent_create,
-        parent,
-        acteurs_revision_to_db,
-        acteurs_base_to_db,
-        data_empty_ignore,
+        sources,
     ):
-        from qfdmo.models import DisplayedActeur
-
-        df_before = df_clusters_parent_create
-
-        DisplayedActeur(**parent).save()
-        df_after = cluster_acteurs_parents_choose_data(
-            df_clusters=df_before,
+        df = cluster_acteurs_parents_choose_data(
+            df_clusters=df_clusters_parent_create,
             fields_to_include=["nom", "siret", "email"],
-            exclude_source_ids=[5],
-            prioritize_source_ids=[10, 20],
-            keep_empty=EMPTY_IGNORE,
+            exclude_source_ids=[],
+            prioritize_source_ids=[sources[2].id],
+            keep_empty=False,
         )
-        filter_parent = df_after["identifiant_unique"] == "p1"
-        parent_data = df_after[filter_parent][COL_PARENT_DATA_NEW].values[0]
-        df_children = df_after[~filter_parent]
-        # Since this parent is to create, it doesn't have a siret so we expect
-        # to have it
-        data_empty_ignore["siret"] = "11111111111111"
-        assert parent_data == data_empty_ignore
-        assert df_children[COL_PARENT_DATA_NEW].isnull().sum() == len(df_children)
+
+        # Retrieve parent data
+        assert df.loc[df["identifiant_unique"] == "p1", "parent_data_new"].values[
+            0
+        ] == {"nom": "prio 1", "email": "email.acteur@source.3"}
+        # tester que tous les autres sont None
+        assert (
+            df.loc[df["identifiant_unique"] != "p1", "parent_data_new"].isnull().all()
+        )

--- a/dags/tests/cluster/tasks/business_logic/test_cluster_acteurs_parents_choose_data.py
+++ b/dags/tests/cluster/tasks/business_logic/test_cluster_acteurs_parents_choose_data.py
@@ -240,7 +240,6 @@ class TestClusterActeursParentsChooseData:
         assert df.loc[df["identifiant_unique"] == "p1", "parent_data_new"].values[
             0
         ] == {"nom": "prio 1", "email": "email.acteur@source.3"}
-        # tester que tous les autres sont None
         assert (
             df.loc[df["identifiant_unique"] != "p1", "parent_data_new"].isnull().all()
-        )
+        ), "tester que tous les autres sont None"


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion 👇 

**🗺️ contexte**: Airflow - Clustering

**💡 quoi**: L’algo de clustering ne devrait pas venir agglomérer du contenu dans des champs DÉJÀ remplis quand il s’agit juste d’ajouter des enfants à un parent EXISTANT

**🎯 pourquoi**: Perte des données corrigé au niveau parent

**🤔 comment**: Ajout d'une option "Converser les données du parent"

![CleanShot 2025-06-12 at 18 11 31](https://github.com/user-attachments/assets/bf2ae112-b6b9-4834-a0fe-e798b3bf1caf)

## Exemple résultats / UI / Data

keep parent by default : vrai
keep empty value : faux

![CleanShot 2025-06-12 at 18 12 41](https://github.com/user-attachments/assets/1ee5cc7e-f7ed-4b64-9e12-6e2da52cba53)

[-5 j](https://mattermost.incubateur.net/betagouv/pl/43sx66bz6byjmeihcmcib4c8ga)

Keep parent = vrai
keep empty = vrai

![CleanShot 2025-06-12 at 18 15 08](https://github.com/user-attachments/assets/ab292501-8150-4b1a-b107-bfed1f2bf1e1)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] Amélioration des tests

