### PR TITLE
Permettre au lien de partage de ne pas fonctionner lors de la prévisualisation d'une page

### DIFF
--- a/core/templatetags/share_tags.py
+++ b/core/templatetags/share_tags.py
@@ -14,7 +14,7 @@ def get_sharer_content(request, object, social_network=None):
     Once jinja will be removed from the project, this can be merged in
     share_url function below
     """
-    if not request:
+    if not request or not request.resolver_match:
         return {}
     carte = request.resolver_match.view_name in ["qfdmo:carte", "qfdmo:carte_custom"]
 


### PR DESCRIPTION

# Description succincte du problème résolu


**🗺️ contexte**: Wagtail / Produits 

**💡 quoi**: Bug de la prévisualisation d'une page

**🎯 pourquoi**: Rendre plus flexible la gestion des erreurs lors qu'une partie du contexte est manquante lors du templating

**🤔 comment**: 

- On ne rend le `sharer` que lorsque la requête dispose d'une vue
- Ce n'est pas le cas lors de la prévisualisation, le `sharer` va donc s'afficher mais son contexte sera vide. 
- Ce n'est pas gênant pour la phase de tests

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
