### PR TITLE
Corrige une régression sur les cartes sur mesure sans sous-catégorie définie

### DIFF
--- a/integration_tests/carte/test_use_carte_config.py
+++ b/integration_tests/carte/test_use_carte_config.py
@@ -64,3 +64,26 @@ class TestCarteConfig:
         assert (
             soup.find(attrs={"data-testid": "preview-content"}).text.strip() == "Coucou"
         )
+
+    def test_cyclevia_regresion(self, get_carte_config_response_and_soup):
+        """A regression introduced by adding the CarteConfig as a wagtail block
+        caused the Cyclevia CarteConfig to fail after a search, because it does
+        not use any sous_categorie_objet.
+        This test ensures that the regression is fixed."""
+        carte_config_without_sous_categories = CarteConfigFactory()
+        response, soup = get_carte_config_response_and_soup(
+            carte_config_without_sous_categories.slug,
+            {
+                "adresse": "Auray",
+                "longitude": "-2.990838",
+                "latitude": "47.668099",
+                "carte": "",
+                "r": "55",
+                "bounding_box": "",
+                "direction": "",
+                "action_displayed": "trier",
+                "sous_categorie_objet": "",
+                "sc_id": "",
+            },
+        )
+        assert response.status_code == 200

--- a/qfdmo/views/carte.py
+++ b/qfdmo/views/carte.py
@@ -107,11 +107,14 @@ class CarteConfigView(DetailView, CarteSearchActeursView):
         return super()._grouped_action_from(*args, **kwargs)
 
     def get_sous_categorie_filter(self):
-        # TODO: Revoir nommage + documenter
-        if sous_categorie_filter := self.request.GET.getlist(
-            CarteConfig.SOUS_CATEGORIE_QUERY_PARAM
-        ):
-            return sous_categorie_filter
+        sous_categories_from_request = list(
+            filter(
+                None, self.request.GET.getlist(CarteConfig.SOUS_CATEGORIE_QUERY_PARAM)
+            )
+        )
+        if sous_categories_from_request:
+            return sous_categories_from_request
+
         return self.get_object().sous_categorie_objet.all().values_list("id", flat=True)
 
     def _compile_acteurs_queryset(self, *args, **kwargs):


### PR DESCRIPTION
# Description succincte du problème résolu


**🗺️ contexte**: Carte sur mesure

**💡 quoi**: Corrige une régression sur les carte cyclevia qui cause une erreur 500 lors d'une recherche, car la carte sur mesure utilisée n'utilise aucune sous catégorie

**🎯 pourquoi**: erreur en prod 

**🤔 comment**: 

- on filtre les valeurs qui sont évaluées à `False` dans ce qu'on récupère depuis la requête 

## Exemple résultats / UI / Data

Voir tests d'intégration 

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
