### PR TITLE
⎯ Ajout d'une bordure autour des iframes de l'assistant

### DIFF
--- a/templates/qfdmd/base.html
+++ b/templates/qfdmd/base.html
@@ -1,4 +1,5 @@
 {% load dsfr_tags qfdmd_tags static wagtailuserbar %}
+
 {% with contact_modal_id="contact" %}
 
 <!DOCTYPE html>
@@ -40,7 +41,11 @@
     </head>
 
     <body
-        class="qf-flex qf-flex-col qf-group"
+        class="qf-flex qf-flex-col qf-group
+        {% if iframe %}
+        qf-overflow-hidden
+        qf-rounded-lg !qf-border !qf-border-solid !qf-border-grey-900
+        {% endif %}"
         {% if STIMULUS_DEBUG %}data-stimulus-debug="true"{% endif %}
         {% block body_attrs %}{% endblock %}
         data-controller="state analytics"
@@ -67,7 +72,7 @@
         {% wagtailuserbar %}
 
         {% if request.user.is_authenticated %}
-        <div class="qf-bg-red-marianne-main-472 qf-text-white qf-text-center qf-w-screen qf-py-1v qf-text-xs">
+        <div class="qf-mt-2w qf-bg-red-marianne-main-472 qf-text-white qf-text-center qf-w-full qf-py-1v qf-text-xs">
         Vous êtes bien authentifié, vos statistiques PostHog seront ignorées pour cette session | <a href="{% url 'admin:index' %}">accéder à l'administration</a>
         </div>
         {% endif %}
@@ -120,7 +125,7 @@
         {% dsfr_js %}
         <script type="module" src="{% static 'qfdmd.js' %}"></script>
         {% if iframe and request.user.is_authenticated %}
-            <div class="qf-bg-warning-425-625-hover qf-text-white qf-text-center qf-w-screen qf-py-1v qf-text-xs">
+            <div class="qf-mb-2w qf-bg-warning-425-625-hover qf-text-white qf-text-center qf-w-full qf-py-1v qf-text-xs">
             Le mode iframe de l'assistant est actif
             </div>
         {% endif %}

--- a/templates/tests/iframe.html
+++ b/templates/tests/iframe.html
@@ -8,7 +8,7 @@
         <meta name="description" content="IFrame test : QFDMO">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.6/iframeResizer.min.js" integrity="sha512-f0wd6UIvZbsjPNebGx+uMzHmg6KXr1jWvumJDYSEDmwYJYOptZ0dTka/wBJu7Tj80tnCYMKoKicqvZiIc9GJgw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script> {# pragma: allowlist secret #}
     </head>
-    <body style="background: rebeccapurple;">
+    <body style="background: white;">
         <div>
             <h1>Page d'affichage dynamique de l'iframe de l'application</h1>
             <p>Ci-dessous s'affiche l'iframe de l'application</p>


### PR DESCRIPTION
# Description succincte du problème résolu

Ajout d'une bordure autour de l'assitant en iframe https://www.notion.so/accelerateur-transition-ecologique-ademe/Assistant-iFrame-Ajouter-un-contour-pour-les-r-utilisations-21f6523d57d78005a3c0ecfcc917d591?source=copy_link 

<img width="1614" alt="image" src="https://github.com/user-attachments/assets/72ef9f35-fbf6-480b-9a4e-59607e106a81" />
