### PR TITLE
Création d’un footer avec plan du site 

### DIFF
--- a/templates/components/footer/_dsfr_footer.html
+++ b/templates/components/footer/_dsfr_footer.html
@@ -1,6 +1,14 @@
 {% extends "dsfr/footer.html" %}
 {% load menu_tags %}
 
+{% block footer_top %}
+<div class="fr-footer__top">
+    {% if request %}
+    {% flat_menu handle="surfooter_assistant" template="components/footer/footer-menu.html" %}
+    {% endif %}
+</div>
+{% endblock footer_top %}
+
 {% block footer_links %}
 {% if request %}
 {% flat_menu handle="footer_assistant" template="components/footer/footer-menu.html" %}

--- a/templates/components/footer/footer.html
+++ b/templates/components/footer/footer.html
@@ -1,10 +1,8 @@
-<div class="qf-bg-grey-1000-50-hover qf-py-9w">
-    {% if request.iframe %}
-        {% include "./_embedded.html" %}
-    {% else %}
-        {% include "./_standalone.html" %}
-    {% endif %}
-</div>
+{% if request.iframe %}
+    <div class="qf-bg-grey-1000-50-hover qf-py-9w">
+    {% include "./_embedded.html" %}
+    </div>
+{% endif %}
 
 {% if not iframe %}
     {% include "./_dsfr_footer.html" %}


### PR DESCRIPTION
# Description succincte du problème résolu

https://www.notion.so/accelerateur-transition-ecologique-ademe/AST-2-Desktop-Mobile-Cr-ation-d-un-footer-avec-plan-du-site-1976523d57d78040beb4cd68bf551ebf?source=copy_link


**🗺️ contexte**: Assistant v2

**💡 quoi**: Ajout d'un footer conformément aux maquettes

**🎯 pourquoi**: Pour apporter un plan du site dans le footer

**🤔 comment**: 

- Implémentation du DSFR, car le composant django-dsfr n'inclut pas ce menu
- Utilisation d'un menu wagtail/sites faciles

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## 📆 A faire une fois la modif déployée

- [ ] Créer le menu en preprod / prod `surfooter_assistant`