### PR TITLE
L'option keep_empty n'est applicable que pour la modification de parent

### DIFF
--- a/dags/cluster/dags/cluster_acteur_suggestions.py
+++ b/dags/cluster/dags/cluster_acteur_suggestions.py
@@ -273,7 +273,8 @@ PARAMS = {
         type="boolean",
         description_md=r"""**∅ CONSERVER LE VIDE**: si OUI et qu'une valeur
         vide est rencontrée sur une source prioritaire, alors elle sera
-        conservée""",
+        conservée.
+        **Cette option n'est appliquée que lors de la mis à jour du parent**""",
     ),
     "dedup_enrich_keep_parent_data_by_default": Param(
         True,
@@ -281,7 +282,7 @@ PARAMS = {
         description_md=r"""
 ** CONSERVER LES DONNÉES DU PARENT**: si OUI, les données du parent seront conservées.
 
-Lorsque l'option `dedup_enrich_keep_empty` est:
+Dans le cas de la mise à jour du parent, lorsque l'option `dedup_enrich_keep_empty` est:
  - VRAI, toutes les données du parent même vides sont conservées
  - FAUX, seules les données non-vides du parent sont conservées
 """,

--- a/dags/cluster/tasks/business_logic/cluster_acteurs_parents_choose_data.py
+++ b/dags/cluster/tasks/business_logic/cluster_acteurs_parents_choose_data.py
@@ -113,6 +113,8 @@ def cluster_acteurs_parents_choose_data(
         # Acteurs to consider: first revisions, then base, but not from excluded sources
         acteurs = list(acteurs_revision) + list(acteurs_base)
         acteurs.sort(key=source_priority)
+        if not parent:
+            keep_empty = False
         if parent and keep_parent_data_by_default:
             acteurs = [parent] + acteurs
 

--- a/dags/cluster/tasks/business_logic/cluster_acteurs_parents_choose_data.py
+++ b/dags/cluster/tasks/business_logic/cluster_acteurs_parents_choose_data.py
@@ -113,6 +113,7 @@ def cluster_acteurs_parents_choose_data(
         # Acteurs to consider: first revisions, then base, but not from excluded sources
         acteurs = list(acteurs_revision) + list(acteurs_base)
         acteurs.sort(key=source_priority)
+        # On parent creation, we don't want to keep empty data
         if not parent:
             keep_empty = False
         if parent and keep_parent_data_by_default:

--- a/dags/tests/cluster/tasks/business_logic/test_cluster_acteurs_parents_choose_data.py
+++ b/dags/tests/cluster/tasks/business_logic/test_cluster_acteurs_parents_choose_data.py
@@ -243,3 +243,56 @@ class TestClusterActeursParentsChooseData:
         assert (
             df.loc[df["identifiant_unique"] != "p1", "parent_data_new"].isnull().all()
         ), "tester que tous les autres sont None"
+
+    def test_cluster_acteurs_parents_choose_data_parent_keep_keep_empty(
+        self,
+        df_clusters_parent_keep,
+        sources,
+    ):
+        df = cluster_acteurs_parents_choose_data(
+            df_clusters=df_clusters_parent_keep,
+            fields_to_include=["nom", "siret", "email"],
+            exclude_source_ids=[],
+            prioritize_source_ids=[sources[0].id, sources[1].id],
+            keep_empty=True,
+        )
+
+        print(df)
+        # Retrieve parent data
+        assert (
+            df.loc[df["identifiant_unique"] == "p1", "parent_data_new"].values[0] == {}
+        ), (
+            "keep_empty is True, first email is empty, as it is the same than parent"
+            " email value, the update in empty"
+        )
+        # tester que tous les autres sont None
+        assert (
+            df.loc[df["identifiant_unique"] != "p1", "parent_data_new"].isnull().all()
+        )
+
+    def test_cluster_acteurs_parents_choose_data_parent_create_keep_empty(
+        self,
+        df_clusters_parent_create,
+        sources,
+    ):
+        df = cluster_acteurs_parents_choose_data(
+            df_clusters=df_clusters_parent_create,
+            fields_to_include=["nom", "siret", "email"],
+            exclude_source_ids=[],
+            prioritize_source_ids=[sources[2].id],
+            keep_empty=True,
+        )
+
+        # Retrieve parent data
+        assert df.loc[df["identifiant_unique"] == "p1", "parent_data_new"].values[
+            0
+        ] == {
+            "nom": "prio 1",
+            "email": "email.acteur@source.3",
+        }, (
+            "keep_empty is forced to False and the empty email is ignored until"
+            " found `email.acteur@source.3`"
+        )
+        assert (
+            df.loc[df["identifiant_unique"] != "p1", "parent_data_new"].isnull().all()
+        ), "tester que tous les autres sont None"


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [Le clustering ne devrait pas créer des parents vides (notamment “Nom” vide)](https://www.notion.so/accelerateur-transition-ecologique-ademe/Le-clustering-ne-devrait-pas-cr-er-des-parents-vides-notamment-Nom-vide-2386523d57d780749127d53bfeff39a0)

**🗺️ contexte**: Airflow - clustering

**💡 quoi**: Appliquer l'option keep_empty_data seulement pour les parents à mettre à jour mais pas pour la création de parent

**🎯 pourquoi**: sinon, il y a des cas de parents vides

**🤔 comment**: 

- Forcer l'option `keep_empty` à False quand il n'existe pas de parent au sein du cluster au moment de choisir les données à attribuer au parent
- Modification du help text des options du dag de clustering

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
