### PR TITLE
 ↔ Réduction des marges en mobile dans les onglets de l'assistant

### DIFF
--- a/static/to_compile/styles/dsfr-overrides.css
+++ b/static/to_compile/styles/dsfr-overrides.css
@@ -1,4 +1,3 @@
-
 .fr-enlarge-link a::before {
   position: relative !important;
 }
@@ -112,6 +111,29 @@
 /*
 DSFR customization for tabs
 */
+
+.fr-tabs--noborder-mobile {
+  &:before,
+  & {
+    @apply max-md:qf-shadow-none;
+  }
+
+  .fr-tabs__list {
+    @apply max-md:qf-p-0;
+  }
+
+  .fr-tabs__panel {
+    @apply max-md:qf-py-1w max-md:qf-px-0;
+  }
+
+  .fr-tabs__list {
+    @apply max-md:qf-space-x-1w max-md:qf-min-h-min;
+  }
+
+  .fr-tabs__tab {
+    @apply max-md:qf-m-0;
+  }
+}
 
 .fr-tabs--noborder {
   &:before,

--- a/templates/components/produit/produit.html
+++ b/templates/components/produit/produit.html
@@ -19,7 +19,7 @@
 </header>
 
 {% if bon_etat and mauvais_etat %}
-    <div class="fr-tabs">
+    <div class="fr-tabs fr-tabs--noborder-mobile">
         <ul class="fr-tabs__list" role="tablist" aria-label="État du produit {{ produit }}">
             <li role="presentation">
                 <button


### PR DESCRIPTION
# Description succincte du problème résolu

Pas de carte, l'objectif est de coller aux maquettes

**🗺️ contexte**: Assistant v2

**💡 quoi**: on réduit les marges appliquées aux onglets affichés dans l'assistant

**🎯 pourquoi**: pour coller aux créas

**🤔 comment**: 

- on réplique fr-tabs--noborder qui avait déjà été écrite, en appliquant la logique uniquement sur mobile 


