### PR TITLE
Corrige un problème sur la recherche en page d'accueil qui entre en conflit avec la recherche dans le menu

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -39,8 +39,12 @@ def global_context(request) -> dict:
     if request.META.get("HTTP_HOST") not in settings.ASSISTANT["HOSTS"]:
         return base
 
+    search_form = SearchForm(prefix="header")
+    home_search_form = SearchForm(prefix="home")
+
     return {
         **base,
-        "search_form": SearchForm(),
+        "search_form": search_form,
+        "home_search_form": home_search_form,
         **constants.ASSISTANT,
     }

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -39,8 +39,8 @@ def global_context(request) -> dict:
     if request.META.get("HTTP_HOST") not in settings.ASSISTANT["HOSTS"]:
         return base
 
-    search_form = SearchForm(prefix="header")
-    home_search_form = SearchForm(prefix="home")
+    search_form = SearchForm(prefix="header", initial={"id": "header"})
+    home_search_form = SearchForm(prefix="home", initial={"id": "home"})
 
     return {
         **base,

--- a/e2e_tests/assistant.spec.ts
+++ b/e2e_tests/assistant.spec.ts
@@ -46,18 +46,41 @@ test(
   async ({ page }) => {
     // Navigate to the carte page
     await page.goto(`/`, { waitUntil: "domcontentloaded" })
+    await hideDjangoToolbar(page)
+
     await page.locator("#id_home-input").click()
-    await page.locator("#id_home-input").fill("lave")
-    expect(await page.locator("#home:search-results a").count()).toBeGreaterThan(0)
+    await page.locator("#id_home-input").pressSequentially("lave")
+    // We expect at least on search result
+    await page.waitForResponse(
+      (response) =>
+        response.url().includes("/assistant/recherche") && response.status() === 200,
+    )
+    expect(page.locator("#home [data-search-target=results] a").first()).toBeAttached()
 
     await page.locator("#id_header-input").click()
-    expect(await page.locator("#home:search-results a").count()).toBe(0)
-    await page.locator("#id_header-input").fill("lave")
-    expect(await page.locator("#header:search-results a").count()).toBeGreaterThan(0)
+    await page.waitForResponse(
+      (response) =>
+        response.url().includes("/assistant/recherche") && response.status() === 200,
+    )
+    expect(
+      page.locator("#home [data-search-target=results] a").first(),
+    ).not.toBeAttached()
+    await page.locator("#id_header-input").pressSequentially("lave")
+    expect(
+      page.locator("#header [data-search-target=results] a").first(),
+    ).toBeAttached()
 
     await page.locator("#id_home-input").click()
-    expect(await page.locator("#home:search-results a").count()).toBe(0)
-    expect(await page.locator("#header:search-results a").count()).toBe(0)
+    await page.waitForResponse(
+      (response) =>
+        response.url().includes("/assistant/recherche") && response.status() === 200,
+    )
+    expect(
+      page.locator("#home [data-search-target=results] a").first(),
+    ).not.toBeAttached()
+    expect(
+      page.locator("#header [data-search-target=results] a").first(),
+    ).not.toBeAttached()
   },
 )
 

--- a/e2e_tests/assistant.spec.ts
+++ b/e2e_tests/assistant.spec.ts
@@ -62,10 +62,13 @@ test(
       (response) =>
         response.url().includes("/assistant/recherche") && response.status() === 200,
     )
-    expect(
-      page.locator("#home [data-search-target=results] a").first(),
-    ).not.toBeAttached()
+    expect(page.locator("#home [data-search-target=results] a")).toHaveCount(0)
     await page.locator("#id_header-input").pressSequentially("lave")
+    await page.waitForResponse(
+      (response) =>
+        response.url().includes("/assistant/recherche") && response.status() === 200,
+    )
+    expect(page.locator("#home [data-search-target=results] a")).toHaveCount(0)
     expect(
       page.locator("#header [data-search-target=results] a").first(),
     ).toBeAttached()
@@ -75,12 +78,8 @@ test(
       (response) =>
         response.url().includes("/assistant/recherche") && response.status() === 200,
     )
-    expect(
-      page.locator("#home [data-search-target=results] a").first(),
-    ).not.toBeAttached()
-    expect(
-      page.locator("#header [data-search-target=results] a").first(),
-    ).not.toBeAttached()
+    expect(page.locator("#home [data-search-target=results] a")).toHaveCount(0)
+    expect(page.locator("#header [data-search-target=results] a")).toHaveCount(0)
   },
 )
 

--- a/e2e_tests/assistant.spec.ts
+++ b/e2e_tests/assistant.spec.ts
@@ -32,6 +32,35 @@ test("Le lien infotri est bien défini", async ({ page }) => {
   expect(href).toBe("https://www.ecologie.gouv.fr/info-tri")
 })
 
+test(
+  "Les deux recherches en page d'accueil fonctionnent",
+  {
+    annotation: [
+      {
+        type: "issue",
+        description:
+          "https://www.notion.so/accelerateur-transition-ecologique-ademe/Assistant-Probl-me-sur-la-double-recherche-en-page-d-accueil-22a6523d57d78057981df59c74704cf9?source=copy_link",
+      },
+    ],
+  },
+  async ({ page }) => {
+    // Navigate to the carte page
+    await page.goto(`/`, { waitUntil: "domcontentloaded" })
+    await page.locator("#id_home-input").click()
+    await page.locator("#id_home-input").fill("lave")
+    expect(await page.locator("#home:search-results a").count()).toBeGreaterThan(0)
+
+    await page.locator("#id_header-input").click()
+    expect(await page.locator("#home:search-results a").count()).toBe(0)
+    await page.locator("#id_header-input").fill("lave")
+    expect(await page.locator("#header:search-results a").count()).toBeGreaterThan(0)
+
+    await page.locator("#id_home-input").click()
+    expect(await page.locator("#home:search-results a").count()).toBe(0)
+    expect(await page.locator("#header:search-results a").count()).toBe(0)
+  },
+)
+
 test("Le tracking PostHog fonctionne comme prévu", async ({ page }) => {
   // Check that homepage scores 1
   await page.goto(`/`, { waitUntil: "domcontentloaded" })

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -23,7 +23,7 @@ module "database" {
   environment     = var.environment
   tags            = var.tags
   node_type       = "DB-PRO2-XXS"
-  volume_size     = 300
+  volume_size     = 200
   db_username     = var.db_username
   db_password     = var.db_password
   db_name         = var.db_name

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -23,7 +23,7 @@ module "database" {
   environment     = var.environment
   tags            = var.tags
   node_type       = "DB-PRO2-XXS"
-  volume_size     = 200
+  volume_size     = 300
   db_username     = var.db_username
   db_password     = var.db_password
   db_name         = var.db_name

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "eslint-config-prettier": "^10.1.5",
         "leaflet": "^1.9.4",
         "posthog-js": "^1.256.0",
+        "stimulus-use": "^0.52.3",
         "tailwindcss": "^3.4.17"
       },
       "devDependencies": {
@@ -7726,6 +7727,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hotkeys-js": {
+      "version": "3.13.14",
+      "resolved": "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.13.14.tgz",
+      "integrity": "sha512-jmWwEP3twlpPV2/WpzuQzJTg/0MRjWlvKJScEREueIuzoMJ6gmqNrv6sm1WIpW+3g0TzDmQpj2pX8HvYPx90hw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -11448,6 +11459,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stimulus-use": {
+      "version": "0.52.3",
+      "resolved": "https://registry.npmjs.org/stimulus-use/-/stimulus-use-0.52.3.tgz",
+      "integrity": "sha512-stZ5dID6FUrGCR/ChWUa0FT5Z8iqkzT6lputOAb50eF+Ayg7RzJj4U/HoRlp2NV333QfvoRidru9HLbom4hZVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@hotwired/stimulus": ">= 3",
+        "hotkeys-js": ">= 3"
       }
     },
     "node_modules/stop-iteration-iterator": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-config-prettier": "^10.1.5",
     "leaflet": "^1.9.4",
     "posthog-js": "^1.256.0",
+    "stimulus-use": "^0.52.3",
     "tailwindcss": "^3.4.17"
   },
   "devDependencies": {

--- a/qfdmd/forms.py
+++ b/qfdmd/forms.py
@@ -19,14 +19,9 @@ class SearchInput(forms.TextInput):
 
 
 class SearchForm(DsfrBaseForm):
+    id = forms.CharField(required=False, widget=forms.HiddenInput())
     input = forms.CharField(
         help_text="Entrez un objet ou un déchet", required=False, widget=SearchInput
-    )
-    iframe = forms.BooleanField(
-        required=False,
-        help_text="Ce champ sert uniquement à faire persister le mode iframe d'une page"
-        "à une recherche",
-        widget=forms.HiddenInput,
     )
 
     def search(self) -> dict[str, str]:

--- a/qfdmd/views.py
+++ b/qfdmd/views.py
@@ -47,7 +47,13 @@ SEARCH_VIEW_TEMPLATE_NAME = "components/search/view.html"
 
 
 def search_view(request) -> HttpResponse:
-    form = SearchForm(request.GET)
+    form_kwargs = {}
+
+    if prefix := request.GET.get("prefix"):
+        form_kwargs.update(prefix=prefix)
+
+    form = SearchForm(request.GET, **form_kwargs)
+
     context = {}
     template_name = SEARCH_VIEW_TEMPLATE_NAME
 

--- a/qfdmd/views.py
+++ b/qfdmd/views.py
@@ -47,14 +47,16 @@ SEARCH_VIEW_TEMPLATE_NAME = "components/search/view.html"
 
 
 def search_view(request) -> HttpResponse:
+    prefix_key = next(
+        (key for key in request.GET.dict().keys() if key.endswith("-id")), ""
+    )
     form_kwargs = {}
 
-    if prefix := request.GET.get("prefix"):
-        form_kwargs.update(prefix=prefix)
+    if prefix := request.GET[prefix_key]:
+        form_kwargs.update(prefix=prefix, initial={"id": prefix})
 
     form = SearchForm(request.GET, **form_kwargs)
-
-    context = {}
+    context = {"prefix": form_kwargs, "prefix_key": prefix_key}
     template_name = SEARCH_VIEW_TEMPLATE_NAME
 
     if form.is_valid():

--- a/static/to_compile/controllers/assistant/search.ts
+++ b/static/to_compile/controllers/assistant/search.ts
@@ -11,14 +11,14 @@ export default class extends ClickOutsideController {
   }
 
   submitFirstItem() {
-    const firstResult = document.querySelector<HTMLAnchorElement>("#search-results > a")
+    const firstResult = this.resultsTarget.querySelector<HTMLAnchorElement>("a")
     if (firstResult) {
       firstResult.click()
     }
   }
 
   clear() {
-    for (const inputElement of this.formTarget.querySelectorAll("input")) {
+    for (const inputElement of this.formTarget.querySelectorAll("input[type=text]")) {
       inputElement.value = ""
       this.submitForm()
     }

--- a/static/to_compile/controllers/assistant/search.ts
+++ b/static/to_compile/controllers/assistant/search.ts
@@ -1,8 +1,10 @@
 import { Controller } from "@hotwired/stimulus"
+import { ClickOutsideController } from "stimulus-use"
 
-export default class extends Controller<HTMLFormElement> {
+export default class extends ClickOutsideController {
   declare readonly formTarget: HTMLFormElement
-  static targets = ["form"]
+  declare readonly resultsTarget: HTMLElement
+  static targets = ["form", "results"]
 
   submitForm() {
     this.formTarget.requestSubmit()
@@ -23,11 +25,9 @@ export default class extends Controller<HTMLFormElement> {
   }
 
   #move(direction: "up" | "down") {
-    const searchResultAlreadyFocused = document.querySelector<HTMLAnchorElement>(
-      "#search-results > a:focus",
-    )
-    let elementToFocus =
-      document.querySelector<HTMLAnchorElement>("#search-results > a")
+    const searchResultAlreadyFocused =
+      this.resultsTarget.querySelector<HTMLAnchorElement>("a:focus")
+    let elementToFocus = this.resultsTarget.querySelector<HTMLAnchorElement>("a")
 
     if (searchResultAlreadyFocused) {
       searchResultAlreadyFocused.blur()

--- a/templates/components/search/view.html
+++ b/templates/components/search/view.html
@@ -1,7 +1,9 @@
-<turbo-frame id="search">
+{% with frame_id=search_form.prefix %}
+<turbo-frame id="{{ frame_id }}">
     <div
         data-controller="search"
         data-action="
+            search:click:outside->search#clear:prevent
             keydown.esc->search#clear:prevent
             keydown.up->search#up:prevent
             keydown.down->search#down:prevent"
@@ -16,7 +18,7 @@
     >
         <form
             data-search-target="form"
-            data-turbo-frame="{{ id|default:'search-results' }}"
+            data-turbo-frame="{{ frame_id }}:search-results"
             action="{% url 'qfdmd:search' %}"
             class="qf-pl-4w {# should match the svg icon width #}
             qf-flex qf-flex-row-reverse qf-relative
@@ -25,6 +27,9 @@
             qf-content-center
             "
         >
+            {% if frame_id %}
+                <input name="prefix" value="{{ frame_id }}" type="hidden">
+            {% endif %}
 
             {% for field in search_form %}
                 {{ field }}
@@ -45,7 +50,8 @@
         </form>
 
         <turbo-frame
-            id="search-results"
+            id="{{ frame_id }}:search-results"
+            data-search-target="results"
             class="qf-flex qf-flex-col"
         >
             {% if search_form.results %}
@@ -56,3 +62,4 @@
         </turbo-frame>
     </div>
 </turbo-frame>
+{% endwith %}

--- a/templates/components/search/view.html
+++ b/templates/components/search/view.html
@@ -1,5 +1,5 @@
-{% with frame_id=search_form.prefix %}
-<turbo-frame id="{{ frame_id }}">
+{% with id=search_form.id.value %}
+<turbo-frame id="{{ id }}">
     <div
         data-controller="search"
         data-action="
@@ -18,7 +18,7 @@
     >
         <form
             data-search-target="form"
-            data-turbo-frame="{{ frame_id }}:search-results"
+            data-turbo-frame="{{ id }}:search-results"
             action="{% url 'qfdmd:search' %}"
             class="qf-pl-4w {# should match the svg icon width #}
             qf-flex qf-flex-row-reverse qf-relative
@@ -27,10 +27,6 @@
             qf-content-center
             "
         >
-            {% if frame_id %}
-                <input name="prefix" value="{{ frame_id }}" type="hidden">
-            {% endif %}
-
             {% for field in search_form %}
                 {{ field }}
             {% endfor %}
@@ -50,7 +46,7 @@
         </form>
 
         <turbo-frame
-            id="{{ frame_id }}:search-results"
+            id="{{ id }}:search-results"
             data-search-target="results"
             class="qf-flex qf-flex-col"
         >

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -14,7 +14,7 @@
     {# search + patchwork #}
     <div class="qf-w-full qf-max-w-3xl qf-m-auto qf-relative qf-pb-6w">
         <div class="qf-absolute qf-left-0 qf-right-0 qf-top-0">
-            {% include "components/search/view.html" with big=True id="search-home" %}
+            {% include "components/search/view.html" with big=True search_form=home_search_form %}
         </div>
     </div>
 


### PR DESCRIPTION
# Description succincte du problème résolu

https://www.notion.so/accelerateur-transition-ecologique-ademe/Assistant-Probl-me-sur-la-double-recherche-en-page-d-accueil-22a6523d57d78057981df59c74704cf9?source=copy_link


**🗺️ contexte**: assistant v2, recherche page d'accueil

On a désormais deux recherches en page d'accueil : celle du header et celle principale. 
On a donc besoin de namespacer nos turbo frames pour éviter les conflits. 

On utilise une combinaison entre un champ `id` passé dans nos turbo frame avec un champ prefix qui va être utile pour namespacer nos champs de formulaires 

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

