### PR TITLE
Remise à zero des bbox lorsqu'on mets à jour les données de localisation

### DIFF
--- a/static/to_compile/controllers/assistant/state.ts
+++ b/static/to_compile/controllers/assistant/state.ts
@@ -1,39 +1,56 @@
 import { Controller } from "@hotwired/stimulus"
+import isEmpty from "lodash/isEmpty"
 import AdresseAutocompleteController from "../carte/address_autocomplete_controller"
 import SearchFormController from "../carte/search_solution_form_controller"
-import isEmpty from "lodash/isEmpty"
 
 export default class extends Controller<HTMLElement> {
   static values = {
-    "location": Object,
+    location: Object,
   }
   static outlets = ["address-autocomplete", "search-solution-form"]
   declare addressAutocompleteOutlets: Array<AdresseAutocompleteController>
   declare searchSolutionFormOutlets: Array<SearchFormController>
-  declare locationValue: { adresse: string | null, latitude: string | null, longitude: string | null }
+  declare locationValue: {
+    adresse: string | null
+    latitude: string | null
+    longitude: string | null
+  }
 
   connect() {
-    document.addEventListener("turbo:frame-load", this.fetchLocationFromSessionStorageOnFirstLoad.bind(this))
+    document.addEventListener(
+      "turbo:frame-load",
+      this.fetchLocationFromSessionStorageOnFirstLoad.bind(this),
+    )
   }
 
   fetchLocationFromSessionStorageOnFirstLoad(event) {
     if (!isEmpty(this.locationValue)) {
-      document.removeEventListener("turbo:frame-load", this.fetchLocationFromSessionStorageOnFirstLoad.bind(this))
+      document.removeEventListener(
+        "turbo:frame-load",
+        this.fetchLocationFromSessionStorageOnFirstLoad.bind(this),
+      )
       return
     }
 
     const nextLocationValue = {
-      "adresse": sessionStorage.getItem("adresse"),
-      "latitude": sessionStorage.getItem("latitude"),
-      "longitude": sessionStorage.getItem("longitude")
+      adresse: sessionStorage.getItem("adresse"),
+      latitude: sessionStorage.getItem("latitude"),
+      longitude: sessionStorage.getItem("longitude"),
     }
 
-    if (Object.values(nextLocationValue).find(value => !!value)) {
+    if (Object.values(nextLocationValue).find((value) => !!value)) {
       this.locationValue = nextLocationValue
     }
   }
 
+  resetBboxInputs() {
+    for (const outlet of this.searchSolutionFormOutlets) {
+      outlet.resetBboxInput()
+    }
+  }
+
   setLocation(event) {
+    this.resetBboxInputs()
     const nextLocationValue = event.detail
     const updatedLocationIsNotEmpty = !isEmpty(nextLocationValue)
     if (updatedLocationIsNotEmpty) {
@@ -94,5 +111,3 @@ export default class extends Controller<HTMLElement> {
     }
   }
 }
-
-

--- a/static/to_compile/controllers/carte/search_solution_form_controller.ts
+++ b/static/to_compile/controllers/carte/search_solution_form_controller.ts
@@ -1,6 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
 import * as Turbo from "@hotwired/turbo"
-import { clearActivePinpoints, removeHash } from "../../js/helpers"
 
 class SearchFormController extends Controller<HTMLElement> {
   #selectedOption: string = ""
@@ -99,7 +98,6 @@ class SearchFormController extends Controller<HTMLElement> {
     this.displayActionList()
   }
 
-
   activeReparerFilters(activate: boolean = true) {
     // Carte mode
     this.activeReparerFiltersCarte()
@@ -161,6 +159,10 @@ class SearchFormController extends Controller<HTMLElement> {
     this.#showSearchFormPanel()
     this.#hideAddressesPanel()
     this.scrollToContent()
+  }
+
+  resetBboxInput() {
+    this.bboxTarget.value = ""
   }
 
   updateBboxInput(event) {


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : https://www.notion.so/accelerateur-transition-ecologique-ademe/2016523d57d780ac8d16cf8cf568d89d?v=2016523d57d78068b32e000c9f5316fb&source=copy_link

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Carte

**💡 quoi**: Gestion de la Bbox lors de la recherche d'adresse

**🎯 pourquoi**: sinon, la Bbox est conservée

**🤔 comment**: Reset de la Bbox dans le controleur state avant la mise à jour des données de localisation

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
