### PR TITLE
Ajout des liens de menu pour l'item courant + bug sur la recherche

### DIFF
--- a/templates/components/header/header_menu.html
+++ b/templates/components/header/header_menu.html
@@ -17,7 +17,7 @@
           <ul class="fr-nav__list">
             {% for item in menu_items %}
             <li class="fr-nav__item">
-              <a class="fr-nav__link" href="{{ item.href }}">
+              <a class="fr-nav__link" href="{{ item.href }}" {% if request.path|urlencode == item.href %}aria-current="true"{% endif %}>
                 {{ item.text }}
               </a>
             </li>

--- a/templates/components/search/view.html
+++ b/templates/components/search/view.html
@@ -16,7 +16,7 @@
     >
         <form
             data-search-target="form"
-            data-turbo-frame="search-results"
+            data-turbo-frame="{{ id|default:'search-results' }}"
             action="{% url 'qfdmd:search' %}"
             class="qf-pl-4w {# should match the svg icon width #}
             qf-flex qf-flex-row-reverse qf-relative

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -14,7 +14,7 @@
     {# search + patchwork #}
     <div class="qf-w-full qf-max-w-3xl qf-m-auto qf-relative qf-pb-6w">
         <div class="qf-absolute qf-left-0 qf-right-0 qf-top-0">
-            {% include "components/search/view.html" with big=True %}
+            {% include "components/search/view.html" with big=True id="search-home" %}
         </div>
     </div>
 


### PR DESCRIPTION
# Description succincte du problème résolu

Correction de deux bugs sur l'assistant 
- La recherche de la page d'accueil ouvrait la recherche dans le header
- L'item de menu courant dans la navigation principale n'était pas décoré d'une bordure bleue 

<img width="1614" alt="image" src="https://github.com/user-attachments/assets/2d37dc42-2417-48fd-bb66-0e63cba321a3" />
