### PR TITLE
Ne plus être dépendant des colonnes rempli par les EO

### DIFF
--- a/dags/sources/config/airflow_params.py
+++ b/dags/sources/config/airflow_params.py
@@ -2,11 +2,13 @@ import json
 from pathlib import Path
 
 import requests
+from sources.config import shared_constants as constants
 from sources.tasks.transform.transform_column import (
     cast_eo_boolean_or_string_to_boolean,
     clean_acteur_type_code,
     clean_code_list,
     clean_code_postal,
+    clean_email,
     clean_horaires_osm,
     clean_public_accueilli,
     clean_reprise,
@@ -33,7 +35,6 @@ from sources.tasks.transform.transform_df import (
     get_latlng_from_geopoint,
     merge_sous_categories_columns,
 )
-
 from utils.django import django_setup_full
 
 PATH_NOMENCLARURE_DECHET = (
@@ -57,6 +58,7 @@ TRANSFORM_COLUMN_MAPPING = {
     "clean_sous_categorie_codes_sinoe": clean_sous_categorie_codes_sinoe,
     "clean_sous_categorie_codes": clean_sous_categorie_codes,
     "clean_url": clean_url,
+    "clean_email": clean_email,
     "convert_opening_hours": convert_opening_hours,
     "strip_lower_string": strip_lower_string,
     "strip_string": strip_string,
@@ -81,6 +83,189 @@ TRANSFORMATION_MAPPING = {
     **TRANSFORM_COLUMN_MAPPING,
     **TRANSFORM_DF_MAPPING,
 }
+
+
+EO_NORMALIZATION_RULES = [
+    # 1. Renommage des colonnes
+    {
+        "origin": "nom_de_lorganisme",
+        "destination": "nom",
+    },
+    {
+        "origin": "enseigne_commerciale",
+        "destination": "nom_commercial",
+    },
+    {
+        "origin": "longitudewgs84",
+        "destination": "longitude",
+    },
+    {
+        "origin": "latitudewgs84",
+        "destination": "latitude",
+    },
+    # 2. Transformation des colonnes
+    {
+        "origin": "ecoorganisme",
+        "transformation": "strip_lower_string",
+        "destination": "source_code",
+    },
+    {
+        "origin": "type_de_point_de_collecte",
+        "transformation": "clean_acteur_type_code",
+        "destination": "acteur_type_code",
+    },
+    {
+        "origin": "public_accueilli",
+        "transformation": "clean_public_accueilli",
+        "destination": "public_accueilli",
+    },
+    {
+        "origin": "exclusivite_de_reprisereparation",
+        "transformation": "cast_eo_boolean_or_string_to_boolean",
+        "destination": "exclusivite_de_reprisereparation",
+    },
+    {
+        "origin": "reprise",
+        "transformation": "clean_reprise",
+        "destination": "reprise",
+    },
+    {
+        "origin": "produitsdechets_acceptes",
+        "transformation": "clean_sous_categorie_codes",
+        "destination": "sous_categorie_codes",
+    },
+    {
+        "origin": "consignes_dacces",
+        "transformation": "strip_string",
+        "destination": "consignes_dacces",
+    },
+    {
+        "origin": "uniquement_sur_rdv",
+        "transformation": "cast_eo_boolean_or_string_to_boolean",
+        "destination": "uniquement_sur_rdv",
+    },
+    {
+        "origin": "adresse_complement",
+        "transformation": "strip_string",
+        "destination": "adresse_complement",
+    },
+    {
+        "origin": "consignes_dacces",
+        "transformation": "strip_string",
+        "destination": "consignes_dacces",
+    },
+    {
+        "origin": "horaires_douverture",
+        "transformation": "clean_horaires_osm",
+        "destination": "horaires_osm",
+    },
+    {
+        "origin": "site_web",
+        "transformation": "clean_url",
+        "destination": "url",
+    },
+    {
+        "origin": "email",
+        "transformation": "clean_email",
+        "destination": "email",
+    },
+    # 3. Ajout des colonnes avec une valeur par défaut
+    {
+        "column": "statut",
+        "value": constants.ACTEUR_ACTIF,
+    },
+    # 4. Transformation du dataframe
+    {
+        "origin": ["latitude", "longitude"],
+        "transformation": "compute_location",
+        "destination": ["location"],
+    },
+    {
+        "origin": ["labels_etou_bonus", "acteur_type_code"],
+        "transformation": "clean_label_codes",
+        "destination": ["label_codes"],
+    },
+    {
+        "origin": ["id_point_apport_ou_reparation", "nom", "acteur_type_code"],
+        "transformation": "clean_identifiant_externe",
+        "destination": ["identifiant_externe"],
+    },
+    {
+        "origin": [
+            "identifiant_externe",
+            "source_code",
+        ],
+        "transformation": "clean_identifiant_unique",
+        "destination": ["identifiant_unique"],
+    },
+    {
+        "origin": ["siret", "siren"],
+        "transformation": "clean_siret_and_siren",
+        "destination": ["siret", "siren"],
+    },
+    {
+        "origin": ["adresse_format_ban"],
+        "transformation": "clean_adresse",
+        "destination": ["adresse", "code_postal", "ville"],
+    },
+    {
+        "origin": ["telephone", "code_postal"],
+        "transformation": "clean_telephone",
+        "destination": ["telephone"],
+    },
+    {
+        "origin": [
+            "point_dapport_de_service_reparation",
+            "point_de_reparation",
+            "point_dapport_pour_reemploi",
+            "point_de_collecte_ou_de_reprise_des_dechets",
+        ],
+        "transformation": "clean_acteur_service_codes",
+        "destination": ["acteur_service_codes"],
+    },
+    {
+        "origin": [
+            "point_dapport_de_service_reparation",
+            "point_de_reparation",
+            "point_dapport_pour_reemploi",
+            "point_de_collecte_ou_de_reprise_des_dechets",
+        ],
+        "transformation": "clean_action_codes",
+        "destination": ["action_codes"],
+    },
+    {
+        "origin": ["action_codes", "sous_categorie_codes"],
+        "transformation": "clean_proposition_services",
+        "destination": ["proposition_service_codes"],
+    },
+    # {
+    #     "origin": ["latitudemercator", "longitudemercator"],
+    #     "transformation": "check_empty_columns",
+    #     "destination": ["latitudemercator", "longitudemercator"],
+    # },
+    # 5. Supression des colonnes
+    {"remove": "_i"},
+    {"remove": "_id"},
+    {"remove": "_updatedAt"},
+    {"remove": "_rand"},
+    {"remove": "_geopoint"},
+    {"remove": "filiere"},
+    {"remove": "_score"},
+    {"remove": "adresse_format_ban"},
+    {"remove": "id_point_apport_ou_reparation"},
+    {"remove": "point_de_collecte_ou_de_reprise_des_dechets"},
+    {"remove": "point_dapport_de_service_reparation"},
+    {"remove": "point_dapport_pour_reemploi"},
+    {"remove": "point_de_reparation"},
+    {"remove": "perimetre_dintervention"},  # Not managed yet
+    {"remove": "labels_etou_bonus"},
+    {"remove": "latitudemercator"},  # check empty
+    {"remove": "longitudemercator"},  # check empty
+    {"remove": "accessible"},  # Not managed yet
+    {"remove": "service_a_domicile"},  # Not managed yet
+    {"remove": "date_fin_point_ephemere"},  # Not managed yet
+    {"remove": "date_debut_point_ephemere"},  # Not managed yet
+]
 
 
 # TODO: dataclass à implémenter pour la validation des paramètres des DAGs

--- a/dags/sources/dags/source_aliapur.py
+++ b/dags/sources/dags/source_aliapur.py
@@ -1,7 +1,6 @@
 from airflow import DAG
 from shared.config.tags import TAGS
-from sources.config import shared_constants as constants
-from sources.config.airflow_params import get_mapping_config
+from sources.config.airflow_params import EO_NORMALIZATION_RULES, get_mapping_config
 from sources.tasks.airflow_logic.operators import (
     default_args,
     default_params,
@@ -25,135 +24,14 @@ with DAG(
     ],
     **default_params,
     params={
-        "normalization_rules": [
-            # 1. Renommage des colonnes
-            {
-                "origin": "nom_de_lorganisme",
-                "destination": "nom",
-            },
-            {
-                "origin": "enseigne_commerciale",
-                "destination": "nom_commercial",
-            },
-            {
-                "origin": "longitudewgs84",
-                "destination": "longitude",
-            },
-            {
-                "origin": "latitudewgs84",
-                "destination": "latitude",
-            },
-            # 2. Transformation des colonnes
-            {
-                "origin": "ecoorganisme",
-                "transformation": "strip_lower_string",
-                "destination": "source_code",
-            },
-            {
-                "origin": "type_de_point_de_collecte",
-                "transformation": "clean_acteur_type_code",
-                "destination": "acteur_type_code",
-            },
-            {
-                "origin": "public_accueilli",
-                "transformation": "clean_public_accueilli",
-                "destination": "public_accueilli",
-            },
-            {
-                "origin": "produitsdechets_acceptes",
-                "transformation": "clean_sous_categorie_codes",
-                "destination": "sous_categorie_codes",
-            },
-            # 3. Ajout des colonnes avec une valeur par défaut
-            {
-                "column": "statut",
-                "value": constants.ACTEUR_ACTIF,
-            },
-            # 4. Transformation du dataframe
-            {
-                "origin": ["latitude", "longitude"],
-                "transformation": "compute_location",
-                "destination": ["location"],
-            },
-            {
-                "origin": ["labels_etou_bonus", "acteur_type_code"],
-                "transformation": "clean_label_codes",
-                "destination": ["label_codes"],
-            },
-            {
-                "origin": ["id_point_apport_ou_reparation", "nom", "acteur_type_code"],
-                "transformation": "clean_identifiant_externe",
-                "destination": ["identifiant_externe"],
-            },
-            {
-                "origin": [
-                    "identifiant_externe",
-                    "source_code",
-                ],
-                "transformation": "clean_identifiant_unique",
-                "destination": ["identifiant_unique"],
-            },
-            {
-                "origin": ["siret"],
-                "transformation": "clean_siret_and_siren",
-                "destination": ["siret", "siren"],
-            },
-            {
-                "origin": ["adresse_format_ban"],
-                "transformation": "clean_adresse",
-                "destination": ["adresse", "code_postal", "ville"],
-            },
-            {
-                "origin": ["telephone", "code_postal"],
-                "transformation": "clean_telephone",
-                "destination": ["telephone"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_acteur_service_codes",
-                "destination": ["acteur_service_codes"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_action_codes",
-                "destination": ["action_codes"],
-            },
-            {
-                "origin": ["action_codes", "sous_categorie_codes"],
-                "transformation": "clean_proposition_services",
-                "destination": ["proposition_service_codes"],
-            },
-            # 5. Supression des colonnes
-            {"remove": "_i"},
-            {"remove": "_id"},
-            {"remove": "_updatedAt"},
-            {"remove": "_rand"},
-            {"remove": "_geopoint"},
-            {"remove": "filiere"},
-            {"remove": "_score"},
-            {"remove": "adresse_format_ban"},
-            {"remove": "id_point_apport_ou_reparation"},
-            {"remove": "point_de_collecte_ou_de_reprise_des_dechets"},
-            {"remove": "labels_etou_bonus"},
-            {"remove": "point_dapport_de_service_reparation"},
-            {"remove": "point_dapport_pour_reemploi"},
-            {"remove": "point_de_reparation"},
-            # 6. Colonnes à garder (rien à faire, utilisé pour le controle)
-            {"keep": "email"},
-        ],
+        "normalization_rules": EO_NORMALIZATION_RULES,
         "endpoint": (
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-aliapur/lines?size=10000"
+        ),
+        "metadata_endpoint": (
+            "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
+            "donnees-eo-aliapur/schema"
         ),
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config(),

--- a/dags/sources/dags/source_batribox.py
+++ b/dags/sources/dags/source_batribox.py
@@ -1,7 +1,6 @@
 from airflow import DAG
 from shared.config.tags import TAGS
-from sources.config import shared_constants as constants
-from sources.config.airflow_params import get_mapping_config
+from sources.config.airflow_params import EO_NORMALIZATION_RULES, get_mapping_config
 from sources.tasks.airflow_logic.operators import (
     default_args,
     default_params,
@@ -29,141 +28,16 @@ with DAG(
             "https://data.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-batribox/lines?size=10000"
         ),
-        "normalization_rules": [
-            # 1. Renommage des colonnes
-            {
-                "origin": "nom_de_lorganisme",
-                "destination": "nom",
-            },
-            {
-                "origin": "enseigne_commerciale",
-                "destination": "nom_commercial",
-            },
-            {
-                "origin": "longitudewgs84",
-                "destination": "longitude",
-            },
-            {
-                "origin": "latitudewgs84",
-                "destination": "latitude",
-            },
-            # 2. Transformation des colonnes
-            {
-                "origin": "type_de_point_de_collecte",
-                "transformation": "clean_acteur_type_code",
-                "destination": "acteur_type_code",
-            },
-            {
-                "origin": "public_accueilli",
-                "transformation": "clean_public_accueilli",
-                "destination": "public_accueilli",
-            },
-            {
-                "origin": "uniquement_sur_rdv",
-                "transformation": "cast_eo_boolean_or_string_to_boolean",
-                "destination": "uniquement_sur_rdv",
-            },
-            {
-                "origin": "exclusivite_de_reprisereparation",
-                "transformation": "cast_eo_boolean_or_string_to_boolean",
-                "destination": "exclusivite_de_reprisereparation",
-            },
-            {
-                "origin": "reprise",
-                "transformation": "clean_reprise",
-                "destination": "reprise",
-            },
-            {
-                "origin": "produitsdechets_acceptes",
-                "transformation": "clean_sous_categorie_codes",
-                "destination": "sous_categorie_codes",
-            },
-            # 3. Ajout des colonnes avec une valeur par défaut
-            {
-                "column": "statut",
-                "value": constants.ACTEUR_ACTIF,
-            },
+        "metadata_endpoint": (
+            "https://data.ademe.fr/data-fair/api/v1/datasets/"
+            "donnees-eo-batribox/schema"
+        ),
+        "normalization_rules": EO_NORMALIZATION_RULES
+        + [
             {
                 "column": "source_code",
                 "value": "batribox",
-            },
-            # 4. Transformation du dataframe
-            {
-                "origin": ["latitude", "longitude"],
-                "transformation": "compute_location",
-                "destination": ["location"],
-            },
-            {
-                "origin": ["labels_etou_bonus", "acteur_type_code"],
-                "transformation": "clean_label_codes",
-                "destination": ["label_codes"],
-            },
-            {
-                "origin": ["id_point_apport_ou_reparation", "nom", "acteur_type_code"],
-                "transformation": "clean_identifiant_externe",
-                "destination": ["identifiant_externe"],
-            },
-            {
-                "origin": [
-                    "identifiant_externe",
-                    "source_code",
-                ],
-                "transformation": "clean_identifiant_unique",
-                "destination": ["identifiant_unique"],
-            },
-            {
-                "origin": ["siret"],
-                "transformation": "clean_siret_and_siren",
-                "destination": ["siret", "siren"],
-            },
-            {
-                "origin": ["adresse_format_ban"],
-                "transformation": "clean_adresse",
-                "destination": ["adresse", "code_postal", "ville"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_acteur_service_codes",
-                "destination": ["acteur_service_codes"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_action_codes",
-                "destination": ["action_codes"],
-            },
-            {
-                "origin": ["action_codes", "sous_categorie_codes"],
-                "transformation": "clean_proposition_services",
-                "destination": ["proposition_service_codes"],
-            },
-            # 5. Supression des colonnes
-            {"remove": "_geopoint"},
-            {"remove": "_i"},
-            {"remove": "_id"},
-            {"remove": "_rand"},
-            {"remove": "_score"},
-            {"remove": "_updatedAt"},
-            {"remove": "accessible"},
-            {"remove": "adresse_format_ban"},
-            {"remove": "ecoorganisme"},
-            {"remove": "filiere"},
-            {"remove": "id_point_apport_ou_reparation"},
-            {"remove": "labels_etou_bonus"},
-            {"remove": "point_dapport_de_service_reparation"},
-            {"remove": "point_dapport_pour_reemploi"},
-            {"remove": "point_de_collecte_ou_de_reprise_des_dechets"},
-            {"remove": "point_de_reparation"},
-            # 6. Colonnes à garder (rien à faire, utilisé pour le controle)
+            }
         ],
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config("sous_categories"),

--- a/dags/sources/dags/source_citeo.py
+++ b/dags/sources/dags/source_citeo.py
@@ -1,8 +1,7 @@
 from airflow import DAG
 from airflow.models.param import Param
 from shared.config.tags import TAGS
-from sources.config import shared_constants as constants
-from sources.config.airflow_params import get_mapping_config
+from sources.config.airflow_params import EO_NORMALIZATION_RULES, get_mapping_config
 from sources.tasks.airflow_logic.operators import (
     default_args,
     default_params,
@@ -26,122 +25,14 @@ with DAG(
     ],
     **default_params,
     params={
-        "normalization_rules": [
-            # 1. Renommage des colonnes
-            {
-                "origin": "nom_de_lorganisme",
-                "destination": "nom",
-            },
-            {
-                "origin": "longitudewgs84",
-                "destination": "longitude",
-            },
-            {
-                "origin": "latitudewgs84",
-                "destination": "latitude",
-            },
-            # 2. Transformation des colonnes
-            {
-                "origin": "ecoorganisme",
-                "transformation": "strip_lower_string",
-                "destination": "source_code",
-            },
-            {
-                "origin": "type_de_point_de_collecte",
-                "transformation": "clean_acteur_type_code",
-                "destination": "acteur_type_code",
-            },
-            {
-                "origin": "public_accueilli",
-                "transformation": "clean_public_accueilli",
-                "destination": "public_accueilli",
-            },
-            {
-                "origin": "produitsdechets_acceptes",
-                "transformation": "clean_sous_categorie_codes",
-                "destination": "sous_categorie_codes",
-            },
-            # 3. Ajout des colonnes avec une valeur par défaut
-            {
-                "column": "statut",
-                "value": constants.ACTEUR_ACTIF,
-            },
-            {
-                "column": "label_codes",
-                "value": [],
-            },
-            # 4. Transformation du dataframe
-            {
-                "origin": ["latitude", "longitude"],
-                "transformation": "compute_location",
-                "destination": ["location"],
-            },
-            {
-                "origin": ["id_point_apport_ou_reparation", "nom", "acteur_type_code"],
-                "transformation": "clean_identifiant_externe",
-                "destination": ["identifiant_externe"],
-            },
-            {
-                "origin": [
-                    "identifiant_externe",
-                    "source_code",
-                ],
-                "transformation": "clean_identifiant_unique",
-                "destination": ["identifiant_unique"],
-            },
-            {
-                "origin": ["siren"],
-                "transformation": "clean_siret_and_siren",
-                "destination": ["siret", "siren"],
-            },
-            {
-                "origin": ["adresse_format_ban"],
-                "transformation": "clean_adresse",
-                "destination": ["adresse", "code_postal", "ville"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_acteur_service_codes",
-                "destination": ["acteur_service_codes"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_action_codes",
-                "destination": ["action_codes"],
-            },
-            {
-                "origin": ["action_codes", "sous_categorie_codes"],
-                "transformation": "clean_proposition_services",
-                "destination": ["proposition_service_codes"],
-            },
-            # 5. Supression des colonnes
-            {"remove": "_i"},
-            {"remove": "_id"},
-            {"remove": "_updatedAt"},
-            {"remove": "_rand"},
-            {"remove": "_geopoint"},
-            {"remove": "filiere"},
-            {"remove": "_score"},
-            {"remove": "adresse_format_ban"},
-            {"remove": "id_point_apport_ou_reparation"},
-            {"remove": "point_de_collecte_ou_de_reprise_des_dechets"},
-            {"remove": "point_dapport_de_service_reparation"},
-            {"remove": "point_dapport_pour_reemploi"},
-            {"remove": "point_de_reparation"},
-        ],
+        "normalization_rules": EO_NORMALIZATION_RULES,
         "endpoint": (
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-citeo/lines?size=10000"
+        ),
+        "metadata_endpoint": (
+            "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
+            "donnees-eo-citeo/schema"
         ),
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config(),

--- a/dags/sources/dags/source_corepile.py
+++ b/dags/sources/dags/source_corepile.py
@@ -1,7 +1,6 @@
 from airflow import DAG
 from shared.config.tags import TAGS
-from sources.config import shared_constants as constants
-from sources.config.airflow_params import get_mapping_config
+from sources.config.airflow_params import EO_NORMALIZATION_RULES, get_mapping_config
 from sources.tasks.airflow_logic.operators import (
     default_args,
     default_params,
@@ -25,127 +24,14 @@ with DAG(
     ],
     **default_params,
     params={
-        "normalization_rules": [
-            # 1. Renommage des colonnes
-            {
-                "origin": "nom_de_lorganisme",
-                "destination": "nom",
-            },
-            {
-                "origin": "enseigne_commerciale",
-                "destination": "nom_commercial",
-            },
-            {
-                "origin": "longitudewgs84",
-                "destination": "longitude",
-            },
-            {
-                "origin": "latitudewgs84",
-                "destination": "latitude",
-            },
-            # 2. Transformation des colonnes
-            {
-                "origin": "ecoorganisme",
-                "transformation": "strip_lower_string",
-                "destination": "source_code",
-            },
-            {
-                "origin": "type_de_point_de_collecte",
-                "transformation": "clean_acteur_type_code",
-                "destination": "acteur_type_code",
-            },
-            {
-                "origin": "public_accueilli",
-                "transformation": "clean_public_accueilli",
-                "destination": "public_accueilli",
-            },
-            {
-                "origin": "produitsdechets_acceptes",
-                "transformation": "clean_sous_categorie_codes",
-                "destination": "sous_categorie_codes",
-            },
-            # 3. Ajout des colonnes avec une valeur par défaut
-            {
-                "column": "statut",
-                "value": constants.ACTEUR_ACTIF,
-            },
-            {
-                "column": "label_codes",
-                "value": [],
-            },
-            # 4. Transformation du dataframe
-            {
-                "origin": ["latitude", "longitude"],
-                "transformation": "compute_location",
-                "destination": ["location"],
-            },
-            {
-                "origin": ["id_point_apport_ou_reparation", "nom", "acteur_type_code"],
-                "transformation": "clean_identifiant_externe",
-                "destination": ["identifiant_externe"],
-            },
-            {
-                "origin": [
-                    "identifiant_externe",
-                    "source_code",
-                ],
-                "transformation": "clean_identifiant_unique",
-                "destination": ["identifiant_unique"],
-            },
-            {
-                "origin": ["siret"],
-                "transformation": "clean_siret_and_siren",
-                "destination": ["siret", "siren"],
-            },
-            {
-                "origin": ["adresse_format_ban"],
-                "transformation": "clean_adresse",
-                "destination": ["adresse", "code_postal", "ville"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_acteur_service_codes",
-                "destination": ["acteur_service_codes"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_action_codes",
-                "destination": ["action_codes"],
-            },
-            {
-                "origin": ["action_codes", "sous_categorie_codes"],
-                "transformation": "clean_proposition_services",
-                "destination": ["proposition_service_codes"],
-            },
-            # 5. Supression des colonnes
-            {"remove": "_i"},
-            {"remove": "_id"},
-            {"remove": "_updatedAt"},
-            {"remove": "_rand"},
-            {"remove": "_geopoint"},
-            {"remove": "filiere"},
-            {"remove": "_score"},
-            {"remove": "adresse_format_ban"},
-            {"remove": "id_point_apport_ou_reparation"},
-            {"remove": "point_de_collecte_ou_de_reprise_des_dechets"},
-            {"remove": "point_dapport_de_service_reparation"},
-            {"remove": "point_dapport_pour_reemploi"},
-            {"remove": "point_de_reparation"},
-            # 6. Colonnes à garder (rien à faire, utilisé pour le controle)
-        ],
+        "normalization_rules": EO_NORMALIZATION_RULES,
         "endpoint": (
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-corepile/lines?size=10000"
+        ),
+        "metadata_endpoint": (
+            "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
+            "donnees-eo-corepile/schema"
         ),
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config(),

--- a/dags/sources/dags/source_cyclevia.py
+++ b/dags/sources/dags/source_cyclevia.py
@@ -1,7 +1,6 @@
 from airflow import DAG
 from shared.config.tags import TAGS
-from sources.config import shared_constants as constants
-from sources.config.airflow_params import get_mapping_config
+from sources.config.airflow_params import EO_NORMALIZATION_RULES, get_mapping_config
 from sources.tasks.airflow_logic.operators import (
     default_args,
     default_params,
@@ -25,159 +24,14 @@ with DAG(
     ],
     **default_params,
     params={
-        "normalization_rules": [
-            # 1. Renommage des colonnes
-            {
-                "origin": "nom_de_lorganisme",
-                "destination": "nom",
-            },
-            {
-                "origin": "enseigne_commerciale",
-                "destination": "nom_commercial",
-            },
-            {
-                "origin": "longitudewgs84",
-                "destination": "longitude",
-            },
-            {
-                "origin": "latitudewgs84",
-                "destination": "latitude",
-            },
-            {
-                "origin": "horaires_douverture",
-                "destination": "horaires_description",
-            },
-            # 2. Transformation des colonnes
-            {
-                "origin": "ecoorganisme",
-                "transformation": "strip_lower_string",
-                "destination": "source_code",
-            },
-            {
-                "origin": "site_web",
-                "transformation": "clean_url",
-                "destination": "url",
-            },
-            {
-                "origin": "type_de_point_de_collecte",
-                "transformation": "clean_acteur_type_code",
-                "destination": "acteur_type_code",
-            },
-            {
-                "origin": "public_accueilli",
-                "transformation": "clean_public_accueilli",
-                "destination": "public_accueilli",
-            },
-            {
-                "origin": "uniquement_sur_rdv",
-                "transformation": "cast_eo_boolean_or_string_to_boolean",
-                "destination": "uniquement_sur_rdv",
-            },
-            {
-                "origin": "exclusivite_de_reprisereparation",
-                "transformation": "cast_eo_boolean_or_string_to_boolean",
-                "destination": "exclusivite_de_reprisereparation",
-            },
-            {
-                "origin": "reprise",
-                "transformation": "clean_reprise",
-                "destination": "reprise",
-            },
-            {
-                "origin": "produitsdechets_acceptes",
-                "transformation": "clean_sous_categorie_codes",
-                "destination": "sous_categorie_codes",
-            },
-            # 3. Ajout des colonnes avec une valeur par défaut
-            {
-                "column": "statut",
-                "value": constants.ACTEUR_ACTIF,
-            },
-            # 4. Transformation du dataframe
-            {
-                "origin": ["labels_etou_bonus", "acteur_type_code"],
-                "transformation": "clean_label_codes",
-                "destination": ["label_codes"],
-            },
-            {
-                "origin": ["id_point_apport_ou_reparation", "nom", "acteur_type_code"],
-                "transformation": "clean_identifiant_externe",
-                "destination": ["identifiant_externe"],
-            },
-            {
-                "origin": [
-                    "identifiant_externe",
-                    "source_code",
-                ],
-                "transformation": "clean_identifiant_unique",
-                "destination": ["identifiant_unique"],
-            },
-            {
-                "origin": ["siret"],
-                "transformation": "clean_siret_and_siren",
-                "destination": ["siret", "siren"],
-            },
-            {
-                "origin": ["adresse_format_ban"],
-                "transformation": "clean_adresse",
-                "destination": ["adresse", "code_postal", "ville"],
-            },
-            {
-                "origin": ["telephone", "code_postal"],
-                "transformation": "clean_telephone",
-                "destination": ["telephone"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_acteur_service_codes",
-                "destination": ["acteur_service_codes"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_action_codes",
-                "destination": ["action_codes"],
-            },
-            {
-                "origin": ["action_codes", "sous_categorie_codes"],
-                "transformation": "clean_proposition_services",
-                "destination": ["proposition_service_codes"],
-            },
-            # 5. Supression des colonnes
-            {"remove": "_i"},
-            {"remove": "_id"},
-            {"remove": "_updatedAt"},
-            {"remove": "_rand"},
-            {"remove": "_geopoint"},
-            {"remove": "filiere"},
-            {"remove": "_score"},
-            {"remove": "accessible"},
-            {"remove": "adresse_format_ban"},
-            {"remove": "id_point_apport_ou_reparation"},
-            {"remove": "point_de_collecte_ou_de_reprise_des_dechets"},
-            {"remove": "labels_etou_bonus"},
-            {"remove": "point_dapport_de_service_reparation"},
-            {"remove": "point_dapport_pour_reemploi"},
-            {"remove": "point_de_reparation"},
-            {"remove": "date_debut_point_ephemere"},
-            {"remove": "date_fin_point_ephemere"},
-            # 6. Colonnes à garder (rien à faire, utilisé pour le controle)
-            {"keep": "adresse_complement"},
-            {"keep": "consignes_dacces"},
-            {"keep": "email"},
-        ],
+        "normalization_rules": EO_NORMALIZATION_RULES,
         "endpoint": (
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-cyclevia/lines?size=10000"
+        ),
+        "metadata_endpoint": (
+            "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
+            "donnees-eo-cyclevia/schema"
         ),
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config(),

--- a/dags/sources/dags/source_ecodds.py
+++ b/dags/sources/dags/source_ecodds.py
@@ -1,7 +1,6 @@
 from airflow import DAG
 from shared.config.tags import TAGS
-from sources.config import shared_constants as constants
-from sources.config.airflow_params import get_mapping_config
+from sources.config.airflow_params import EO_NORMALIZATION_RULES, get_mapping_config
 from sources.tasks.airflow_logic.operators import (
     default_args,
     default_params,
@@ -26,134 +25,14 @@ with DAG(
     ],
     **default_params,
     params={
-        "normalization_rules": [
-            # 1. Renommage des colonnes
-            {
-                "origin": "nom_de_lorganisme",
-                "destination": "nom",
-            },
-            {
-                "origin": "enseigne_commerciale",
-                "destination": "nom_commercial",
-            },
-            {
-                "origin": "longitudewgs84",
-                "destination": "longitude",
-            },
-            {
-                "origin": "latitudewgs84",
-                "destination": "latitude",
-            },
-            # 2. Transformation des colonnes
-            {
-                "origin": "ecoorganisme",
-                "transformation": "strip_lower_string",
-                "destination": "source_code",
-            },
-            {
-                "origin": "type_de_point_de_collecte",
-                "transformation": "clean_acteur_type_code",
-                "destination": "acteur_type_code",
-            },
-            {
-                "origin": "public_accueilli",
-                "transformation": "clean_public_accueilli",
-                "destination": "public_accueilli",
-            },
-            {
-                "origin": "exclusivite_de_reprisereparation",
-                "transformation": "cast_eo_boolean_or_string_to_boolean",
-                "destination": "exclusivite_de_reprisereparation",
-            },
-            {
-                "origin": "reprise",
-                "transformation": "clean_reprise",
-                "destination": "reprise",
-            },
-            {
-                "origin": "produitsdechets_acceptes",
-                "transformation": "clean_sous_categorie_codes",
-                "destination": "sous_categorie_codes",
-            },
-            # 3. Ajout des colonnes avec une valeur par défaut
-            {
-                "column": "statut",
-                "value": constants.ACTEUR_ACTIF,
-            },
-            # 4. Transformation du dataframe
-            {
-                "origin": ["latitude", "longitude"],
-                "transformation": "compute_location",
-                "destination": ["location"],
-            },
-            {
-                "origin": ["labels_etou_bonus", "acteur_type_code"],
-                "transformation": "clean_label_codes",
-                "destination": ["label_codes"],
-            },
-            {
-                "origin": ["id_point_apport_ou_reparation", "nom", "acteur_type_code"],
-                "transformation": "clean_identifiant_externe",
-                "destination": ["identifiant_externe"],
-            },
-            {
-                "origin": [
-                    "identifiant_externe",
-                    "source_code",
-                ],
-                "transformation": "clean_identifiant_unique",
-                "destination": ["identifiant_unique"],
-            },
-            {
-                "origin": ["adresse_format_ban"],
-                "transformation": "clean_adresse",
-                "destination": ["adresse", "code_postal", "ville"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_acteur_service_codes",
-                "destination": ["acteur_service_codes"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_action_codes",
-                "destination": ["action_codes"],
-            },
-            {
-                "origin": ["action_codes", "sous_categorie_codes"],
-                "transformation": "clean_proposition_services",
-                "destination": ["proposition_service_codes"],
-            },
-            # 5. Supression des colonnes
-            {"remove": "_i"},
-            {"remove": "_id"},
-            {"remove": "_updatedAt"},
-            {"remove": "_rand"},
-            {"remove": "_geopoint"},
-            {"remove": "filiere"},
-            {"remove": "_score"},
-            {"remove": "adresse_format_ban"},
-            {"remove": "id_point_apport_ou_reparation"},
-            {"remove": "point_de_collecte_ou_de_reprise_des_dechets"},
-            {"remove": "labels_etou_bonus"},
-            {"remove": "point_dapport_de_service_reparation"},
-            {"remove": "point_dapport_pour_reemploi"},
-            {"remove": "point_de_reparation"},
-            # 6. Colonnes à garder (rien à faire, utilisé pour le controle)
-        ],
+        "normalization_rules": EO_NORMALIZATION_RULES,
         "endpoint": (
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-ecodds/lines?size=10000"
+        ),
+        "metadata_endpoint": (
+            "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
+            "donnees-eo-ecodds/schema"
         ),
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config(),

--- a/dags/sources/dags/source_ecologic.py
+++ b/dags/sources/dags/source_ecologic.py
@@ -1,7 +1,6 @@
 from airflow import DAG
 from shared.config.tags import TAGS
-from sources.config import shared_constants as constants
-from sources.config.airflow_params import get_mapping_config
+from sources.config.airflow_params import EO_NORMALIZATION_RULES, get_mapping_config
 from sources.tasks.airflow_logic.operators import (
     default_args,
     default_params,
@@ -27,151 +26,14 @@ with DAG(
     ],
     **default_params,
     params={
-        "normalization_rules": [
-            # 1. Renommage des colonnes
-            {
-                "origin": "nom_de_lorganisme",
-                "destination": "nom",
-            },
-            {
-                "origin": "enseigne_commerciale",
-                "destination": "nom_commercial",
-            },
-            {
-                "origin": "longitudewgs84",
-                "destination": "longitude",
-            },
-            {
-                "origin": "latitudewgs84",
-                "destination": "latitude",
-            },
-            # 2. Transformation des colonnes
-            {
-                "origin": "site_web",
-                "transformation": "clean_url",
-                "destination": "url",
-            },
-            {
-                "origin": "uniquement_sur_rdv",
-                "transformation": "cast_eo_boolean_or_string_to_boolean",
-                "destination": "uniquement_sur_rdv",
-            },
-            {
-                "origin": "ecoorganisme",
-                "transformation": "strip_lower_string",
-                "destination": "source_code",
-            },
-            {
-                "origin": "type_de_point_de_collecte",
-                "transformation": "clean_acteur_type_code",
-                "destination": "acteur_type_code",
-            },
-            {
-                "origin": "public_accueilli",
-                "transformation": "clean_public_accueilli",
-                "destination": "public_accueilli",
-            },
-            {
-                "origin": "reprise",
-                "transformation": "clean_reprise",
-                "destination": "reprise",
-            },
-            {
-                "origin": "produitsdechets_acceptes",
-                "transformation": "clean_sous_categorie_codes",
-                "destination": "sous_categorie_codes",
-            },
-            # 3. Ajout des colonnes avec une valeur par défaut
-            {
-                "column": "statut",
-                "value": constants.ACTEUR_ACTIF,
-            },
-            # 4. Transformation du dataframe
-            {
-                "origin": ["labels_etou_bonus", "acteur_type_code"],
-                "transformation": "clean_label_codes",
-                "destination": ["label_codes"],
-            },
-            {
-                "origin": ["siret", "siren"],
-                "transformation": "clean_siret_and_siren",
-                "destination": ["siret", "siren"],
-            },
-            {
-                "origin": ["latitude", "longitude"],
-                "transformation": "compute_location",
-                "destination": ["location"],
-            },
-            {
-                "origin": ["id_point_apport_ou_reparation", "nom", "acteur_type_code"],
-                "transformation": "clean_identifiant_externe",
-                "destination": ["identifiant_externe"],
-            },
-            {
-                "origin": [
-                    "identifiant_externe",
-                    "source_code",
-                ],
-                "transformation": "clean_identifiant_unique",
-                "destination": ["identifiant_unique"],
-            },
-            {
-                "origin": ["adresse_format_ban"],
-                "transformation": "clean_adresse",
-                "destination": ["adresse", "code_postal", "ville"],
-            },
-            {
-                "origin": ["telephone", "code_postal"],
-                "transformation": "clean_telephone",
-                "destination": ["telephone"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_acteur_service_codes",
-                "destination": ["acteur_service_codes"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_action_codes",
-                "destination": ["action_codes"],
-            },
-            {
-                "origin": ["action_codes", "sous_categorie_codes"],
-                "transformation": "clean_proposition_services",
-                "destination": ["proposition_service_codes"],
-            },
-            # 5. Supression des colonnes
-            {"remove": "_i"},
-            {"remove": "_id"},
-            {"remove": "_updatedAt"},
-            {"remove": "_rand"},
-            {"remove": "_geopoint"},
-            {"remove": "filiere"},
-            {"remove": "_score"},
-            {"remove": "adresse_format_ban"},
-            {"remove": "id_point_apport_ou_reparation"},
-            {"remove": "point_de_collecte_ou_de_reprise_des_dechets"},
-            {"remove": "point_dapport_de_service_reparation"},
-            {"remove": "point_dapport_pour_reemploi"},
-            {"remove": "point_de_reparation"},
-            {"remove": "horaires_douverture"},
-            {"remove": "labels_etou_bonus"},
-            # 6. Colonnes à garder (rien à faire, utilisé pour le controle)
-            {"keep": "email"},
-        ],
+        "normalization_rules": EO_NORMALIZATION_RULES,
         "endpoint": (
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-ecologic/lines?size=10000"
+        ),
+        "metadata_endpoint": (
+            "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
+            "donnees-eo-ecologic/schema"
         ),
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config(mapping_key="sous_categories_3eee"),

--- a/dags/sources/dags/source_ecomaison.py
+++ b/dags/sources/dags/source_ecomaison.py
@@ -1,7 +1,6 @@
 from airflow import DAG
 from shared.config.tags import TAGS
-from sources.config import shared_constants as constants
-from sources.config.airflow_params import get_mapping_config
+from sources.config.airflow_params import EO_NORMALIZATION_RULES, get_mapping_config
 from sources.tasks.airflow_logic.operators import (
     default_args,
     default_params,
@@ -28,144 +27,14 @@ with DAG(
     ],
     **default_params,
     params={
-        "normalization_rules": [
-            # 1. Renommage des colonnes
-            {
-                "origin": "nom_de_lorganisme",
-                "destination": "nom",
-            },
-            {
-                "origin": "enseigne_commerciale",
-                "destination": "nom_commercial",
-            },
-            {
-                "origin": "longitudewgs84",
-                "destination": "longitude",
-            },
-            {
-                "origin": "latitudewgs84",
-                "destination": "latitude",
-            },
-            # 2. Transformation des colonnes
-            {
-                "origin": "ecoorganisme",
-                "transformation": "strip_lower_string",
-                "destination": "source_code",
-            },
-            {
-                "origin": "site_web",
-                "transformation": "clean_url",
-                "destination": "url",
-            },
-            {
-                "origin": "type_de_point_de_collecte",
-                "transformation": "clean_acteur_type_code",
-                "destination": "acteur_type_code",
-            },
-            {
-                "origin": "public_accueilli",
-                "transformation": "clean_public_accueilli",
-                "destination": "public_accueilli",
-            },
-            {
-                "origin": "uniquement_sur_rdv",
-                "transformation": "cast_eo_boolean_or_string_to_boolean",
-                "destination": "uniquement_sur_rdv",
-            },
-            {
-                "origin": "produitsdechets_acceptes",
-                "transformation": "clean_sous_categorie_codes",
-                "destination": "sous_categorie_codes",
-            },
-            # 3. Ajout des colonnes avec une valeur par défaut
-            {
-                "column": "statut",
-                "value": constants.ACTEUR_ACTIF,
-            },
-            {
-                "column": "label_codes",
-                "value": [],
-            },
-            # 4. Transformation du dataframe
-            {
-                "origin": ["latitude", "longitude"],
-                "transformation": "compute_location",
-                "destination": ["location"],
-            },
-            {
-                "origin": ["id_point_apport_ou_reparation", "nom", "acteur_type_code"],
-                "transformation": "clean_identifiant_externe",
-                "destination": ["identifiant_externe"],
-            },
-            {
-                "origin": [
-                    "identifiant_externe",
-                    "source_code",
-                ],
-                "transformation": "clean_identifiant_unique",
-                "destination": ["identifiant_unique"],
-            },
-            {
-                "origin": ["siret"],
-                "transformation": "clean_siret_and_siren",
-                "destination": ["siret", "siren"],
-            },
-            {
-                "origin": ["adresse_format_ban"],
-                "transformation": "clean_adresse",
-                "destination": ["adresse", "code_postal", "ville"],
-            },
-            {
-                "origin": ["telephone", "code_postal"],
-                "transformation": "clean_telephone",
-                "destination": ["telephone"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_acteur_service_codes",
-                "destination": ["acteur_service_codes"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_action_codes",
-                "destination": ["action_codes"],
-            },
-            {
-                "origin": ["action_codes", "sous_categorie_codes"],
-                "transformation": "clean_proposition_services",
-                "destination": ["proposition_service_codes"],
-            },
-            # 5. Supression des colonnes
-            {"remove": "_i"},
-            {"remove": "_id"},
-            {"remove": "_updatedAt"},
-            {"remove": "_rand"},
-            {"remove": "_geopoint"},
-            {"remove": "filiere"},
-            {"remove": "_score"},
-            {"remove": "adresse_format_ban"},
-            {"remove": "id_point_apport_ou_reparation"},
-            {"remove": "point_de_collecte_ou_de_reprise_des_dechets"},
-            # {"remove": "labels_etou_bonus"},
-            {"remove": "point_dapport_de_service_reparation"},
-            {"remove": "point_dapport_pour_reemploi"},
-            {"remove": "point_de_reparation"},
-            # 6. Colonnes à garder (rien à faire, utilisé pour le controle)
-            {"keep": "email"},
-        ],
+        "normalization_rules": EO_NORMALIZATION_RULES,
         "endpoint": (
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-ecomaison/lines?size=10000"
+        ),
+        "metadata_endpoint": (
+            "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
+            "donnees-eo-ecomaison/schema"
         ),
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config(),

--- a/dags/sources/dags/source_ecopae.py
+++ b/dags/sources/dags/source_ecopae.py
@@ -1,7 +1,6 @@
 from airflow import DAG
 from shared.config.tags import TAGS
-from sources.config import shared_constants as constants
-from sources.config.airflow_params import get_mapping_config
+from sources.config.airflow_params import EO_NORMALIZATION_RULES, get_mapping_config
 from sources.tasks.airflow_logic.operators import (
     default_args,
     default_params,
@@ -25,136 +24,14 @@ with DAG(
     ],
     **default_params,
     params={
-        "normalization_rules": [
-            # 1. Renommage des colonnes
-            {
-                "origin": "nom_de_lorganisme",
-                "destination": "nom",
-            },
-            {
-                "origin": "enseigne_commerciale",
-                "destination": "nom_commercial",
-            },
-            {
-                "origin": "longitudewgs84",
-                "destination": "longitude",
-            },
-            {
-                "origin": "latitudewgs84",
-                "destination": "latitude",
-            },
-            # 2. Transformation des colonnes
-            {
-                "origin": "ecoorganisme",
-                "transformation": "strip_lower_string",
-                "destination": "source_code",
-            },
-            {
-                "origin": "type_de_point_de_collecte",
-                "transformation": "clean_acteur_type_code",
-                "destination": "acteur_type_code",
-            },
-            {
-                "origin": "public_accueilli",
-                "transformation": "clean_public_accueilli",
-                "destination": "public_accueilli",
-            },
-            {
-                "origin": "exclusivite_de_reprisereparation",
-                "transformation": "cast_eo_boolean_or_string_to_boolean",
-                "destination": "exclusivite_de_reprisereparation",
-            },
-            {
-                "origin": "reprise",
-                "transformation": "clean_reprise",
-                "destination": "reprise",
-            },
-            {
-                "origin": "produitsdechets_acceptes",
-                "transformation": "clean_sous_categorie_codes",
-                "destination": "sous_categorie_codes",
-            },
-            # 3. Ajout des colonnes avec une valeur par défaut
-            {
-                "column": "statut",
-                "value": constants.ACTEUR_ACTIF,
-            },
-            {
-                "column": "label_codes",
-                "value": [],
-            },
-            # 4. Transformation du dataframe
-            {
-                "origin": ["latitude", "longitude"],
-                "transformation": "compute_location",
-                "destination": ["location"],
-            },
-            {
-                "origin": ["id_point_apport_ou_reparation", "nom", "acteur_type_code"],
-                "transformation": "clean_identifiant_externe",
-                "destination": ["identifiant_externe"],
-            },
-            {
-                "origin": [
-                    "identifiant_externe",
-                    "source_code",
-                ],
-                "transformation": "clean_identifiant_unique",
-                "destination": ["identifiant_unique"],
-            },
-            {
-                "origin": ["siret", "siren"],
-                "transformation": "clean_siret_and_siren",
-                "destination": ["siret", "siren"],
-            },
-            {
-                "origin": ["adresse_format_ban"],
-                "transformation": "clean_adresse",
-                "destination": ["adresse", "code_postal", "ville"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_acteur_service_codes",
-                "destination": ["acteur_service_codes"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_action_codes",
-                "destination": ["action_codes"],
-            },
-            {
-                "origin": ["action_codes", "sous_categorie_codes"],
-                "transformation": "clean_proposition_services",
-                "destination": ["proposition_service_codes"],
-            },
-            # 5. Supression des colonnes
-            {"remove": "_i"},
-            {"remove": "_id"},
-            {"remove": "_updatedAt"},
-            {"remove": "_rand"},
-            {"remove": "_geopoint"},
-            {"remove": "filiere"},
-            {"remove": "_score"},
-            {"remove": "adresse_format_ban"},
-            {"remove": "id_point_apport_ou_reparation"},
-            {"remove": "point_de_collecte_ou_de_reprise_des_dechets"},
-            {"remove": "point_dapport_de_service_reparation"},
-            {"remove": "point_dapport_pour_reemploi"},
-            {"remove": "point_de_reparation"},
-        ],
+        "normalization_rules": EO_NORMALIZATION_RULES,
         "endpoint": (
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-ecopae/lines?size=10000"
+        ),
+        "metadata_endpoint": (
+            "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
+            "donnees-eo-ecopae/schema"
         ),
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config(),

--- a/dags/sources/dags/source_ecosystem.py
+++ b/dags/sources/dags/source_ecosystem.py
@@ -1,7 +1,6 @@
 from airflow import DAG
 from shared.config.tags import TAGS
-from sources.config import shared_constants as constants
-from sources.config.airflow_params import get_mapping_config
+from sources.config.airflow_params import EO_NORMALIZATION_RULES, get_mapping_config
 from sources.tasks.airflow_logic.operators import (
     default_args,
     default_params,
@@ -25,123 +24,14 @@ with DAG(
     ],
     **default_params,
     params={
-        "normalization_rules": [
-            # 1. Renommage des colonnes
-            {
-                "origin": "nom_de_lorganisme",
-                "destination": "nom",
-            },
-            {
-                "origin": "enseigne_commerciale",
-                "destination": "nom_commercial",
-            },
-            {
-                "origin": "longitudewgs84",
-                "destination": "longitude",
-            },
-            {
-                "origin": "latitudewgs84",
-                "destination": "latitude",
-            },
-            # 2. Transformation des colonnes
-            {
-                "origin": "ecoorganisme",
-                "transformation": "strip_lower_string",
-                "destination": "source_code",
-            },
-            {
-                "origin": "type_de_point_de_collecte",
-                "transformation": "clean_acteur_type_code",
-                "destination": "acteur_type_code",
-            },
-            {
-                "origin": "public_accueilli",
-                "transformation": "clean_public_accueilli",
-                "destination": "public_accueilli",
-            },
-            {
-                "origin": "produitsdechets_acceptes",
-                "transformation": "clean_sous_categorie_codes",
-                "destination": "sous_categorie_codes",
-            },
-            # 3. Ajout des colonnes avec une valeur par défaut
-            {
-                "column": "statut",
-                "value": constants.ACTEUR_ACTIF,
-            },
-            {
-                "column": "label_codes",
-                "value": [],
-            },
-            # 4. Transformation du dataframe
-            {
-                "origin": ["latitude", "longitude"],
-                "transformation": "compute_location",
-                "destination": ["location"],
-            },
-            {
-                "origin": ["id_point_apport_ou_reparation", "nom", "acteur_type_code"],
-                "transformation": "clean_identifiant_externe",
-                "destination": ["identifiant_externe"],
-            },
-            {
-                "origin": [
-                    "identifiant_externe",
-                    "source_code",
-                ],
-                "transformation": "clean_identifiant_unique",
-                "destination": ["identifiant_unique"],
-            },
-            {
-                "origin": ["siren"],
-                "transformation": "clean_siret_and_siren",
-                "destination": ["siret", "siren"],
-            },
-            {
-                "origin": ["adresse_format_ban"],
-                "transformation": "clean_adresse",
-                "destination": ["adresse", "code_postal", "ville"],
-            },
-            {
-                "origin": [
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_acteur_service_codes",
-                "destination": ["acteur_service_codes"],
-            },
-            {
-                "origin": [
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_action_codes",
-                "destination": ["action_codes"],
-            },
-            {
-                "origin": ["action_codes", "sous_categorie_codes"],
-                "transformation": "clean_proposition_services",
-                "destination": ["proposition_service_codes"],
-            },
-            # 5. Supression des colonnes
-            {"remove": "_i"},
-            {"remove": "_id"},
-            {"remove": "_updatedAt"},
-            {"remove": "_rand"},
-            {"remove": "_geopoint"},
-            {"remove": "filiere"},
-            {"remove": "_score"},
-            {"remove": "adresse_format_ban"},
-            {"remove": "id_point_apport_ou_reparation"},
-            {"remove": "point_de_collecte_ou_de_reprise_des_dechets"},
-            {"remove": "point_dapport_pour_reemploi"},
-            {"remove": "siret"},
-            # 6. Colonnes à garder (rien à faire, utilisé pour le controle)
-            {"keep": "adresse_complement"},
-        ],
+        "normalization_rules": EO_NORMALIZATION_RULES,
         "endpoint": (
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-ecosystem/lines?size=10000"
+        ),
+        "metadata_endpoint": (
+            "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
+            "donnees-eo-ecosystem/schema"
         ),
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config(mapping_key="sous_categories_3eee"),

--- a/dags/sources/dags/source_ocab.py
+++ b/dags/sources/dags/source_ocab.py
@@ -1,7 +1,6 @@
 from airflow import DAG
 from shared.config.tags import TAGS
-from sources.config import shared_constants as constants
-from sources.config.airflow_params import get_mapping_config
+from sources.config.airflow_params import EO_NORMALIZATION_RULES, get_mapping_config
 from sources.tasks.airflow_logic.operators import (
     default_args,
     default_params,
@@ -25,134 +24,14 @@ with DAG(
     ],
     **default_params,
     params={
-        "normalization_rules": [
-            # 1. Renommage des colonnes
-            {
-                "origin": "nom_de_lorganisme",
-                "destination": "nom",
-            },
-            {
-                "origin": "longitudewgs84",
-                "destination": "longitude",
-            },
-            {
-                "origin": "latitudewgs84",
-                "destination": "latitude",
-            },
-            # 2. Transformation des colonnes
-            {
-                "origin": "ecoorganisme",
-                "transformation": "strip_lower_string",
-                "destination": "source_code",
-            },
-            {
-                "origin": "type_de_point_de_collecte",
-                "transformation": "clean_acteur_type_code",
-                "destination": "acteur_type_code",
-            },
-            {
-                "origin": "public_accueilli",
-                "transformation": "clean_public_accueilli",
-                "destination": "public_accueilli",
-            },
-            {
-                "origin": "produitsdechets_acceptes",
-                "transformation": "clean_sous_categorie_codes",
-                "destination": "sous_categorie_codes",
-            },
-            {
-                "origin": "horaires_douverture",
-                "transformation": "clean_horaires_osm",
-                "destination": "horaires_osm",
-            },
-            # 3. Ajout des colonnes avec une valeur par défaut
-            {
-                "column": "statut",
-                "value": constants.ACTEUR_ACTIF,
-            },
-            {
-                "column": "label_codes",
-                "value": [],
-            },
-            # 4. Transformation du dataframe
-            {
-                "origin": ["latitude", "longitude"],
-                "transformation": "compute_location",
-                "destination": ["location"],
-            },
-            {
-                "origin": ["id_point_apport_ou_reparation", "nom", "acteur_type_code"],
-                "transformation": "clean_identifiant_externe",
-                "destination": ["identifiant_externe"],
-            },
-            {
-                "origin": [
-                    "identifiant_externe",
-                    "source_code",
-                ],
-                "transformation": "clean_identifiant_unique",
-                "destination": ["identifiant_unique"],
-            },
-            {
-                "origin": ["siret"],
-                "transformation": "clean_siret_and_siren",
-                "destination": ["siret", "siren"],
-            },
-            {
-                "origin": ["adresse_format_ban"],
-                "transformation": "clean_adresse",
-                "destination": ["adresse", "code_postal", "ville"],
-            },
-            {
-                "origin": ["telephone", "code_postal"],
-                "transformation": "clean_telephone",
-                "destination": ["telephone"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_acteur_service_codes",
-                "destination": ["acteur_service_codes"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_action_codes",
-                "destination": ["action_codes"],
-            },
-            {
-                "origin": ["action_codes", "sous_categorie_codes"],
-                "transformation": "clean_proposition_services",
-                "destination": ["proposition_service_codes"],
-            },
-            # 5. Supression des colonnes
-            {"remove": "_i"},
-            {"remove": "_id"},
-            {"remove": "_updatedAt"},
-            {"remove": "_rand"},
-            {"remove": "_geopoint"},
-            {"remove": "filiere"},
-            {"remove": "_score"},
-            {"remove": "adresse_format_ban"},
-            {"remove": "id_point_apport_ou_reparation"},
-            {"remove": "point_de_collecte_ou_de_reprise_des_dechets"},
-            {"remove": "point_dapport_pour_reemploi"},
-            {"remove": "point_de_reparation"},
-            {"remove": "point_dapport_de_service_reparation"},
-            # 6. Colonnes à garder (rien à faire, utilisé pour le controle)
-            {"keep": "consignes_dacces"},
-        ],
+        "normalization_rules": EO_NORMALIZATION_RULES,
         "endpoint": (
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-ocab/lines?size=10000"
+        ),
+        "metadata_endpoint": (
+            "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
+            "donnees-eo-ocab/schema"
         ),
         "oca": {
             "prefix": "ocab",

--- a/dags/sources/dags/source_ocad3e.py
+++ b/dags/sources/dags/source_ocad3e.py
@@ -1,7 +1,6 @@
 from airflow import DAG
 from shared.config.tags import TAGS
-from sources.config import shared_constants as constants
-from sources.config.airflow_params import get_mapping_config
+from sources.config.airflow_params import EO_NORMALIZATION_RULES, get_mapping_config
 from sources.tasks.airflow_logic.operators import (
     default_args,
     default_params,
@@ -25,140 +24,14 @@ with DAG(
     ],
     **default_params,
     params={
-        "normalization_rules": [
-            # 1. Renommage des colonnes
-            {
-                "origin": "nom_de_lorganisme",
-                "destination": "nom",
-            },
-            {
-                "origin": "enseigne_commerciale",
-                "destination": "nom_commercial",
-            },
-            {
-                "origin": "longitudewgs84",
-                "destination": "longitude",
-            },
-            {
-                "origin": "latitudewgs84",
-                "destination": "latitude",
-            },
-            # 2. Transformation des colonnes
-            {
-                "origin": "site_web",
-                "transformation": "clean_url",
-                "destination": "url",
-            },
-            {
-                "origin": "type_de_point_de_collecte",
-                "transformation": "clean_acteur_type_code",
-                "destination": "acteur_type_code",
-            },
-            {
-                "origin": "public_accueilli",
-                "transformation": "clean_public_accueilli",
-                "destination": "public_accueilli",
-            },
-            {
-                "origin": "exclusivite_de_reprisereparation",
-                "transformation": "cast_eo_boolean_or_string_to_boolean",
-                "destination": "exclusivite_de_reprisereparation",
-            },
-            {
-                "origin": "produitsdechets_acceptes",
-                "transformation": "clean_sous_categorie_codes",
-                "destination": "sous_categorie_codes",
-            },
-            # 3. Ajout des colonnes avec une valeur par défaut
-            {
-                "column": "source_code",
-                "value": "ocad3e",
-            },
-            {
-                "column": "statut",
-                "value": constants.ACTEUR_ACTIF,
-            },
-            # 4. Transformation du dataframe
-            {
-                "origin": ["latitude", "longitude"],
-                "transformation": "compute_location",
-                "destination": ["location"],
-            },
-            {
-                "origin": ["labels_etou_bonus", "acteur_type_code"],
-                "transformation": "clean_label_codes",
-                "destination": ["label_codes"],
-            },
-            {
-                "origin": ["id_point_apport_ou_reparation", "nom", "acteur_type_code"],
-                "transformation": "clean_identifiant_externe",
-                "destination": ["identifiant_externe"],
-            },
-            {
-                "origin": [
-                    "identifiant_externe",
-                    "source_code",
-                ],
-                "transformation": "clean_identifiant_unique",
-                "destination": ["identifiant_unique"],
-            },
-            {
-                "origin": ["siret"],
-                "transformation": "clean_siret_and_siren",
-                "destination": ["siret", "siren"],
-            },
-            {
-                "origin": ["adresse_format_ban"],
-                "transformation": "clean_adresse",
-                "destination": ["adresse", "code_postal", "ville"],
-            },
-            {
-                "origin": ["telephone", "code_postal"],
-                "transformation": "clean_telephone",
-                "destination": ["telephone"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                ],
-                "transformation": "clean_acteur_service_codes",
-                "destination": ["acteur_service_codes"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                ],
-                "transformation": "clean_action_codes",
-                "destination": ["action_codes"],
-            },
-            {
-                "origin": ["action_codes", "sous_categorie_codes"],
-                "transformation": "clean_proposition_services",
-                "destination": ["proposition_service_codes"],
-            },
-            # 5. Supression des colonnes
-            {"remove": "_i"},
-            {"remove": "_id"},
-            {"remove": "_updatedAt"},
-            {"remove": "_rand"},
-            {"remove": "_geopoint"},
-            {"remove": "filiere"},
-            {"remove": "_score"},
-            {"remove": "adresse_format_ban"},
-            {"remove": "id_point_apport_ou_reparation"},
-            {"remove": "labels_etou_bonus"},
-            {"remove": "point_dapport_de_service_reparation"},
-            {"remove": "point_de_reparation"},
-            {"remove": "perimetre_dintervention"},
-            {"remove": "ecoorganisme"},
-            {"remove": "service_a_domicile"},
-            # 6. Colonnes à garder (rien à faire, utilisé pour le controle)
-        ],
+        "normalization_rules": EO_NORMALIZATION_RULES,
         "endpoint": (
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-ocad3e/lines?size=10000"
+        ),
+        "metadata_endpoint": (
+            "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
+            "donnees-eo-ocad3e/schema"
         ),
         "validate_address_with_ban": False,
         "label_bonus_reparation": "qualirepar",

--- a/dags/sources/dags/source_pyreo.py
+++ b/dags/sources/dags/source_pyreo.py
@@ -1,7 +1,6 @@
 from airflow import DAG
 from shared.config.tags import TAGS
-from sources.config import shared_constants as constants
-from sources.config.airflow_params import get_mapping_config
+from sources.config.airflow_params import EO_NORMALIZATION_RULES, get_mapping_config
 from sources.tasks.airflow_logic.operators import (
     default_args,
     default_params,
@@ -25,158 +24,14 @@ with DAG(
     ],
     **default_params,
     params={
-        "normalization_rules": [
-            # 1. Renommage des colonnes
-            {
-                "origin": "nom_de_lorganisme",
-                "destination": "nom",
-            },
-            # {
-            #     "origin": "enseigne_commerciale",
-            #     "destination": "nom_commercial",
-            # },
-            {
-                "origin": "longitudewgs84",
-                "destination": "longitude",
-            },
-            {
-                "origin": "latitudewgs84",
-                "destination": "latitude",
-            },
-            # 2. Transformation des colonnes
-            {
-                "origin": "ecoorganisme",
-                "transformation": "strip_lower_string",
-                "destination": "source_code",
-            },
-            # {
-            #     "origin": "site_web",
-            #     "transformation": "clean_url",
-            #     "destination": "url",
-            # },
-            {
-                "origin": "type_de_point_de_collecte",
-                "transformation": "clean_acteur_type_code",
-                "destination": "acteur_type_code",
-            },
-            {
-                "origin": "public_accueilli",
-                "transformation": "clean_public_accueilli",
-                "destination": "public_accueilli",
-            },
-            # {
-            #     "origin": "uniquement_sur_rdv",
-            #     "transformation": "cast_eo_boolean_or_string_to_boolean",
-            #     "destination": "uniquement_sur_rdv",
-            # },
-            # {
-            #     "origin": "exclusivite_de_reprisereparation",
-            #     "transformation": "cast_eo_boolean_or_string_to_boolean",
-            #     "destination": "exclusivite_de_reprisereparation",
-            # },
-            {
-                "origin": "reprise",
-                "transformation": "clean_reprise",
-                "destination": "reprise",
-            },
-            {
-                "origin": "produitsdechets_acceptes",
-                "transformation": "clean_sous_categorie_codes",
-                "destination": "sous_categorie_codes",
-            },
-            # 3. Ajout des colonnes avec une valeur par défaut
-            {
-                "column": "statut",
-                "value": constants.ACTEUR_ACTIF,
-            },
-            # {
-            #     "column": "label_codes",
-            #     "value": [],
-            # },
-            # 4. Transformation du dataframe
-            {
-                "origin": ["latitude", "longitude"],
-                "transformation": "compute_location",
-                "destination": ["location"],
-            },
-            {
-                "origin": ["labels_etou_bonus", "acteur_type_code"],
-                "transformation": "clean_label_codes",
-                "destination": ["label_codes"],
-            },
-            {
-                "origin": ["id_point_apport_ou_reparation", "nom", "acteur_type_code"],
-                "transformation": "clean_identifiant_externe",
-                "destination": ["identifiant_externe"],
-            },
-            {
-                "origin": [
-                    "identifiant_externe",
-                    "source_code",
-                ],
-                "transformation": "clean_identifiant_unique",
-                "destination": ["identifiant_unique"],
-            },
-            {
-                "origin": ["siret"],
-                "transformation": "clean_siret_and_siren",
-                "destination": ["siret", "siren"],
-            },
-            {
-                "origin": ["adresse_format_ban"],
-                "transformation": "clean_adresse",
-                "destination": ["adresse", "code_postal", "ville"],
-            },
-            # {
-            #     "origin": ["telephone", "code_postal"],
-            #     "transformation": "clean_telephone",
-            #     "destination": ["telephone"],
-            # },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_acteur_service_codes",
-                "destination": ["acteur_service_codes"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_action_codes",
-                "destination": ["action_codes"],
-            },
-            {
-                "origin": ["action_codes", "sous_categorie_codes"],
-                "transformation": "clean_proposition_services",
-                "destination": ["proposition_service_codes"],
-            },
-            # 5. Supression des colonnes
-            {"remove": "_i"},
-            {"remove": "_id"},
-            {"remove": "_updatedAt"},
-            {"remove": "_rand"},
-            {"remove": "_geopoint"},
-            {"remove": "filiere"},
-            {"remove": "_score"},
-            {"remove": "adresse_format_ban"},
-            {"remove": "id_point_apport_ou_reparation"},
-            {"remove": "point_de_collecte_ou_de_reprise_des_dechets"},
-            {"remove": "labels_etou_bonus"},
-            {"remove": "point_dapport_de_service_reparation"},
-            {"remove": "point_dapport_pour_reemploi"},
-            {"remove": "point_de_reparation"},
-            # 6. Colonnes à garder (rien à faire, utilisé pour le controle)
-        ],
+        "normalization_rules": EO_NORMALIZATION_RULES,
         "endpoint": (
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-pyreo/lines?size=10000"
+        ),
+        "metadata_endpoint": (
+            "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
+            "donnees-eo-pyreo/schema"
         ),
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config(),

--- a/dags/sources/dags/source_refashion.py
+++ b/dags/sources/dags/source_refashion.py
@@ -1,7 +1,6 @@
 from airflow import DAG
 from shared.config.tags import TAGS
-from sources.config import shared_constants as constants
-from sources.config.airflow_params import get_mapping_config
+from sources.config.airflow_params import EO_NORMALIZATION_RULES, get_mapping_config
 from sources.tasks.airflow_logic.operators import (
     default_args,
     default_params,
@@ -25,161 +24,14 @@ with DAG(
     ],
     **default_params,
     params={
-        "normalization_rules": [
-            # 1. Renommage des colonnes
-            {
-                "origin": "nom_de_lorganisme",
-                "destination": "nom",
-            },
-            {
-                "origin": "enseigne_commerciale",
-                "destination": "nom_commercial",
-            },
-            {
-                "origin": "longitudewgs84",
-                "destination": "longitude",
-            },
-            {
-                "origin": "latitudewgs84",
-                "destination": "latitude",
-            },
-            {
-                "origin": "horaires_douverture",
-                "destination": "horaires_description",
-            },
-            # 2. Transformation des colonnes
-            {
-                "origin": "ecoorganisme",
-                "transformation": "strip_lower_string",
-                "destination": "source_code",
-            },
-            {
-                "origin": "site_web",
-                "transformation": "clean_url",
-                "destination": "url",
-            },
-            {
-                "origin": "type_de_point_de_collecte",
-                "transformation": "clean_acteur_type_code",
-                "destination": "acteur_type_code",
-            },
-            {
-                "origin": "public_accueilli",
-                "transformation": "clean_public_accueilli",
-                "destination": "public_accueilli",
-            },
-            {
-                "origin": "uniquement_sur_rdv",
-                "transformation": "cast_eo_boolean_or_string_to_boolean",
-                "destination": "uniquement_sur_rdv",
-            },
-            {
-                "origin": "exclusivite_de_reprisereparation",
-                "transformation": "cast_eo_boolean_or_string_to_boolean",
-                "destination": "exclusivite_de_reprisereparation",
-            },
-            {
-                "origin": "reprise",
-                "transformation": "clean_reprise",
-                "destination": "reprise",
-            },
-            {
-                "origin": "produitsdechets_acceptes",
-                "transformation": "clean_sous_categorie_codes",
-                "destination": "sous_categorie_codes",
-            },
-            # 3. Ajout des colonnes avec une valeur par défaut
-            {
-                "column": "statut",
-                "value": constants.ACTEUR_ACTIF,
-            },
-            # 4. Transformation du dataframe
-            {
-                "origin": ["latitude", "longitude"],
-                "transformation": "compute_location",
-                "destination": ["location"],
-            },
-            {
-                "origin": ["labels_etou_bonus", "acteur_type_code"],
-                "transformation": "clean_label_codes",
-                "destination": ["label_codes"],
-            },
-            {
-                "origin": ["id_point_apport_ou_reparation", "nom", "acteur_type_code"],
-                "transformation": "clean_identifiant_externe",
-                "destination": ["identifiant_externe"],
-            },
-            {
-                "origin": [
-                    "identifiant_externe",
-                    "source_code",
-                ],
-                "transformation": "clean_identifiant_unique",
-                "destination": ["identifiant_unique"],
-            },
-            {
-                "origin": ["siret"],
-                "transformation": "clean_siret_and_siren",
-                "destination": ["siret", "siren"],
-            },
-            {
-                "origin": ["adresse_format_ban"],
-                "transformation": "clean_adresse",
-                "destination": ["adresse", "code_postal", "ville"],
-            },
-            {
-                "origin": ["telephone", "code_postal"],
-                "transformation": "clean_telephone",
-                "destination": ["telephone"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_acteur_service_codes",
-                "destination": ["acteur_service_codes"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_action_codes",
-                "destination": ["action_codes"],
-            },
-            {
-                "origin": ["action_codes", "sous_categorie_codes"],
-                "transformation": "clean_proposition_services",
-                "destination": ["proposition_service_codes"],
-            },
-            # 5. Supression des colonnes
-            {"remove": "_i"},
-            {"remove": "_id"},
-            {"remove": "_updatedAt"},
-            {"remove": "_rand"},
-            {"remove": "_geopoint"},
-            {"remove": "filiere"},
-            {"remove": "_score"},
-            {"remove": "adresse_format_ban"},
-            {"remove": "id_point_apport_ou_reparation"},
-            {"remove": "point_de_collecte_ou_de_reprise_des_dechets"},
-            {"remove": "labels_etou_bonus"},
-            {"remove": "point_dapport_de_service_reparation"},
-            {"remove": "point_dapport_pour_reemploi"},
-            {"remove": "point_de_reparation"},
-            {"remove": "perimetre_dintervention"},
-            {"remove": "service_a_domicile"},
-            # 6. Colonnes à garder (rien à faire, utilisé pour le controle)
-            {"keep": "adresse_complement"},
-        ],
+        "normalization_rules": EO_NORMALIZATION_RULES,
         "endpoint": (
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-refashion/lines?size=10000"
+        ),
+        "metadata_endpoint": (
+            "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
+            "donnees-eo-refashion/schema"
         ),
         "validate_address_with_ban": False,
         "label_bonus_reparation": "refashion",

--- a/dags/sources/dags/source_soren.py
+++ b/dags/sources/dags/source_soren.py
@@ -1,7 +1,6 @@
 from airflow import DAG
 from shared.config.tags import TAGS
-from sources.config import shared_constants as constants
-from sources.config.airflow_params import get_mapping_config
+from sources.config.airflow_params import EO_NORMALIZATION_RULES, get_mapping_config
 from sources.tasks.airflow_logic.operators import (
     default_args,
     default_params,
@@ -25,144 +24,14 @@ with DAG(
     ],
     **default_params,
     params={
-        "normalization_rules": [
-            # 1. Renommage des colonnes
-            {"origin": "nom_de_lorganisme", "destination": "nom"},
-            {"origin": "enseigne_commerciale", "destination": "nom_commercial"},
-            {"origin": "longitudewgs84", "destination": "longitude"},
-            {"origin": "latitudewgs84", "destination": "latitude"},
-            # 2. Transformation des colonnes
-            {"origin": "site_web", "transformation": "clean_url", "destination": "url"},
-            {
-                "origin": "ecoorganisme",
-                "transformation": "strip_lower_string",
-                "destination": "source_code",
-            },
-            {
-                "origin": "horaires_douverture",
-                "transformation": "clean_horaires_osm",
-                "destination": "horaires_osm",
-            },
-            {
-                "origin": "horaires_osm",
-                "transformation": "convert_opening_hours",
-                "destination": "horaires_description",
-            },
-            {
-                "origin": "type_de_point_de_collecte",
-                "transformation": "clean_acteur_type_code",
-                "destination": "acteur_type_code",
-            },
-            {
-                "origin": "public_accueilli",
-                "transformation": "clean_public_accueilli",
-                "destination": "public_accueilli",
-            },
-            {
-                "origin": "uniquement_sur_rdv",
-                "transformation": "cast_eo_boolean_or_string_to_boolean",
-                "destination": "uniquement_sur_rdv",
-            },
-            {
-                "origin": "exclusivite_de_reprisereparation",
-                "transformation": "cast_eo_boolean_or_string_to_boolean",
-                "destination": "exclusivite_de_reprisereparation",
-            },
-            {
-                "origin": "reprise",
-                "transformation": "clean_reprise",
-                "destination": "reprise",
-            },
-            {
-                "origin": "produitsdechets_acceptes",
-                "transformation": "clean_sous_categorie_codes",
-                "destination": "sous_categorie_codes",
-            },
-            # 3. Ajout des colonnes avec une valeur par défaut
-            {"column": "statut", "value": constants.ACTEUR_ACTIF},
-            # 4. Transformation du dataframe
-            {
-                "origin": ["siret", "siren"],
-                "transformation": "clean_siret_and_siren",
-                "destination": ["siret", "siren"],
-            },
-            {
-                "origin": ["latitude", "longitude"],
-                "transformation": "compute_location",
-                "destination": ["location"],
-            },
-            {
-                "origin": ["labels_etou_bonus", "acteur_type_code"],
-                "transformation": "clean_label_codes",
-                "destination": ["label_codes"],
-            },
-            {
-                "origin": ["id_point_apport_ou_reparation", "nom", "acteur_type_code"],
-                "transformation": "clean_identifiant_externe",
-                "destination": ["identifiant_externe"],
-            },
-            {
-                "origin": [
-                    "identifiant_externe",
-                    "source_code",
-                ],
-                "transformation": "clean_identifiant_unique",
-                "destination": ["identifiant_unique"],
-            },
-            {
-                "origin": ["adresse_format_ban"],
-                "transformation": "clean_adresse",
-                "destination": ["adresse", "code_postal", "ville"],
-            },
-            {
-                "origin": ["telephone", "code_postal"],
-                "transformation": "clean_telephone",
-                "destination": ["telephone"],
-            },
-            {
-                "origin": [
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_acteur_service_codes",
-                "destination": ["acteur_service_codes"],
-            },
-            {
-                "origin": [
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_action_codes",
-                "destination": ["action_codes"],
-            },
-            {
-                "origin": ["action_codes", "sous_categorie_codes"],
-                "transformation": "clean_proposition_services",
-                "destination": ["proposition_service_codes"],
-            },
-            # 5. Supression des colonnes
-            {"remove": "_i"},
-            {"remove": "_id"},
-            {"remove": "_updatedAt"},
-            {"remove": "_rand"},
-            {"remove": "_geopoint"},
-            {"remove": "filiere"},
-            {"remove": "_score"},
-            {"remove": "adresse_format_ban"},
-            {"remove": "id_point_apport_ou_reparation"},
-            {"remove": "point_de_collecte_ou_de_reprise_des_dechets"},
-            {"remove": "labels_etou_bonus"},
-            {"remove": "point_dapport_de_service_reparation"},
-            {"remove": "point_dapport_pour_reemploi"},
-            {"remove": "point_de_reparation"},
-            {"remove": "perimetre_dintervention"},
-            {"remove": "service_a_domicile"},
-            # 6. Colonnes à garder (rien à faire, utilisé pour le controle)
-            {"keep": "email"},
-            {"keep": "adresse_complement"},
-            {"keep": "consignes_dacces"},
-        ],
+        "normalization_rules": EO_NORMALIZATION_RULES,
         "endpoint": (
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-soren/lines?size=10000"
+        ),
+        "metadata_endpoint": (
+            "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
+            "donnees-eo-soren/schema"
         ),
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config(),

--- a/dags/sources/dags/source_valdelia.py
+++ b/dags/sources/dags/source_valdelia.py
@@ -1,7 +1,6 @@
 from airflow import DAG
 from shared.config.tags import TAGS
-from sources.config import shared_constants as constants
-from sources.config.airflow_params import get_mapping_config
+from sources.config.airflow_params import EO_NORMALIZATION_RULES, get_mapping_config
 from sources.tasks.airflow_logic.operators import (
     default_args,
     default_params,
@@ -25,149 +24,14 @@ with DAG(
     ],
     **default_params,
     params={
-        "normalization_rules": [
-            # 1. Renommage des colonnes
-            {
-                "origin": "nom_de_lorganisme",
-                "destination": "nom",
-            },
-            {
-                "origin": "enseigne_commerciale",
-                "destination": "nom_commercial",
-            },
-            {
-                "origin": "longitudewgs84",
-                "destination": "longitude",
-            },
-            {
-                "origin": "latitudewgs84",
-                "destination": "latitude",
-            },
-            # 2. Transformation des colonnes
-            {
-                "origin": "ecoorganisme",
-                "transformation": "strip_lower_string",
-                "destination": "source_code",
-            },
-            {
-                "origin": "type_de_point_de_collecte",
-                "transformation": "clean_acteur_type_code",
-                "destination": "acteur_type_code",
-            },
-            {
-                "origin": "public_accueilli",
-                "transformation": "clean_public_accueilli",
-                "destination": "public_accueilli",
-            },
-            {
-                "origin": "uniquement_sur_rdv",
-                "transformation": "cast_eo_boolean_or_string_to_boolean",
-                "destination": "uniquement_sur_rdv",
-            },
-            {
-                "origin": "exclusivite_de_reprisereparation",
-                "transformation": "cast_eo_boolean_or_string_to_boolean",
-                "destination": "exclusivite_de_reprisereparation",
-            },
-            {
-                "origin": "reprise",
-                "transformation": "clean_reprise",
-                "destination": "reprise",
-            },
-            {
-                "origin": "produitsdechets_acceptes",
-                "transformation": "clean_sous_categorie_codes",
-                "destination": "sous_categorie_codes",
-            },
-            # 3. Ajout des colonnes avec une valeur par défaut
-            {
-                "column": "statut",
-                "value": constants.ACTEUR_ACTIF,
-            },
-            # 4. Transformation du dataframe
-            {
-                "origin": ["latitude", "longitude"],
-                "transformation": "compute_location",
-                "destination": ["location"],
-            },
-            {
-                "origin": ["labels_etou_bonus", "acteur_type_code"],
-                "transformation": "clean_label_codes",
-                "destination": ["label_codes"],
-            },
-            {
-                "origin": ["id_point_apport_ou_reparation", "nom", "acteur_type_code"],
-                "transformation": "clean_identifiant_externe",
-                "destination": ["identifiant_externe"],
-            },
-            {
-                "origin": [
-                    "identifiant_externe",
-                    "source_code",
-                ],
-                "transformation": "clean_identifiant_unique",
-                "destination": ["identifiant_unique"],
-            },
-            {
-                "origin": ["siret", "siren"],
-                "transformation": "clean_siret_and_siren",
-                "destination": ["siret", "siren"],
-            },
-            {
-                "origin": ["adresse_format_ban"],
-                "transformation": "clean_adresse",
-                "destination": ["adresse", "code_postal", "ville"],
-            },
-            {
-                "origin": ["telephone", "code_postal"],
-                "transformation": "clean_telephone",
-                "destination": ["telephone"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_acteur_service_codes",
-                "destination": ["acteur_service_codes"],
-            },
-            {
-                "origin": [
-                    "point_dapport_de_service_reparation",
-                    "point_de_reparation",
-                    "point_dapport_pour_reemploi",
-                    "point_de_collecte_ou_de_reprise_des_dechets",
-                ],
-                "transformation": "clean_action_codes",
-                "destination": ["action_codes"],
-            },
-            {
-                "origin": ["action_codes", "sous_categorie_codes"],
-                "transformation": "clean_proposition_services",
-                "destination": ["proposition_service_codes"],
-            },
-            # 5. Supression des colonnes
-            {"remove": "_i"},
-            {"remove": "_id"},
-            {"remove": "_updatedAt"},
-            {"remove": "_rand"},
-            {"remove": "_geopoint"},
-            {"remove": "filiere"},
-            {"remove": "_score"},
-            {"remove": "adresse_format_ban"},
-            {"remove": "id_point_apport_ou_reparation"},
-            {"remove": "point_de_collecte_ou_de_reprise_des_dechets"},
-            {"remove": "labels_etou_bonus"},
-            {"remove": "point_dapport_de_service_reparation"},
-            {"remove": "point_dapport_pour_reemploi"},
-            {"remove": "point_de_reparation"},
-            # 6. Colonnes à garder (rien à faire, utilisé pour le controle)
-        ],
+        "normalization_rules": EO_NORMALIZATION_RULES,
         "endpoint": (
             "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
             "donnees-eo-valdelia/lines?size=10000"
+        ),
+        "metadata_endpoint": (
+            "https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/"
+            "donnees-eo-valdelia/schema"
         ),
         "validate_address_with_ban": False,
         "product_mapping": get_mapping_config(),

--- a/dags/sources/tasks/airflow_logic/config_management.py
+++ b/dags/sources/tasks/airflow_logic/config_management.py
@@ -63,6 +63,7 @@ class DAGConfig(BaseModel):
     dechet_mapping: dict = {}
     s3_connection_id: str | None = None
     endpoint: str  # HttpURL or s3URL
+    metadata_endpoint: str | None = None
     label_bonus_reparation: Optional[str] = None
     product_mapping: dict
     source_code: Optional[str] = None
@@ -87,6 +88,15 @@ class DAGConfig(BaseModel):
             raise ValueError("URL must start with 's3://' or 'http(s)://'")
 
         return endpoint
+
+    @field_validator("metadata_endpoint")
+    def validate_metadata_endpoint(cls, metadata_endpoint):
+        if metadata_endpoint is not None:
+            if not re.match(r"^https?://[^/\s]+[^\s]*$", metadata_endpoint):
+                raise ValueError(
+                    "if metadata_endpoint is set, it must be a valid HTTP URL"
+                )
+        return metadata_endpoint
 
     @classmethod
     def from_airflow_params(

--- a/dags/sources/tasks/airflow_logic/source_data_download_task.py
+++ b/dags/sources/tasks/airflow_logic/source_data_download_task.py
@@ -24,10 +24,15 @@ def source_data_download_task(dag: DAG) -> PythonOperator:
 def source_data_download_wrapper(**kwargs) -> pd.DataFrame:
     dag_config = DAGConfig.from_airflow_params(kwargs["params"])
     endpoint = dag_config.endpoint
+    metadata_endpoint = dag_config.metadata_endpoint
     s3_connection_id = dag_config.s3_connection_id
 
     log.preview("API end point", endpoint)
     if s3_connection_id:
         log.preview("S3 connection id", s3_connection_id)
 
-    return source_data_download(endpoint=endpoint, s3_connection_id=s3_connection_id)
+    return source_data_download(
+        endpoint=endpoint,
+        s3_connection_id=s3_connection_id,
+        metadata_endpoint=metadata_endpoint,
+    )

--- a/dags/sources/tasks/business_logic/source_data_download.py
+++ b/dags/sources/tasks/business_logic/source_data_download.py
@@ -6,14 +6,15 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import requests
-
 from utils import logging_utils as log
 
 logger = logging.getLogger(__name__)
 
 
 def source_data_download(
-    endpoint: str, s3_connection_id: str | None = None
+    endpoint: str,
+    s3_connection_id: str | None = None,
+    metadata_endpoint: str | None = None,
 ) -> pd.DataFrame:
     """Téléchargement de la données source sans lui apporter de modification"""
     logger.info("Téléchargement données de l'API : début...")
@@ -27,6 +28,33 @@ def source_data_download(
     if df.empty:
         raise ValueError("Aucune donnée reçue de l'API")
     log.preview("df retournée par la tâche", df)
+
+    if metadata_endpoint:
+        metadata = requests.get(metadata_endpoint, timeout=60)
+        metadata.raise_for_status()
+        schema = metadata.json()
+
+        # Récupérer toutes les colonnes attendues du schéma
+        expected_columns = [
+            field["key"] for field in schema if not field.get("x-calculated", False)
+        ]
+
+        # Vérifier les colonnes manquantes
+        missing_columns = set(expected_columns) - set(df.columns)
+        if missing_columns:
+            logger.warning(f"Colonnes manquantes dans le DataFrame : {missing_columns}")
+        for column in missing_columns:
+            df[column] = ""
+
+        # Vérifier les colonnes supplémentaires non attendues
+        extra_columns = set(df.columns) - set(expected_columns)
+        if extra_columns:
+            logger.warning(
+                f"Colonnes supplémentaires dans le DataFrame : {extra_columns}"
+            )
+
+        log.preview("metadata retournée par la tâche", schema)
+
     return df
 
 

--- a/dags/sources/tasks/transform/transform_column.py
+++ b/dags/sources/tasks/transform/transform_column.py
@@ -14,12 +14,15 @@ logger = logging.getLogger(__name__)
 CLOSED_THIS_DAY = "Fermé"
 
 
-def cast_eo_boolean_or_string_to_boolean(value: str | bool, _) -> bool:
+def cast_eo_boolean_or_string_to_boolean(value: str | bool, _) -> bool | None:
     if isinstance(value, bool):
         return value
     if isinstance(value, str):
-        return value.lower().strip() == "oui"
-    return False
+        if value.lower().strip() == "oui":
+            return True
+        if value.lower().strip() == "non":
+            return False
+    return None
 
 
 def convert_opening_hours(opening_hours: str | None, _) -> str:
@@ -158,6 +161,15 @@ def clean_url(url, _) -> str:
         url = "https://" + url
 
     return url
+
+
+def clean_email(email: str | None, _) -> str:
+    if pd.isna(email) or not email:
+        return ""
+    email = str(email).strip().lower()
+    if not re.match(r"[^@]+@[^@]+\.[^@]+", email):
+        return ""
+    return email
 
 
 def clean_code_postal(cp: str | None, _) -> str:

--- a/dags/tests/sources/tasks/transform/test_transform_column.py
+++ b/dags/tests/sources/tasks/transform/test_transform_column.py
@@ -6,6 +6,7 @@ from sources.tasks.transform.transform_column import (
     clean_acteur_type_code,
     clean_code_list,
     clean_code_postal,
+    clean_email,
     clean_horaires_osm,
     clean_number,
     clean_public_accueilli,
@@ -25,7 +26,7 @@ class TestCastEOBooleanOrStringToBoolean:
     @pytest.mark.parametrize(
         "value,expected_value",
         [
-            (None, False),
+            (None, None),
             (False, False),
             (True, True),
             ("oui", True),
@@ -34,9 +35,9 @@ class TestCastEOBooleanOrStringToBoolean:
             ("non", False),
             ("NON", False),
             (" NON ", False),
-            ("", False),
-            (" ", False),
-            ("fake", False),
+            ("", None),
+            (" ", None),
+            ("fake", None),
         ],
     )
     def test_cast_eo_boolean_or_string_to_boolean(
@@ -323,6 +324,26 @@ class TestCleanUrl:
     )
     def test_clean_url(self, url, expected_url):
         assert clean_url(url, None) == expected_url
+
+
+class TestCleanEmail:
+    @pytest.mark.parametrize(
+        "email, expected_email",
+        [
+            (None, ""),
+            ("", ""),
+            ("fake", ""),
+            ("@example.com ", ""),
+            ("fake@example.com", "fake@example.com"),
+            (" fake@example.com ", "fake@example.com"),
+            (
+                "prenom.de-mon_nom@ex-am_ple.com.fr",
+                "prenom.de-mon_nom@ex-am_ple.com.fr",
+            ),
+        ],
+    )
+    def test_clean_email(self, email, expected_email):
+        assert clean_email(email, None) == expected_email
 
 
 class TestCleanCodePostal:


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [Airflow : couvrir toutes les colonnes du schéma de données, pour ne pas être surpris si de nouvelles colonnes sont remplies lors d’une prochaine version du fichier EO - “Le dataframe n'a pas les colonnes attendues”](https://www.notion.so/accelerateur-transition-ecologique-ademe/Airflow-couvrir-toutes-les-colonnes-du-sch-ma-de-donn-es-pour-ne-pas-tre-surpris-si-de-nouvelles-1916523d57d780a08880c065d37bfba1?source=copy_link)

**🗺️ contexte**: Airflow - Source

**💡 quoi**: Normaliser l'ingestion des sources de type eco-organisme

**🎯 pourquoi**: Eviter que ça plante quand l'EO rempli ou non une nouvelle colonne

**🤔 comment**:

- Récupération du schema sur pointdapport et création des colonnes vide si celle-ci n'existent pas
- Gestion des emails et de la validation d'email : l'email est ignoré si il est mal formatté
- correction de uniquement_sur_rdv, on laisse la valeur à None si celle-ci n'est pas renseignée

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code
