### PR TITLE
Correction du lancement du Dag export_opendata une fois par semaine

### DIFF
--- a/dags/acteurs/dags/export_opendata.py
+++ b/dags/acteurs/dags/export_opendata.py
@@ -1,12 +1,12 @@
 from datetime import timedelta
 
+import pendulum
 from acteurs.tasks.airflow_logic.export_opendata_csv_to_s3_task import (
     export_opendata_csv_to_s3_task,
 )
 from airflow import DAG
 from decouple import config
 from shared.config.schedules import SCHEDULES
-from shared.config.start_dates import START_DATES
 from shared.config.tags import TAGS
 
 ENVIRONMENT = config("ENVIRONMENT", default="development")
@@ -24,7 +24,7 @@ default_args = {
 with DAG(
     "export_opendata_dag",
     default_args=default_args,
-    start_date=START_DATES.YESTERDAY,
+    start_date=pendulum.datetime(2025, 8, 1, tz="UTC"),
     dag_display_name="Acteurs Open-Data - Exporter les Acteurs en Open-Data",
     description=(
         "Ce DAG export les acteurs disponibles en opendata précédemment générés dans la"


### PR DESCRIPTION
# Description succincte du problème résolu

Mattermost : [Le run hebdomadaire pour exporter les acteurs en open data a échoué à nouveau](https://mattermost.incubateur.net/betagouv/pl/ia9pfoe5ctfsxgyyip49wkdaio)

**🗺️ contexte**: Airflow - Export Opendata

**💡 quoi**: Résolution du lancement hedbomadaire qui ne marche pas

**🎯 pourquoi**: Start date dynamique -> pas une bonne pratique

**🤔 comment**: Mise à jour d'une start date fixe pour ce DAG

cf. https://github.com/apache/airflow/discussions/54369

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
