### PR TITLE
L'option exclusivité de source doit prendre en compte les sources des parents

### DIFF
--- a/dags/cluster/tasks/business_logic/cluster_acteurs_clusters.py
+++ b/dags/cluster/tasks/business_logic/cluster_acteurs_clusters.py
@@ -22,7 +22,6 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 from slugify import slugify
 from unidecode import unidecode
-
 from utils import logging_utils as log
 
 logger = logging.getLogger(__name__)

--- a/dags/cluster/tasks/business_logic/cluster_acteurs_clusters.py
+++ b/dags/cluster/tasks/business_logic/cluster_acteurs_clusters.py
@@ -16,7 +16,7 @@ import re
 import numpy as np
 import pandas as pd
 from cluster.tasks.business_logic.misc.cluster_exclude_intra_source import (
-    cluster_exclude_intra_source,
+    split_clusters_infra_source,
 )
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
@@ -201,7 +201,12 @@ def cluster_acteurs_clusters(
         if re.search(r"(^id|^identifiant|_code$|_id$)", col, re.I)
     ]
     cols_to_keep = list(
-        set(cols_ids_codes + cluster_fields_exact + cluster_fields_fuzzy + ["nom"])
+        set(
+            cols_ids_codes
+            + cluster_fields_exact
+            + cluster_fields_fuzzy
+            + ["nom", "source_codes"]
+        )
     )
     df = df[cols_to_keep]
 
@@ -241,22 +246,15 @@ def cluster_acteurs_clusters(
             # Only relying on exact clustering
             clusters_potential.append(("exact", keys, exact_rows))
 
+        if not cluster_intra_source_is_allowed:
+            clusters_potential = split_clusters_infra_source(clusters_potential)
+
         # For all potential clusters, we apply the intra-source logic
-        for ctype, keys, rows in clusters_potential:
+        for _, keys, rows in clusters_potential:
             cluster_id = cluster_id_from_strings(keys)
             rows["cluster_id"] = cluster_id
 
-            if cluster_intra_source_is_allowed:
-                clusters.append(rows.copy())
-            else:
-                kept, lost = cluster_exclude_intra_source(rows)
-                if isinstance(lost, pd.DataFrame):
-                    log.preview_df_as_markdown("❌ Acteurs intra-source exclus", lost)
-                if len(kept) < 2:
-                    log.preview_df_as_markdown("🔴 Cluster de taille <2", kept)
-                    continue
-                log.preview_df_as_markdown(f"🟢 Cluster {ctype} conservé", kept)
-                clusters.append(kept.copy())
+            clusters.append(rows.copy())
 
     if not clusters:
         return pd.DataFrame()

--- a/dags/cluster/tasks/business_logic/cluster_acteurs_read/for_clustering.py
+++ b/dags/cluster/tasks/business_logic/cluster_acteurs_read/for_clustering.py
@@ -62,9 +62,9 @@ def cluster_acteurs_read_for_clustering(
     logger.info(f"# orphelins récupérées: {len(df_orphans)}")
     if df_orphans.empty:
         return df_orphans
-    log.preview("# acteurs par source_id", df_orphans.groupby("source_id").size())
+    log.preview("# acteurs par source_code", df_orphans.groupby("source_code").size())
     log.preview(
-        "# acteurs par acteur_type_id", df_orphans.groupby("acteur_type_id").size()
+        "# acteurs par acteur_type_code", df_orphans.groupby("acteur_type_code").size()
     )
     log.preview_df_as_markdown("acteurs sélectionnés", df_orphans)
     df_orphans = df_sort(df_orphans)

--- a/dags/cluster/tasks/business_logic/cluster_acteurs_read/orphans.py
+++ b/dags/cluster/tasks/business_logic/cluster_acteurs_read/orphans.py
@@ -157,5 +157,6 @@ def cluster_acteurs_read_orphans(
     mapping_source_codes_by_ids = {x.id: x.code for x in Source.objects.all()}
     mapping_acteur_type_codes_by_ids = {x.id: x.code for x in ActeurType.objects.all()}
     df["source_code"] = df["source_id"].map(mapping_source_codes_by_ids)
+    df["source_codes"] = df["source_code"].apply(lambda x: [x])
     df["acteur_type_code"] = df["acteur_type_id"].map(mapping_acteur_type_codes_by_ids)
     return df, sql

--- a/dags/cluster/tasks/business_logic/misc/df_sort.py
+++ b/dags/cluster/tasks/business_logic/misc/df_sort.py
@@ -1,6 +1,5 @@
 import pandas as pd
 from cluster.config.constants import COL_PARENT_DATA_NEW
-
 from utils.django import django_setup_full
 
 django_setup_full()
@@ -32,9 +31,19 @@ def df_sort(
     ]
     sort_rows = [x for x in sort_rows if x in df.columns]
     sort_rows += [
-        x for x in df.columns if x not in cluster_fields_exact and x not in sort_rows
+        x
+        for x in df.columns
+        if x not in cluster_fields_exact and x not in sort_rows
+        # remove column of type list because they aren't sortable
+        and not df[x].apply(lambda y: isinstance(y, list)).any()
     ]
-    df = df.sort_values(by=sort_rows)[sort_rows]
+    # keep column of type list in the df after sorting
+    list_rows = [
+        x
+        for x in df.columns
+        if x not in sort_rows and df[x].apply(lambda y: isinstance(y, list)).any()
+    ]
+    df = df.sort_values(by=sort_rows)[sort_rows + list_rows]
 
     # SORTING COLUMNS: by what makes sense for debugging
     sort_cols = [

--- a/dags/tests/cluster/tasks/business_logic/test_cluster_acteurs_clusters.py
+++ b/dags/tests/cluster/tasks/business_logic/test_cluster_acteurs_clusters.py
@@ -39,6 +39,15 @@ class TestClusterActeursClusters:
                 ],
                 "source_id": range(1, 8),
                 "source_code": ["s1", "s2", "s3", "s4", "s5", "s6", "s7"],
+                "source_codes": [
+                    ["s1"],
+                    ["s2"],
+                    ["s3"],
+                    ["s4"],
+                    ["s5"],
+                    ["s6"],
+                    ["s7"],
+                ],
                 "code_departement": ["75", "75", "75", "75", "75", "53", "53"],
                 "code_postal": [
                     "75000",
@@ -76,6 +85,8 @@ class TestClusterActeursClusters:
             df_basic,
             cluster_fields_exact=["ville"],
             cluster_fields_fuzzy=[],
+            cluster_fuzzy_threshold=0.5,
+            cluster_intra_source_is_allowed=True,
         )
         assert len(df_clusters) == len(df_basic)
         assert df_clusters["cluster_id"].nunique() == 3
@@ -115,6 +126,8 @@ class TestClusterActeursClusters:
                     "id4",
                 ],
                 "source_id": range(1, 5),
+                "source_code": ["s1", "s2", "s3", "s4"],
+                "source_codes": [["s1"], ["s2"], ["s3"], ["s4"]],
                 "code_departement": ["13", "75", "53", "13"],
                 "code_postal": ["13000", "75000", "53000", "13000"],
                 "ville": ["Marseille", "Paris", "Laval", "Marseille"],
@@ -129,6 +142,8 @@ class TestClusterActeursClusters:
             df_some_clusters_of_one,
             cluster_fields_exact=["ville"],
             cluster_fields_fuzzy=[],
+            cluster_fuzzy_threshold=0.5,
+            cluster_intra_source_is_allowed=True,
         )
         assert len(df_clusters) == 2
         clusters = df_clusters_to_dict(df_clusters)
@@ -144,6 +159,8 @@ class TestClusterActeursClusters:
         return pd.DataFrame(
             {
                 "source_id": range(1, 8),
+                "source_code": ["s1", "s1", "s1", "s1", "s1", "s1", "s1"],
+                "source_codes": [["s1"] for _ in range(7)],
                 "code_postal": ["10000" for _ in range(7)],
                 "identifiant_unique": ["id" + str(i) for i in range(0, 7)],
                 "nom": [
@@ -167,6 +184,7 @@ class TestClusterActeursClusters:
             cluster_fields_exact=["code_postal"],
             cluster_fields_fuzzy=["nom"],
             cluster_fuzzy_threshold=0.7,
+            cluster_intra_source_is_allowed=True,
         )
         assert df_clusters["cluster_id"].nunique() == 3
         assert len(df_clusters) == 6
@@ -202,6 +220,7 @@ class TestClusterActeursClusters:
                     "statut": "ACTIF",
                     "source_id": 2513,
                     "source_code": "s2",
+                    "source_codes": ["s2"],
                 },
                 {
                     "identifiant_unique": "id13",
@@ -214,6 +233,7 @@ class TestClusterActeursClusters:
                     "statut": "ACTIF",
                     "source_id": None,
                     "source_code": None,
+                    "source_codes": ["s1"],
                 },
                 {
                     "identifiant_unique": "id14",
@@ -226,6 +246,7 @@ class TestClusterActeursClusters:
                     "statut": "ACTIF",
                     "source_id": 2512,
                     "source_code": "s1",
+                    "source_codes": ["s1"],
                 },
             ]
         )
@@ -234,7 +255,9 @@ class TestClusterActeursClusters:
             cluster_fields_exact=["code_postal", "ville"],
             cluster_fields_fuzzy=["nom"],
             cluster_fuzzy_threshold=0.5,
+            cluster_intra_source_is_allowed=True,
         )
+
         assert df_clusters["cluster_id"].nunique() == 1
         assert sorted(df_clusters["identifiant_unique"].tolist()) == [
             "id13",
@@ -264,6 +287,8 @@ class TestClusterActeursClusters:
             {
                 "identifiant_unique": ["orphan1", "orphan2"],
                 "source_id": [s1.id, s1.id],
+                "source_code": ["s1", "s1"],
+                "source_codes": [["s1"], ["s1"]],
                 "acteur_type_id": [at1.id, at1.id],
                 "ville": ["Laval", "Laval"],
                 "nombre_enfants": [0, 0],
@@ -446,3 +471,46 @@ class TestScoreTuplesToClusters:
         threshold = 0.5
         expected = [[1, 2, 3, 4]]
         assert score_tuples_to_clusters(data, threshold) == expected
+
+
+class TestClusterExcludeIntraSource:
+
+    @pytest.fixture
+    def df_acteurs(self):
+        return pd.DataFrame(
+            {
+                "identifiant_unique": ["a1", "a2", "a3", "a4", "a5", "a6", "a7"],
+                "source_codes": [
+                    ["s1"],
+                    ["s2"],
+                    ["s1", "s3"],
+                    ["s4"],
+                    ["s3"],
+                    ["s2"],
+                    ["s3"],
+                ],
+                "nom": ["décheterie du village" for _ in range(7)],
+            }
+        )
+
+    def test_cluster_split_clusterintra_source_intrasource_allowed(self, df_acteurs):
+        df_clusters = cluster_acteurs_clusters(
+            df_acteurs,
+            cluster_fields_exact=["nom"],
+            cluster_fields_fuzzy=[],
+            cluster_fuzzy_threshold=0.5,
+            cluster_intra_source_is_allowed=True,
+        )
+        assert df_clusters["cluster_id"].nunique() == 1
+
+    def test_cluster_split_clusterintra_source_intrasource_not_allowed(
+        self, df_acteurs
+    ):
+        df_clusters = cluster_acteurs_clusters(
+            df_acteurs,
+            cluster_fields_exact=["nom"],
+            cluster_fields_fuzzy=[],
+            cluster_fuzzy_threshold=0.5,
+            cluster_intra_source_is_allowed=False,
+        )
+        assert df_clusters["cluster_id"].nunique() == 2

--- a/dags/tests/cluster/tasks/business_logic/test_cluster_acteurs_clusters_prepare.py
+++ b/dags/tests/cluster/tasks/business_logic/test_cluster_acteurs_clusters_prepare.py
@@ -22,6 +22,7 @@ class TestClusterActeursClustersDisplay:
         the clustering function must return early with empty df"""
         at1 = ActeurTypeFactory(code="at1")
         s1 = SourceFactory(code="s1")
+        s2 = SourceFactory(code="s2")
         DisplayedActeurFactory(identifiant_unique="p1", acteur_type=at1, ville="Paris")
         DisplayedActeurFactory(
             identifiant_unique="orphan1", acteur_type=at1, ville="Laval", source=s1
@@ -30,6 +31,8 @@ class TestClusterActeursClustersDisplay:
             {
                 "identifiant_unique": ["p1", "orphan1"],
                 "source_id": [None, s1.id],
+                "source_code": [None, s1.code],
+                "source_codes": [[s1.code, s2.code], [s1.code]],
                 "acteur_type_id": [at1.id, at1.id],
                 "ville": ["Paris", "Laval"],
                 "nombre_enfants": [1, 0],
@@ -67,6 +70,8 @@ class TestClusterActeursClustersDisplay:
             {
                 "identifiant_unique": ["p1", "orphan1", "orphan2"],
                 "source_id": [None, s1.id, s2.id],
+                "source_code": [None, s1.code, s2.code],
+                "source_codes": [[s1.code, s2.code], [s1.code], [s2.code]],
                 "acteur_type_id": [at1.id, at1.id, at1.id],
                 "ville": ["Paris", "Laval", "Laval"],
                 "nombre_enfants": [1, 0, 0],

--- a/dags/tests/cluster/tasks/business_logic/test_cluster_acteurs_read_parents.py
+++ b/dags/tests/cluster/tasks/business_logic/test_cluster_acteurs_read_parents.py
@@ -97,6 +97,7 @@ class TestClusterActeursSelectionActeurTypeParents:
                 "statut",
                 "latitude",
                 "nom",
+                "source_codes",
             ]
         )
 


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [[Clustering] L’interdiction de clustering intra-source devrait s’appliquer AUSSI à l’éventuelle update de clusters (pas juste à la création)](https://www.notion.so/accelerateur-transition-ecologique-ademe/Clustering-L-interdiction-de-clustering-intra-source-devrait-s-appliquer-AUSSI-l-ventuelle-updat-2416523d57d780ba9306e4e591baf29b?source=copy_link)

**🗺️ contexte**: Airflow Clustering

**💡 quoi**: L'option `cluster_intra_source_is_allowed = False` doit aussi prend en compte les sources des parents

**🎯 pourquoi**: Sinon, l'option est buggé dès qu'il y a un parent existant

**🤔 comment**: 
- Ajout d'une colonne `source_codes` qui liste les sources des acteurs à rapprocher dans les clusters. Dans le cas des acteurs sans parent, la liste `source_codes` est de longueur 1, pour les parents la liste `source_codes` est >= 2
- Après la création des clusters, on redivise les clusters si `cluster_intra_source_is_allowed = False` pour que les clusters ne contiennent pas des acteurs qui apartiennent aux mêmes sources. On commence par les parents qui ont le plus de source et on mets de coté tous les acteurs (parents et enfants) qui appartiennent aux mêmes sources que les sources qui ont été parcourru. Puis on relance cette opération récursivement pour acteur qui ont été mis de coté.
- La fonction est testé unitaiement et en test d'intégration

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code
