### PR TITLE
🖊️ Meilleure incitation aux contributions utilisateurs

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -18,6 +18,7 @@ CARTE = {
     },
     "ajouter_un_lieu": "Ajouter un lieu sur la carte",
     "nouvelle_recherche_dans_cette_zone": "Nouvelle recherche dans cette zone",
+    "filtres_bouton": "Filtres",
 }
 
 ASSISTANT = {

--- a/jinja2/qfdmo/acteur/_actions.html
+++ b/jinja2/qfdmo/acteur/_actions.html
@@ -21,5 +21,7 @@
     {% endif %}
 
     {% include "qfdmo/acteur/_action_share.html" %}
-
+    {% with text="Modifier",icon="fr-icon-ball-pen-fill",url=url('qfdmo:address-suggestion-form'),extra_classes="fr-btn--secondary-light" %}
+        {% include "qfdmo/acteur/_action.html" %}
+    {% endwith %}
 </div>

--- a/jinja2/qfdmo/acteur/_actions.html
+++ b/jinja2/qfdmo/acteur/_actions.html
@@ -21,7 +21,7 @@
     {% endif %}
 
     {% include "qfdmo/acteur/_action_share.html" %}
-    {% with text="Modifier",icon="fr-icon-ball-pen-fill",url=url('qfdmo:update-suggestion-form'),extra_classes="fr-btn--secondary-light" %}
+    {% with text="Modifier",icon="fr-icon-ball-pen-fill",url=object.suggestion_form_url,extra_classes="fr-btn--secondary-light" %}
         {% include "qfdmo/acteur/_action.html" %}
     {% endwith %}
 </div>

--- a/jinja2/qfdmo/acteur/_actions.html
+++ b/jinja2/qfdmo/acteur/_actions.html
@@ -21,7 +21,7 @@
     {% endif %}
 
     {% include "qfdmo/acteur/_action_share.html" %}
-    {% with text="Modifier",icon="fr-icon-ball-pen-fill",url=url('qfdmo:address-suggestion-form'),extra_classes="fr-btn--secondary-light" %}
+    {% with text="Modifier",icon="fr-icon-ball-pen-fill",url=url('qfdmo:update-suggestion-form'),extra_classes="fr-btn--secondary-light" %}
         {% include "qfdmo/acteur/_action.html" %}
     {% endwith %}
 </div>

--- a/jinja2/qfdmo/acteur/tabs/sections/meta.html
+++ b/jinja2/qfdmo/acteur/tabs/sections/meta.html
@@ -22,7 +22,7 @@
     </div>
 
     <a class="fr-my-1w fr-btn fr-btn--tertiary qf-whitespace-nowrap qf-w-full qf-justify-center"
-        href="{{ url('qfdmo:update-suggestion-form')}}?Nom={{object.nom}}&Ville={{object.ville}}&Adresse={{object.adresse}}"
+        href="{{ object.suggestion_form_url }}"
         target="_blank"
         rel="noreferrer"
         title="Proposer une modification - Nouvelle fenêtre"

--- a/jinja2/qfdmo/carte/panels/legend.html
+++ b/jinja2/qfdmo/carte/panels/legend.html
@@ -23,7 +23,7 @@
         data-action="search-solution-form#toggleAdvancedFilters"
         data-testid="advanced-filters-in-legend"
     >
-        Filtres avancés
+        {{ CARTE.filtres_bouton }}
     </button>
 
     {# Check if the branding configuration is not set or if branding is allowed.

--- a/jinja2/qfdmo/shared/_search_in_zone.html
+++ b/jinja2/qfdmo/shared/_search_in_zone.html
@@ -2,6 +2,7 @@
     data-map-target="searchInZoneButton"
     data-action="click -> state#submit"
     class="fr-btn fr-btn--sm fr-btn--secondary
+            fr-icon-refresh-line fr-btn--icon-left
             qf-bg-white
             qf-mx-auto
             qf-absolute qf-z-20 qf-top-1w qf-inline-flex qf-left-0 qf-right-0 qf-hidden"

--- a/qfdmo/models/acteur.py
+++ b/qfdmo/models/acteur.py
@@ -6,6 +6,7 @@ import string
 import uuid
 from copy import deepcopy
 from typing import Any, List, cast
+from urllib.parse import urlencode
 
 import opening_hours
 import orjson
@@ -1065,6 +1066,16 @@ class DisplayedActeur(BaseActeur):
         return reverse(
             "admin:qfdmo_displayedacteur_change", args=[quote(self.identifiant_unique)]
         )
+
+    @cached_property
+    def suggestion_form_url(self):
+        query_params = {
+            "Nom": self.nom,
+            "Ville": self.ville,
+            "Adresse": self.adresse,
+        }
+        querystring = urlencode(query_params)
+        return f"{reverse('qfdmo:update-suggestion-form')}?{querystring}"
 
     # La propriété au sein du Displayed se base sur Revision
     # car c'est la seule façon de récupérer les enfants (n'existe pas

--- a/unit_tests/qfdmo/acteur_factory.py
+++ b/unit_tests/qfdmo/acteur_factory.py
@@ -79,7 +79,7 @@ class DisplayedActeurFactory(Factory):
         model = DisplayedActeur
 
     identifiant_unique = factory.fuzzy.FuzzyText(length=10)
-    nom = Faker("word")
+    nom = Faker("company")
     location = Point(3, 3)
     acteur_type = SubFactory(ActeurTypeFactory)
     source = SubFactory(SourceFactory)

--- a/unit_tests/qfdmo/test_acteur.py
+++ b/unit_tests/qfdmo/test_acteur.py
@@ -31,10 +31,15 @@ from unit_tests.qfdmo.action_factory import (
 from unit_tests.qfdmo.sscatobj_factory import SousCategorieObjetFactory
 
 
-@pytest.fixture()
+@pytest.fixture
 def acteur(db):
     ps = PropositionServiceFactory.create()
     yield ps.acteur
+
+
+@pytest.fixture
+def displayed_acteur(db):
+    return DisplayedActeurFactory()
 
 
 class TestPoint:
@@ -556,10 +561,6 @@ class TestRevisionActeurRemoveParentWithoutChildren:
 
 @pytest.mark.django_db
 class TestActeurService:
-    @pytest.fixture
-    def displayed_acteur(self):
-        return DisplayedActeurFactory()
-
     def test_acteur_services_basic(self, displayed_acteur):
         displayed_acteur.acteur_services.add(
             ActeurServiceFactory(libelle="Par un professionnel")
@@ -946,6 +947,19 @@ class TestDisplayedActeurJsonActeurForDisplay:
         assert acteur_for_display["icon"] == "icon-actionjai2", (
             "The pinpoint of action_principale is displayed if multiple"
             " actions match the map's sous categorie filter"
+        )
+
+
+class TestDisplayedActeurFormUrls:
+    def test_suggestion_form_url(self, displayed_acteur):
+        displayed_acteur.nom = "Palais de l'Élysée"
+        displayed_acteur.adresse = "55 rue du Faubourg Saint-Honoré"
+        displayed_acteur.ville = "Paris"
+
+        assert displayed_acteur.suggestion_form_url == (
+            "/proposer-une-modification/?Nom=Palais+de+l%27%C3%89lys%C3%A9e"
+            "&Ville=Paris"
+            "&Adresse=55+rue+du+Faubourg+Saint-Honor%C3%A9"
         )
 
 

--- a/unit_tests/qfdmo/test_acteur.py
+++ b/unit_tests/qfdmo/test_acteur.py
@@ -957,7 +957,7 @@ class TestDisplayedActeurFormUrls:
         displayed_acteur.ville = "Paris"
 
         assert displayed_acteur.suggestion_form_url == (
-            "/proposer-une-modification/?Nom=Palais+de+l%27%C3%89lys%C3%A9e"
+            "/proposer-une-modification?Nom=Palais+de+l%27%C3%89lys%C3%A9e"
             "&Ville=Paris"
             "&Adresse=55+rue+du+Faubourg+Saint-Honor%C3%A9"
         )


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : https://www.notion.so/accelerateur-transition-ecologique-ademe/Rendre-plus-visible-la-contribution-usager-sur-la-carte-ajout-et-modification-1ea6523d57d780e4a68fdd36dc55f824?source=copy_link

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Assistant v2

**💡 quoi**: Mise en oeuvre d'améliorations de la UI 

**🎯 pourquoi**: pour inciter les usagers à contribuer des modifications des données affichées

**🤔 comment**: 
- Ajout d'une icône sur le bouton rechercher dans cette zone 
- Renommage du bouton filtres avancées : On en profite pour stocker ça dans une variable globale 
- Ajout d'un bouton Modifier avec un crayon sur les fiches acteurs, qui reprend le lien vers le tally 

À noter : on ne dispose pas exactement de la même icone que le créa pour le bouton rechercher dans cette zone 

## Exemple résultats / UI / Data

### Créa
<img width="401" alt="image" src="https://github.com/user-attachments/assets/882754ff-d178-4102-88d3-d50b7e73190c" />
<img width="850" alt="image" src="https://github.com/user-attachments/assets/a398c2ca-6e7c-44dc-8c41-6e9fc5bc5ece" />


### Exemples 
<img width="463" alt="image" src="https://github.com/user-attachments/assets/916d20e2-cb5a-4db9-b657-d838329ff01b" />

<img width="405" alt="image" src="https://github.com/user-attachments/assets/1f7a1083-c5f9-4f74-8572-f7b6fc4a405e" />


## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code

