### PR TITLE
🖲️ Définir la valeur à faux pour iframeFromScript dans PostHog

### DIFF
--- a/static/to_compile/controllers/shared/analytics.ts
+++ b/static/to_compile/controllers/shared/analytics.ts
@@ -143,9 +143,9 @@ export default class extends Controller<HTMLElement> {
     this.personProperties.iframe = weAreInAnIframe
     this.personProperties.iframeReferrer = referrer
     const url = new URL(window.location.href)
-    if (url.searchParams.has(URL_PARAM_NAME_FOR_IFRAME_SCRIPT_MODE)) {
-      this.personProperties.iframeFromScript = true
-    }
+    this.personProperties.iframeFromScript = url.searchParams.has(
+      URL_PARAM_NAME_FOR_IFRAME_SCRIPT_MODE,
+    )
   }
 
   #computeConversionScoreFromSessionStorage() {


### PR DESCRIPTION
# Description succincte du problème résolu

Tout est dans le titre, suite de https://www.notion.so/accelerateur-transition-ecologique-ademe/Tracking-Ajout-dans-Posthog-URL-compl-te-int-gration-via-iFrame-script-15f6523d57d7808f81f6d8cd1bd545a6?source=copy_link


**🗺️ contexte**: Tracking PostHog

**💡 quoi**: Redéfinition d'un paramètre envoyé à PostHog

**🎯 pourquoi**: Pour faciliter le travail de Delphine, actuellement elle ne peut pas filtrer sur une valeur non définie dans PostHog

**🤔 comment**: 
Que le mode iframe soit actif ou non, on envoie la valeur (booléenne) à PostHog

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
