### PR TITLE
Ajout du backlink sur les iframes de l'assistant

### DIFF
--- a/static/to_compile/embed/assistant.ts
+++ b/static/to_compile/embed/assistant.ts
@@ -6,6 +6,19 @@ const slug = script?.dataset?.objet
 const epci = script?.dataset?.epci
 const origin = new URL(script?.getAttribute("src")).origin
 
+function generateBackLink(iframe: HTMLIFrameElement) {
+  const backlinkTag = document.createElement("div")
+  backlinkTag.setAttribute(
+    "style",
+    "font-size: 0.9rem; text-align: center; padding-top: 0.5rem;",
+  )
+  const assistantUrl = "https://google.fr"
+  backlinkTag.innerHTML = `
+    Avant de jeter votre objet, demandez-lui !
+    <a href="${assistantUrl}" target="_blank" rel="noreferrer" title="Ouvrir l'assistant au tri dans une nouvelle fenêtre">L'assistant au tri de l'ADEME</a> vous aide à choisir entre recyclage, réemploi ou mise à la poubelle en dernier recours.`
+  iframe.insertAdjacentElement("afterend", backlinkTag)
+}
+
 function initScript() {
   const parts = [origin]
   const iframeResizerOptions = { license: "GPLv3" }
@@ -45,6 +58,7 @@ function initScript() {
   }
 
   script.parentNode?.insertBefore(iframe, script)
+  generateBackLink(iframe)
   iframe.onload = () => {
     iframeResize(iframeResizerOptions, iframe)
   }


### PR DESCRIPTION
# Description succincte du problème résolu

Cf https://www.notion.so/accelerateur-transition-ecologique-ademe/SEO-Ajouter-un-backlink-au-niveau-des-iFrames-2326523d57d780d09411e91b9eb60c8f?source=copy_link


**🗺️ contexte**: SEO

**💡 quoi**: Ajout d'un backlink sur les iframes

**🎯 pourquoi**: Pour améliorer le SEO des intégrations par iframe

**🤔 comment**: 
- à la génération de l'iframe, on ajoute un backlink en dessous de l'iframe
- le contenu doit etre contribuable de manière centralisée

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
