### PR TITLE
Docker Airflow : uniquement Scaleway

### DIFF
--- a/.github/workflows/airflow_docker.yml
+++ b/.github/workflows/airflow_docker.yml
@@ -3,6 +3,7 @@
 name: 🐳 Docker images for Airflow
 on:
   # See https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#webhook-payload-object-38
+  workflow_dispatch:
   workflow_call:
   release:
     types: [ released, prereleased ]
@@ -10,8 +11,6 @@ on:
     branches:
       - main
 env:
-  GITHUB_REGISTRY: ghcr.io
-  OWNER: ${{ github.repository_owner }}
   SCALEWAY_REGISTRY: rg.fr-par.scw.cloud
   SCALEWAY_NAMESPACE: ns-qfdmo
 jobs:
@@ -19,54 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
-
-      # https://github.com/docker/login-action
-      - name: "[⚫️ GitHub] Log in to the Container registry"
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1
-        with:
-          registry: ${{ env.GITHUB_REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # https://github.com/docker/metadata-action
-      - name: "[⚫️ GitHub] Extract metadata (tags, labels) for Docker"
-        id: airflow_scheduler_meta
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
-        with:
-          images: ${{ env.GITHUB_REGISTRY }}/${{ env.OWNER }}/airflow-scheduler
-
-      # https://github.com/docker/build-push-action
-      - name: "[⚫️ GitHub] Build and push Docker image (airflow-scheduler)"
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
-        with:
-          context: .
-          push: true
-          cache-from: type=registry,ref=${{ env.OWNER }}/airflow-scheduler:latest
-          cache-to: type=inline
-          tags: ${{ steps.airflow_scheduler_meta.outputs.tags }}
-          labels: ${{ steps.airflow_scheduler_meta.outputs.labels }}
-          file: airflow-scheduler.Dockerfile
-
-      - name: "[⚫️ GitHub] Extract metadata (tags, labels) for Docker"
-        id: airflow_webserver_meta
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
-        with:
-          images: ${{ env.GITHUB_REGISTRY }}/${{ env.OWNER }}/airflow-webserver
-
-      - name: "[⚫️ GitHub] Build and push Docker image (airflow-webserver)"
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
-        with:
-          context: .
-          push: true
-          cache-from: type=registry,ref=${{ env.OWNER }}/airflow-webserver:latest
-          cache-to: type=inline
-          tags: ${{ steps.airflow_webserver_meta.outputs.tags }}
-          labels: ${{ steps.airflow_webserver_meta.outputs.labels }}
-          file: airflow-webserver.Dockerfile
 
       # https://github.com/docker/login-action
       - name: "[🟣 Scaleway] Log in to the Scaleway Container registry"
@@ -89,8 +43,6 @@ jobs:
         with:
           context: .
           push: true
-          cache-from: type=registry,ref=${{ env.SCALEWAY_NAMESPACE }}/airflow-scheduler:latest
-          cache-to: type=inline
           tags: ${{ steps.airflow_scheduler_meta_scaleway.outputs.tags }}
           labels: ${{ steps.airflow_scheduler_meta_scaleway.outputs.labels }}
           file: airflow-scheduler.Dockerfile
@@ -106,8 +58,6 @@ jobs:
         with:
           context: .
           push: true
-          cache-from: type=registry,ref=${{ env.SCALEWAY_NAMESPACE }}/airflow-webserver:latest
-          cache-to: type=inline
           tags: ${{ steps.airflow_webserver_meta_scaleway.outputs.tags }}
           labels: ${{ steps.airflow_webserver_meta_scaleway.outputs.labels }}
           file: airflow-webserver.Dockerfile


### PR DESCRIPTION
# Description succincte du problème résolu

Modifie le job de CI Docker en charge de build et push les images d'Airflow afin de :
- pouvoir le trigger depuis l'interface avec `workflow_dispatch`
- ne pas push les images sur GitHub (non utilisé) et uniquement sur Scaleway
- ne pas utiliser de cache, qui ne semble pas fonctionner sur Scaleway :sad:


## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->