### PR TITLE
Rendu dynamique des produits via le tag `<objet>` dans Wagtail

### DIFF
--- a/qfdmd/templatetags/qfdmd_tags.py
+++ b/qfdmd/templatetags/qfdmd_tags.py
@@ -18,8 +18,7 @@ def richtext_with_objet(reusable_content, page):
     """
     TODO: docstring
     """
-    return richtext(reusable_content)
-    # .replace("<objet>", page.title))
+    return richtext(reusable_content.replace("&lt;objet&gt;", page.title))
 
 
 @register.inclusion_tag("components/patchwork/patchwork.html")


### PR DESCRIPTION
# Description succincte du problème résolu

Permettre d'afficher le nom d'un objet lorsque le texte est `<objet>` dans un contenu réutilisable 

