### PR TITLE
🐛 Retours sur le maintien de la géoloc dans l'assistant

### DIFF
--- a/jinja2/qfdmo/carte.html
+++ b/jinja2/qfdmo/carte.html
@@ -39,8 +39,7 @@
         <section class="map-grid qf-relative">
             <header
                 {# The z-index below can impact the shadow over#}
-                class="{% block header_classes %}qf-z-20{% endblock header_classes %}
-                    qf-bg-white qf-border-solid qf-border-b-grey-900 qf-border-0 qf-shadow-lg qf-border-b"
+                class="{% block header_classes %}qf-z-20{% endblock header_classes %} qf-bg-white qf-shadow-lg"
             >
                 <div
                     class="
@@ -95,7 +94,8 @@
             <aside class="
                 md:qf-relative qf-z-20
                 aria-[hidden=false]:qf-block qf-hidden
-                qf-overflow-auto
+                md:qf-overflow-auto
+                max-md:qf-overflow-visible
                 qf-bg-white
                 max-md:qf-absolute
                 max-md:qf-top-full max-md:qf-bottom-0 max-md:qf-left-0 max-md:qf-right-0

--- a/jinja2/qfdmo/formulaire.html
+++ b/jinja2/qfdmo/formulaire.html
@@ -79,7 +79,8 @@
             <aside class="
                 qf-relative qf-z-30
                 aria-[hidden=false]:qf-block qf-hidden
-                qf-overflow-auto
+                md:qf-overflow-auto
+                max-md:qf-overflow-visible
                 md:qf-h-[calc(100vh_-_250px)]
                 max-md:qf-absolute
                 max-md:qf-top-full max-md:qf-bottom-0 max-md:qf-left-0 max-md:qf-right-0


### PR DESCRIPTION
# Description succincte du problème résolu

https://www.notion.so/accelerateur-transition-ecologique-ademe/Mobile-La-fen-tre-pour-le-partage-de-la-fiche-est-pas-visible-compl-tement-21d6523d57d780d6aa87dd4cb6003cf6?source=copy_link


**🗺️ contexte**: Assistant v2

**💡 quoi**: résolution d'un bug qui empêche de voir la tooltip de partage dans une fiche acteur

**🎯 pourquoi**: pour pouvoir partager un acteur 

**🤔 comment**: 

- Suppression de l'overflow auto en mobile, on utilise overflow visible 

## Exemple résultats / UI / Data

<img width="544" alt="image" src="https://github.com/user-attachments/assets/c57a57e5-a6d5-452e-9bc3-1a50e94b0c67" />


## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
