### PR TITLE
Résoudre l'interdiction de créer un Acteur sans nom via Django admin

### DIFF
--- a/qfdmo/admin/acteur.py
+++ b/qfdmo/admin/acteur.py
@@ -381,7 +381,7 @@ class CustomRevisionActeurForm(forms.ModelForm):
 
     def clean_nom(self):
         nom = self.cleaned_data.get("nom")
-        if self.instance.pk is None and nom:
+        if not self.instance.pk and not nom:
             raise ValidationError("Le nom est obligatoire")
         return nom
 


### PR DESCRIPTION
# Description succincte du problème résolu

Un raté lors de l'implémentation de l'interdiction créer un acteur sans nom 

**🗺️ contexte**: django admin

**💡 quoi**: ne pas permettrela création de l'acteur sans nom

**🎯 pourquoi**: corriger la PR précédente

**🤔 comment**: correction de la condition mal formée

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
