### PR TITLE
CI Docker Airflow : cache GitHub Actions

### DIFF
--- a/.github/workflows/airflow_docker.yml
+++ b/.github/workflows/airflow_docker.yml
@@ -30,6 +30,8 @@ jobs:
           username: nologin
           password: ${{ secrets.SCALEWAY_DOCKER_SECRET }}
 
+      - uses: docker/setup-buildx-action@4cc794f83e4b7488282e879f4469e86246e52ddd
+
       # https://github.com/docker/metadata-action
       - name: "[🟣 Scaleway] Extract metadata (tags, labels) for Docker"
         id: airflow_scheduler_meta_scaleway
@@ -42,6 +44,8 @@ jobs:
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           push: true
           tags: ${{ steps.airflow_scheduler_meta_scaleway.outputs.tags }}
           labels: ${{ steps.airflow_scheduler_meta_scaleway.outputs.labels }}
@@ -57,6 +61,8 @@ jobs:
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           push: true
           tags: ${{ steps.airflow_webserver_meta_scaleway.outputs.tags }}
           labels: ${{ steps.airflow_webserver_meta_scaleway.outputs.labels }}


### PR DESCRIPTION
# Description succincte du problème résolu

Met en place le cache GitHub Actions lors du build et push des images Docker Airflow vers Scaleway.

Job de test de cette branche, avec `workflow_dispatch` : https://github.com/incubateur-ademe/quefairedemesobjets/actions/runs/17069611039/job/48394914650

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
