### PR TITLE
Le déploiement du docker ne connait pas le conatiner_id avant de définir l'environnement

### DIFF
--- a/.github/workflows/_deploy-airflow.yml
+++ b/.github/workflows/_deploy-airflow.yml
@@ -30,7 +30,7 @@ jobs:
     uses: ./.github/workflows/_scaleway_container_deploy.yml
     with:
       environment: ${{ inputs.environment }}
-      container_id: SCALEWAY_AIRFLOW_SCHEDULER_CONTAINER_ID
+      container_key: SCALEWAY_AIRFLOW_SCHEDULER_CONTAINER_ID
 
   deploy_scaleway_webserver:
     secrets: inherit # pragma: allowlist secret`
@@ -38,7 +38,7 @@ jobs:
     uses: ./.github/workflows/_scaleway_container_deploy.yml
     with:
       environment: ${{ inputs.environment }}
-      container_id: SCALEWAY_AIRFLOW_WEBSERVER_CONTAINER_ID
+      container_key: SCALEWAY_AIRFLOW_WEBSERVER_CONTAINER_ID
 
 # Address actions/missing-workflow-permissions rule in
 # code scanning alerts

--- a/.github/workflows/_deploy-airflow.yml
+++ b/.github/workflows/_deploy-airflow.yml
@@ -30,7 +30,7 @@ jobs:
     uses: ./.github/workflows/_scaleway_container_deploy.yml
     with:
       environment: ${{ inputs.environment }}
-      container_id: ${{ vars.SCALEWAY_AIRFLOW_SCHEDULER_CONTAINER_ID }}
+      container_id: SCALEWAY_AIRFLOW_SCHEDULER_CONTAINER_ID
 
   deploy_scaleway_webserver:
     secrets: inherit # pragma: allowlist secret`
@@ -38,7 +38,7 @@ jobs:
     uses: ./.github/workflows/_scaleway_container_deploy.yml
     with:
       environment: ${{ inputs.environment }}
-      container_id: ${{ vars.SCALEWAY_AIRFLOW_WEBSERVER_CONTAINER_ID }}
+      container_id: SCALEWAY_AIRFLOW_WEBSERVER_CONTAINER_ID
 
 # Address actions/missing-workflow-permissions rule in
 # code scanning alerts

--- a/.github/workflows/_scaleway_container_deploy.yml
+++ b/.github/workflows/_scaleway_container_deploy.yml
@@ -4,7 +4,7 @@ on:
       environment:
         required: true
         type: string
-      container_id:
+      container_key:
         type: string
         required: true
 
@@ -23,7 +23,7 @@ jobs:
         "https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/$CONTAINER_ID/deploy"
       env:
         SCALEWAY_DEPLOY_KEY: ${{ secrets.SCALEWAY_DEPLOY_KEY }}
-        CONTAINER_ID: ${{ vars[inputs.container_id] }}
+        CONTAINER_ID: ${{ vars[inputs.container_key] }}
 
 # Address actions/missing-workflow-permissions rule in
 # code scanning alerts

--- a/.github/workflows/_scaleway_container_deploy.yml
+++ b/.github/workflows/_scaleway_container_deploy.yml
@@ -23,7 +23,7 @@ jobs:
         "https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/$CONTAINER_ID/deploy"
       env:
         SCALEWAY_DEPLOY_KEY: ${{ secrets.SCALEWAY_DEPLOY_KEY }}
-        CONTAINER_ID: ${{ inputs.container_id }}
+        CONTAINER_ID: ${{ vars[inputs.container_id] }}
 
 # Address actions/missing-workflow-permissions rule in
 # code scanning alerts


### PR DESCRIPTION
# Description succincte du problème résolu

On essaye d'accéder aux variable de l'environnement alors qu'l n'est pas encore définit, du coup on utilise le nom de la variable à passer au job qui lui connait l'environnement


**🗺️ contexte**: CD - Airflow - Scaleway

**💡 quoi**: Correction du deploiement sur Scaleway

**🎯 pourquoi**: Car ça ne marchait pas

**🤔 comment**: On passe le nom de la variable plutôt que la variable car elle n'est pas encore accessible

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code



