### PR TITLE
La date de début du dag est souvent pas initialisée au bon endroit

### DIFF
--- a/dags/acteurs/dags/compute_acteur.py
+++ b/dags/acteurs/dags/compute_acteur.py
@@ -1,6 +1,5 @@
 from datetime import timedelta
 
-import pendulum
 from acteurs.tasks.airflow_logic.check_model_table_consistency_task import (
     check_model_table_consistency_task,
 )
@@ -10,12 +9,12 @@ from acteurs.tasks.airflow_logic.replace_acteur_table_task import (
 from airflow import DAG
 from airflow.operators.bash import BashOperator
 from shared.config.schedules import SCHEDULES
+from shared.config.start_dates import START_DATES
 from shared.config.tags import TAGS
 
 default_args = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": pendulum.today("UTC").add(days=-1),
     "email_on_failure": False,
     "email_on_retry": False,
     "retries": 3,
@@ -29,6 +28,7 @@ dbt_test = "dbt test --resource-type model --select"
 with DAG(
     "compute_acteurs",
     default_args=default_args,
+    start_date=START_DATES.YESTERDAY,
     dag_display_name="Acteurs affichés - Rafraîchir les acteurs affichés",
     description=(
         "Ce DAG construit les tables des acteurs utilisables par l'admin"

--- a/dags/acteurs/dags/export_opendata.py
+++ b/dags/acteurs/dags/export_opendata.py
@@ -1,12 +1,12 @@
 from datetime import timedelta
 
-import pendulum
 from acteurs.tasks.airflow_logic.export_opendata_csv_to_s3_task import (
     export_opendata_csv_to_s3_task,
 )
 from airflow import DAG
 from decouple import config
 from shared.config.schedules import SCHEDULES
+from shared.config.start_dates import START_DATES
 from shared.config.tags import TAGS
 
 ENVIRONMENT = config("ENVIRONMENT", default="development")
@@ -14,7 +14,6 @@ ENVIRONMENT = config("ENVIRONMENT", default="development")
 default_args = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": pendulum.today("UTC").add(days=-1),
     "email_on_failure": False,
     "email_on_retry": False,
     "retries": 3,
@@ -25,6 +24,7 @@ default_args = {
 with DAG(
     "export_opendata_dag",
     default_args=default_args,
+    start_date=START_DATES.YESTERDAY,
     dag_display_name="Acteurs Open-Data - Exporter les Acteurs en Open-Data",
     description=(
         "Ce DAG export les acteurs disponibles en opendata précédemment générés dans la"

--- a/dags/crawl/dags/crawl_urls.py
+++ b/dags/crawl/dags/crawl_urls.py
@@ -1,4 +1,3 @@
-import pendulum
 from airflow import DAG
 from airflow.models.param import Param
 from crawl.tasks.airflow_logic.crawl_urls_check_crawl_task import (
@@ -25,6 +24,7 @@ from crawl.tasks.airflow_logic.crawl_urls_suggest_dns_fail_task import (
 from crawl.tasks.airflow_logic.crawl_urls_suggest_syntax_fail_task import (
     crawl_urls_suggest_syntax_fail_task,
 )
+from shared.config.start_dates import START_DATES
 from shared.config.tags import TAGS
 
 UI_PARAMS_SEPARATOR_SELECTION = r"""
@@ -43,11 +43,11 @@ with DAG(
     default_args={
         "owner": "airflow",
         "depends_on_past": False,
-        "start_date": pendulum.today("UTC").add(days=-1),
         "email_on_failure": False,
         "email_on_retry": False,
         "retries": 0,
     },
+    start_date=START_DATES.YESTERDAY,
     catchup=False,
     schedule_interval=None,
     description=("Un DAG pour parcourir des URLs et suggérer des corrections"),

--- a/dags/shared/config/start_dates.py
+++ b/dags/shared/config/start_dates.py
@@ -6,11 +6,11 @@ we configure start dates to be 1 interval in the past of schedule
 present/future date) thus if there is catchup, it's only 1 run max."""
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 
-NOW = datetime.now(timezone.utc)
+import pendulum
 
 
 @dataclass(frozen=True)
 class START_DATES:
-    YESTERDAY: datetime = NOW - timedelta(days=1)
+    YESTERDAY: datetime = pendulum.today("UTC").add(days=-1)

--- a/dags/sources/tasks/airflow_logic/operators.py
+++ b/dags/sources/tasks/airflow_logic/operators.py
@@ -1,6 +1,6 @@
-import pendulum
 from airflow import DAG
 from airflow.models.baseoperator import chain
+from shared.config.start_dates import START_DATES
 from sources.tasks.airflow_logic.db_data_prepare_task import db_data_prepare_task
 from sources.tasks.airflow_logic.db_read_acteur_task import db_read_acteur_task
 from sources.tasks.airflow_logic.db_write_type_action_suggestions_task import (
@@ -25,7 +25,6 @@ from sources.tasks.airflow_logic.source_data_validate_task import (
 default_args = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": pendulum.today("UTC").add(days=-1),
     "email_on_failure": False,
     "email_on_retry": False,
     "retries": 1,
@@ -34,6 +33,7 @@ default_args = {
 default_params = {
     "schedule": None,
     "max_active_runs": 1,
+    "start_date": START_DATES.YESTERDAY,
 }
 
 

--- a/dags/suggestions/dags/apply_suggestions.py
+++ b/dags/suggestions/dags/apply_suggestions.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
-import pendulum
 from airflow.models import DAG
+from shared.config.start_dates import START_DATES
 from shared.config.tags import TAGS
 from suggestions.tasks.airflow_logic.db_apply_suggestion_task import (
     db_apply_suggestion_task,
@@ -16,7 +16,6 @@ from suggestions.tasks.airflow_logic.launch_compute_task import (
 default_args = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": pendulum.today("UTC").add(days=-1),
     "retries": 1,
     "retry_delay": timedelta(minutes=5),
 }
@@ -25,6 +24,7 @@ dag = DAG(
     dag_id="apply_suggestions",
     dag_display_name="Acteurs - Application des suggestions validées",
     default_args=default_args,
+    start_date=START_DATES.YESTERDAY,
     description="traiter les suggestions à traiter",
     tags=[TAGS.COMPUTE, TAGS.SUGGESTIONS, TAGS.APPLY, TAGS.ACTEURS],
     schedule="*/5 * * * *",

--- a/dags/tools/dags/airflow_logs.py
+++ b/dags/tools/dags/airflow_logs.py
@@ -1,10 +1,9 @@
 import logging
 
-import pendulum
 from airflow import DAG
 from airflow.operators.python import PythonOperator
+from shared.config.start_dates import START_DATES
 from shared.config.tags import TAGS
-
 from utils.django import django_setup_full
 
 # Load Django environement to test Django and saving airflow logs to s3 storage are
@@ -16,7 +15,6 @@ logger = logging.getLogger(__name__)
 default_args = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": pendulum.today("UTC").add(days=-1),
     "email_on_failure": False,
     "email_on_retry": False,
 }
@@ -31,6 +29,7 @@ with DAG(
     dag_display_name="[TEST] Les logs Airflow sont enregistrés sur s3",
     tags=[TAGS.DEV_TOOLS],
     default_args=default_args,
+    start_date=START_DATES.YESTERDAY,
     description=(
         """
 Lancer le DAG et vérifier que les logs sont disponibles sur s3

--- a/dags/views/view_acteur_tous.py
+++ b/dags/views/view_acteur_tous.py
@@ -2,10 +2,10 @@ import time
 from logging import getLogger
 from pathlib import Path
 
-import pendulum
 from airflow import DAG
 from airflow.decorators import task
 from airflow.providers.postgres.hooks.postgres import PostgresHook
+from shared.config.start_dates import START_DATES
 from shared.config.tags import TAGS
 
 logger = getLogger(__name__)
@@ -13,7 +13,6 @@ logger = getLogger(__name__)
 DEFAULT_ARGS = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": pendulum.today("UTC").add(days=-1),
     "email_on_failure": False,
     "email_on_retry": False,
     "retries": 0,
@@ -34,6 +33,7 @@ with DAG(
     dag_id="view_acteur_all",
     tags=[TAGS.VUE, TAGS.ACTEURS, TAGS.TOUT, TAGS.SQL],
     default_args=DEFAULT_ARGS,
+    start_date=START_DATES.YESTERDAY,
     catchup=False,
     schedule=SCHEDULE,
     dag_display_name="Vue - Acteur - Tous les acteurs",


### PR DESCRIPTION
# Description succincte du problème résolu

Fix broken windows : `start_date` du dag ne doit pas être initialisé dans `default_args`

**🗺️ contexte**: Airflow

**💡 quoi**: start date mal initialisé

**🎯 pourquoi**: car c'était mal fait

**🤔 comment**: extraction de start_date de default_args


## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
