### PR TITLE
♻️ Correction d'un bug sur le lien de l'infotri qui ne redirige plus vers ecologie.gouv.fr

### DIFF
--- a/e2e_tests/assistant.spec.ts
+++ b/e2e_tests/assistant.spec.ts
@@ -25,6 +25,13 @@ test("La carte s'affiche sur une fiche déchet/objet", async ({ page }) => {
   expect(sessionStorage.longitude).toContain("-2.9")
 })
 
+test("Le lien infotri est bien défini", async ({ page }) => {
+  // Navigate to the carte page
+  await page.goto(`/dechet/lave-linge`, { waitUntil: "domcontentloaded" })
+  await page.getByTestId("infotri-link").click()
+  await page.waitForURL("https://www.ecologie.gouv.fr/info-tri")
+})
+
 test("Le tracking PostHog fonctionne comme prévu", async ({ page }) => {
   // Check that homepage scores 1
   await page.goto(`/`, { waitUntil: "domcontentloaded" })

--- a/e2e_tests/assistant.spec.ts
+++ b/e2e_tests/assistant.spec.ts
@@ -28,8 +28,8 @@ test("La carte s'affiche sur une fiche déchet/objet", async ({ page }) => {
 test("Le lien infotri est bien défini", async ({ page }) => {
   // Navigate to the carte page
   await page.goto(`/dechet/lave-linge`, { waitUntil: "domcontentloaded" })
-  await page.getByTestId("infotri-link").click()
-  await page.waitForURL("https://www.ecologie.gouv.fr/info-tri")
+  const href = await page.getByTestId("infotri-link").getAttribute("href")
+  expect(href).toBe("https://www.ecologie.gouv.fr/info-tri")
 })
 
 test("Le tracking PostHog fonctionne comme prévu", async ({ page }) => {

--- a/qfdmd/templatetags/qfdmd_tags.py
+++ b/qfdmd/templatetags/qfdmd_tags.py
@@ -6,10 +6,20 @@ from django.conf import settings
 from django.core.cache import cache
 from django.forms import FileField
 from django.utils.safestring import mark_safe
+from wagtail.templatetags.wagtailcore_tags import richtext
 
 register = template.Library()
 
 logger = logging.getLogger(__name__)
+
+
+@register.filter
+def richtext_with_objet(reusable_content, page):
+    """
+    TODO: docstring
+    """
+    return richtext(reusable_content)
+    # .replace("<objet>", page.title))
 
 
 @register.inclusion_tag("components/patchwork/patchwork.html")

--- a/templates/blocks/reusable.html
+++ b/templates/blocks/reusable.html
@@ -1,3 +1,3 @@
-{% load wagtailcore_tags %}
+{% load qfdmd_tags %}
 
-{{ value.content|richtext }}
+{{ value.content|richtext_with_objet:page }}

--- a/templates/components/produit/_infotri.html
+++ b/templates/components/produit/_infotri.html
@@ -11,7 +11,7 @@
         </ul>
 
         <p class="qf-m-0">
-            <a href="{{ infotri.lien }}" class="fr-link" rel="noopener external" target="_blank" title="Lien vers les infotris - Nouvelle fenêtre">{{ ASSISTANT.infotri.texte_du_lien }}</a>
+            <a href="{{ ASSISTANT.infotri.lien }}" class="fr-link" rel="noopener external" target="_blank" title="Lien vers les infotris - Nouvelle fenêtre">{{ ASSISTANT.infotri.texte_du_lien }}</a>
         </p>
     </div>
 {% endif %}

--- a/templates/components/produit/_infotri.html
+++ b/templates/components/produit/_infotri.html
@@ -11,7 +11,7 @@
         </ul>
 
         <p class="qf-m-0">
-            <a href="{{ ASSISTANT.infotri.lien }}" class="fr-link" rel="noopener external" target="_blank" title="Lien vers les infotris - Nouvelle fenêtre">{{ ASSISTANT.infotri.texte_du_lien }}</a>
+            <a href="{{ ASSISTANT.infotri.lien }}" class="fr-link" rel="noopener external" target="_blank" title="Lien vers les infotris - Nouvelle fenêtre" data-testid="infotri-link">{{ ASSISTANT.infotri.texte_du_lien }}</a>
         </p>
     </div>
 {% endif %}

--- a/templates/qfdmd/produit_page.html
+++ b/templates/qfdmd/produit_page.html
@@ -25,7 +25,7 @@
 
     <div class="qf-flex qf-flex-col max-md:qf-order-2 md:qf-row-start-2 md:qf-col-span-2">
 
-      {% include "sites_faciles_content_manager/blocks/blocks_stream.html" with stream=page.body %}
+      {% include "sites_faciles_content_manager/blocks/blocks_stream.html" with stream=page.body page=page %}
     </div>
 </article>
 {% endblock main %}


### PR DESCRIPTION
# Description succincte du problème résolu

Régression sur le lien vers l'infotri. 
Celui-ci exploitait une variable globale dont une variable locale a été introduite avec le même nom dans le template. 

Au passage, ajout de la fondation permettant de dynamiser les contenus réutilisables dans la future mouture du CMS 