### PR TITLE
[Cluster] Normaliser aussi le paramètre de recherche par le nom

### DIFF
--- a/dags/cluster/tasks/business_logic/cluster_acteurs_read/orphans.py
+++ b/dags/cluster/tasks/business_logic/cluster_acteurs_read/orphans.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pandas as pd
 from shared.tasks.business_logic import normalize
-
 from utils.django import (
     django_model_queryset_generate,
     django_model_queryset_to_df,
@@ -131,7 +130,9 @@ def cluster_acteurs_read_orphans(
             # On applique la normalisation de base à la volée
             # pour simplifier les regex
             .map(normalize.string_basic).str.contains(
-                include_only_if_regex_matches_nom, na=False, regex=True
+                normalize.string_basic(include_only_if_regex_matches_nom),
+                na=False,
+                regex=True,
             )
         ].copy()
 


### PR DESCRIPTION
# Description succincte du problème résolu

Mattermost : Pb quand include_only_if_regex_matches_nom = "Mat'ild", les majuscules et caractères spéciaux semblent casser el matching

**🗺️ contexte**: Airflow - Clustering

**💡 quoi**: include_only_if_regex_matches_nom = "Mat'ild" ne marche pas

**🎯 pourquoi**: le champ `nom` est normalisé mais pas le paramètre `include_only_if_regex_matches_nom`

**🤔 comment**: nomaliser le paramètre `include_only_if_regex_matches_nom`

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
