### PR TITLE
Les données des révisions sont prioritaires pour choisir les données du parent

### DIFF
--- a/dags/cluster/tasks/business_logic/cluster_acteurs_parents_choose_data.py
+++ b/dags/cluster/tasks/business_logic/cluster_acteurs_parents_choose_data.py
@@ -109,9 +109,13 @@ def cluster_acteurs_parents_choose_data(
                 else float("inf")
             )
 
-        # Acteurs to consider: first revisions, then base, but not from excluded sources
-        acteurs = list(acteurs_revision) + list(acteurs_base)
-        acteurs.sort(key=source_priority)
+        # Acteurs to consider: first revisions, then base
+        acteurs_revision_list = list(acteurs_revision)
+        acteurs_revision_list.sort(key=source_priority)
+        acteurs_base_list = list(acteurs_base)
+        acteurs_base_list.sort(key=source_priority)
+        acteurs = acteurs_revision_list + acteurs_base_list
+
         # On parent creation, we don't want to keep empty data
         if not parent:
             keep_empty = False

--- a/dags/cluster/tasks/business_logic/cluster_acteurs_parents_choose_data.py
+++ b/dags/cluster/tasks/business_logic/cluster_acteurs_parents_choose_data.py
@@ -109,10 +109,31 @@ def cluster_acteurs_parents_choose_data(
                 else float("inf")
             )
 
+        def set_revision_source(
+            acteurs_base: list[Acteur], acteurs_revision: list[RevisionActeur]
+        ) -> list[RevisionActeur]:
+            source_by_acteur_base = {
+                acteur.identifiant_unique: acteur.source for acteur in acteurs_base
+            }
+            # set source_id for acteur_revision from source_by_acteur_base
+            # if not already set
+            for acteur_revision in acteurs_revision:
+                if (
+                    acteur_revision.source is None
+                    and acteur_revision.identifiant_unique in source_by_acteur_base
+                ):
+                    acteur_revision.source = source_by_acteur_base[
+                        acteur_revision.identifiant_unique
+                    ]
+            return acteurs_revision
+
         # Acteurs to consider: first revisions, then base
         acteurs_revision_list = list(acteurs_revision)
-        acteurs_revision_list.sort(key=source_priority)
         acteurs_base_list = list(acteurs_base)
+        acteurs_revision_list = set_revision_source(
+            acteurs_base_list, acteurs_revision_list
+        )
+        acteurs_revision_list.sort(key=source_priority)
         acteurs_base_list.sort(key=source_priority)
         acteurs = acteurs_revision_list + acteurs_base_list
 

--- a/dags/tests/cluster/tasks/business_logic/test_cluster_acteurs_read_children.py
+++ b/dags/tests/cluster/tasks/business_logic/test_cluster_acteurs_read_children.py
@@ -33,5 +33,5 @@ class TestClusterActeursSelectionChildren:
         parent_ids = [p1.identifiant_unique, p2.identifiant_unique]
         fields_to_include = ["nom", "parent", "nombre_enfants", "source_id"]
         df = cluster_acteurs_read_children(parent_ids, fields_to_include)
-        assert df["nom"].tolist() == ["Enfant p1 a", "Enfant p2 a", "Enfant p2 b"]
+        assert set(df["nom"].tolist()) == {"Enfant p1 a", "Enfant p2 a", "Enfant p2 b"}
         assert df.columns.tolist() == fields_to_include


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [[Clustering] Les parents devraient être enrichis avec les données (fraiches) de DisplayedActeurs pas de la table Importé](https://www.notion.so/accelerateur-transition-ecologique-ademe/Clustering-Les-parents-devraient-tre-enrichis-avec-les-donn-es-fraiches-de-DisplayedActeurs-pas--1fb6523d57d780afbe39f832c644e51e?source=copy_link)

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Airflow Cluster

**💡 quoi**: pb de priorité des sources sélectionnées

Plus d'info sur le ticket notion

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [x] s'assurer que le champ source_id est dispo au niveau des revisions

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
