### PR TITLE
Affichage des consignes d'accès et initialisation pour les déchèteries

### DIFF
--- a/jinja2/qfdmo/acteur/tabs/about_panel.html
+++ b/jinja2/qfdmo/acteur/tabs/about_panel.html
@@ -24,6 +24,10 @@
         {% include "qfdmo/acteur/tabs/sections/description.html" %}
     {% endif %}
 
+    {% if object.consignes_dacces %}
+        {% include "qfdmo/acteur/tabs/sections/consignes_dacces.html" %}
+    {% endif %}
+
     {% if object.sorted_acteur_services_libelles %}
         {% include "qfdmo/acteur/tabs/sections/services_disponibles.html" %}
     {% endif %}

--- a/jinja2/qfdmo/acteur/tabs/sections/consignes_dacces.html
+++ b/jinja2/qfdmo/acteur/tabs/sections/consignes_dacces.html
@@ -1,0 +1,9 @@
+{% extends "qfdmo/acteur/tabs/_section.html" %}
+
+{% block title %}
+Consignes d'accès
+{% endblock title %}
+
+{% block content %}
+{{ object.consignes_dacces|linebreaks|safe }}
+{% endblock content %}

--- a/qfdmo/management/commands/fill_consignes_dacces.py
+++ b/qfdmo/management/commands/fill_consignes_dacces.py
@@ -1,0 +1,45 @@
+from django.core.management.base import BaseCommand
+
+from qfdmo.models.acteur import Acteur, ActeurStatus, RevisionActeur
+
+consignes_dacces = (
+    "Un badge d'accès peut vous être demandé à l’entrée."
+    " Nous vous invitons à vous renseigner avant de vous rendre sur place."
+)
+
+
+def add_consignes_dacces():
+    for acteur in Acteur.objects.filter(acteur_type__code="decheterie"):
+        print("ACTEUR", acteur.identifiant_unique)
+        if acteur.statut != ActeurStatus.ACTIF:
+            revision_acteur = RevisionActeur.objects.filter(
+                identifiant_unique=acteur.identifiant_unique
+            ).first()
+            if revision_acteur is None or revision_acteur.statut != ActeurStatus.ACTIF:
+                continue
+        else:
+            revision_acteur = acteur.get_or_create_revision()
+        parent_revision_acteur = revision_acteur.parent
+        if (
+            parent_revision_acteur is None
+            and not revision_acteur.consignes_dacces
+            and revision_acteur.statut == ActeurStatus.ACTIF
+        ):
+            print("REVISION ACTEUR", revision_acteur.identifiant_unique)
+            revision_acteur.consignes_dacces = consignes_dacces
+            revision_acteur.save()
+        elif (
+            parent_revision_acteur is not None
+            and not parent_revision_acteur.consignes_dacces
+            and parent_revision_acteur.statut == ActeurStatus.ACTIF
+        ):
+            print("PARENT REVISION ACTEUR", parent_revision_acteur.identifiant_unique)
+            parent_revision_acteur.consignes_dacces = consignes_dacces
+            parent_revision_acteur.save()
+
+
+class Command(BaseCommand):
+    help = "Initialisation des consignes d'accès pour les déchèteries"
+
+    def handle(self, *args, **options):
+        add_consignes_dacces()


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [Déchèteries : ajouter warning : besoin (possible) de présenter un badge pour accéder](https://www.notion.so/accelerateur-transition-ecologique-ademe/D-ch-teries-ajouter-warning-besoin-possible-de-pr-senter-un-badge-pour-acc-der-1fb6523d57d78091911fcc996f7892f2?source=copy_link)

**🗺️ contexte**: Webapp

**💡 quoi**: Afficher les consignes d'accès + mettre à jour les consignes d'accès pour les déchetteries

**🎯 pourquoi**: Besoin d'afficher les consignes d'accès

**🤔 comment**: Affichage sous la description + script pour populer les consignes d'accès des déchèteries

## Exemple résultats / UI / Data

<img width="2748" height="1570" alt="CleanShot 2025-08-11 at 14 46 15@2x" src="https://github.com/user-attachments/assets/643a7eeb-7c87-4c24-8925-7415b675a681" />

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## 📆 A faire (prochaine PR)

- [ ] Lancer le script `fill_consignes_dacces` en preprod et en prod
