### PR TITLE
💣 Empêcher l'admin de crasher quand on visionne un produit

### DIFF
--- a/qfdmd/admin.py
+++ b/qfdmd/admin.py
@@ -154,7 +154,7 @@ class ProduitAdmin(
     search_fields = ["nom__unaccent", "id", "synonymes_existants__unaccent"]
     # ajout des filtres de recherche sur bdd et code
     list_filter = ["bdd", "code"]
-    fields_to_display_in_first_position = ["id", "nom"]
+    fields_to_display_in_first_position = ["nom"]
     inlines = [SynonymeInline, LienInline]
     exclude = ("infotri",)
 


### PR DESCRIPTION
# Description succincte du problème résolu

https://www.notion.so/accelerateur-transition-ecologique-ademe/Admin-Django-Pas-d-acc-s-au-d-tail-des-fiches-produits-21e6523d57d780749603e0a1bc4f86b1?source=copy_link


**🗺️ contexte**: django admin

**💡 quoi**: correction d'une erreur serveur dans django admin 

**🎯 pourquoi**: empêcher l'admin de crasher quand on visionne un produit 

**🤔 comment**: 
- un champ id était précédemment défini sur le modèle, il l'est désormais dans un modèle parent 
- On y a donc plus accès, ce qui provoque une erreur dans django admin 

Comme il n'est pas prévu de modifier ces IDs, on peut sans soucis ne pas l'afficher et le supprimer de la liste ici qui servait à la placer en première position dans le formulaire django 

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

