### PR TITLE
🖊️ Changement texte pour bouton Intégrer qui n'est plus à droite

### DIFF
--- a/templates/components/footer/_standalone.html
+++ b/templates/components/footer/_standalone.html
@@ -30,7 +30,7 @@
     <h2>
         Comment intégrer cet outil à votre site ou application ?</h2>
 
-    <p>Cliquez sur le bouton à droite <span class="fr-icon fr-icon-code-s-slash-line"></span> et copiez/collez le code proposé dans votre site Internet.
+    <p>Cliquez sur le bouton <span class="fr-icon fr-icon-code-s-slash-line"></span> Intégrer et copiez/collez le code proposé dans votre site Internet.
     Vous souhaitez réutiliser le code de cet outil ? Il est développé de manière ouverte (open source), le code est 
     <a
         href="https://github.com/incubateur-ademe/quefairedemesobjets"


### PR DESCRIPTION
Changement texte pour bouton Intégrer qui n'est plus à droite

# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [Titre](__url__)

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: <!-- Quelle épic / opportinuté est concernée ? -->

**💡 quoi**: <!-- description de ce qu'on est en train de changer -->

**🎯 pourquoi**: <!-- pourquoi on fait ce changement -->

**🤔 comment**: <!-- Descrire l'ensemble des tâches réalisées (bullet points) -->

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
