### PR TITLE
Résolution de l'affichage du detail exact match quand il n'y a qu'un champ

### DIFF
--- a/dags/cluster/tasks/business_logic/cluster_acteurs_suggestions/context.py
+++ b/dags/cluster/tasks/business_logic/cluster_acteurs_suggestions/context.py
@@ -58,7 +58,9 @@ def suggestion_context_generate(
     cols = ["identifiant_unique"] + cluster_fields_fuzzy
     context = {}
     context["cluster_id"] = cluster_id
-    context["exact_match"] = dict(zip(cluster_fields_exact, groups[0]))  # type: ignore
+    # Make sure groups[0] is always a tuple, even with a single field
+    group_val = groups[0] if isinstance(groups[0], tuple) else (groups[0],)
+    context["exact_match"] = dict(zip(cluster_fields_exact, group_val))  # type: ignore
     context["fuzzy_details"] = df_cluster[cols].to_dict(orient="records")
 
     return context


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [[Suggestions] Le template pour Clustering n’affiche plus correctement le code postal](https://www.notion.so/accelerateur-transition-ecologique-ademe/Suggestions-Le-template-pour-Clustering-n-affiche-plus-correctement-le-code-postal-2376523d57d7809e9ba7f953ad0ced35?source=copy_link)

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Clustering


**💡 quoi**:  le code postal ne n'affiche pas bien

<img width="1189" height="532" alt="image" src="https://github.com/user-attachments/assets/c0a07001-4c73-4182-8ef0-4d2308931fe8" />

**🎯 pourquoi**: pb de tuble vs string

**🤔 comment**: forcer le type tuple quand 1 seule entrée

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
