### PR TITLE
Ajout d'un expiration lors de la cération du backup

### DIFF
--- a/scripts/infrastructure/backup-db.sh
+++ b/scripts/infrastructure/backup-db.sh
@@ -22,8 +22,10 @@ fi
 
 # Créer le backup
 BACKUP_NAME="backup-manuel-qfdmo-$(date +%Y%m%d%H%M%S)"
-echo "Création du backup $BACKUP_NAME..."
-BACKUP_ID=$(scw rdb backup create instance-id=$INSTANCE_ID database-name=qfdmo name=$BACKUP_NAME | grep "^ID\s" | awk '{print $2}')
+# Définir la date d'expiration dans une semaine au format ISO 8601
+EXPIRATION_DATE=$(date -u -v+7d +"%Y-%m-%dT%H:%M:%SZ")
+echo "Création du backup $BACKUP_NAME (expire le $EXPIRATION_DATE)..."
+BACKUP_ID=$(scw rdb backup create instance-id=$INSTANCE_ID database-name=qfdmo name=$BACKUP_NAME expires-at=$EXPIRATION_DATE | grep "^ID\s" | awk '{print $2}')
 
 if [ -z "$BACKUP_ID" ]; then
     echo "Erreur lors de la création du backup"


### PR DESCRIPTION
# Description succincte du problème résolu

Ajout d'une expiration à une semaine lors de la création d'un backup via le script `backup-db.sh`
permet de ne pas se trainer 2000 backup

**🗺️ contexte**: Makefile / script

**💡 quoi**: expiration des backup

**🎯 pourquoi**: limiter le nombre de backup stocké

**🤔 comment**: ajout du paramètre expire-at lors de la création du backup en ligne de commande

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
