### PR TITLE
Recherche des suggestions selon le texte de metadata

### DIFF
--- a/data/admin.py
+++ b/data/admin.py
@@ -3,11 +3,7 @@ import logging
 from django.contrib import admin, messages
 from django.utils.html import format_html
 
-from core.admin import (
-    NotEditableMixin,
-    NotSelfDeletableMixin,
-    QuerysetFilterAdmin,
-)
+from core.admin import NotEditableMixin, NotSelfDeletableMixin, QuerysetFilterAdmin
 from data.models.suggestion import Suggestion, SuggestionCohorte, SuggestionStatut
 
 NB_SUGGESTIONS_DISPLAYED_WHEN_DELETING = 100
@@ -35,6 +31,12 @@ class SuggestionCohorteAdmin(NotEditableMixin, admin.ModelAdmin):
         "__str__",
         "statut",
         "metadonnees",
+    ]
+
+    search_fields = ["metadata", "identifiant_action", "identifiant_execution"]
+    list_filter = [
+        ("statut", admin.ChoicesFieldListFilter),
+        ("type_action", admin.ChoicesFieldListFilter),
     ]
 
     def metadonnees(self, obj):
@@ -115,7 +117,7 @@ class SuggestionAdmin(NotSelfDeletableMixin, QuerysetFilterAdmin):
         def field_choices(self, field, request, model_admin):
             return field.get_choices(include_blank=False, ordering=("-cree_le",))
 
-    search_fields = ["contexte", "suggestion"]
+    search_fields = ["contexte", "suggestion", "metadata"]
     list_display = [
         "id",
         "cohorte",


### PR DESCRIPTION
# Description succincte du problème résolu

Permettre de chercher les suggestions par metadata
Amélioration de la recherche des cohortes dans l'admin

**🗺️ contexte**: Django Admin - data

**💡 quoi**: Meilleur recherche

**🎯 pourquoi**: simplifier la recherche pour Christian

**🤔 comment**: 
- Ajout du champ `metadata` dans la recherche des suggestion
- Ajout de la recherche pour les cohortes sur les champs `metadata`,  `identifiant_action`, `identifiant_execution`
- Ajout des filtres `statut` et `action_type` pour les cohortes

## Exemple résultats / UI / Data

<img width="2106" height="1284" alt="CleanShot 2025-08-06 at 09 52 31@2x" src="https://github.com/user-attachments/assets/69a451ad-d2c9-4e82-8060-f1dabfd0561b" />

<img width="2220" height="1176" alt="CleanShot 2025-08-06 at 09 53 32@2x" src="https://github.com/user-attachments/assets/ed2dfff5-29ff-41be-8f16-a03ef827d02e" />

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
