### PR TITLE
Ajouter un id sur l'iframe de l'assistant pour éviter des conflits avec iframe resizer

### DIFF
--- a/static/to_compile/embed/assistant.ts
+++ b/static/to_compile/embed/assistant.ts
@@ -1,5 +1,6 @@
 import iframeResize from "@iframe-resizer/parent"
 import { URL_PARAM_NAME_FOR_IFRAME_SCRIPT_MODE } from "../js/helpers"
+import { iframeResizer } from "@iframe-resizer/child"
 
 const script = document.currentScript as HTMLScriptElement
 const slug = script?.dataset?.objet
@@ -12,8 +13,10 @@ if (process.env.BASE_URL) {
 
 function initScript() {
   const parts = [origin]
-  const iframeResizerOptions = { license: "GPLv3" }
-
+  const iframeResizerOptions: iframeResizer.IFramePageOptions = {
+    license: "GPLv3",
+    id: "quefairedemesdechets-assistant",
+  }
   if (slug) {
     parts.push("dechet", slug)
   }
@@ -28,7 +31,6 @@ function initScript() {
   const src = `${parts.join("/")}?${searchParams.toString()}`
   const iframe = document.createElement("iframe")
   const iframeAttributes = {
-    id: "quefairedemesdechets-assistant",
     src,
     style: "border: none; width: 100%; display: block; margin: 0 auto;",
     allowfullscreen: true,

--- a/static/to_compile/embed/assistant.ts
+++ b/static/to_compile/embed/assistant.ts
@@ -28,6 +28,7 @@ function initScript() {
   const src = `${parts.join("/")}?${searchParams.toString()}`
   const iframe = document.createElement("iframe")
   const iframeAttributes = {
+    id: "quefairedemesdechets-assistant",
     src,
     style: "border: none; width: 100%; display: block; margin: 0 auto;",
     allowfullscreen: true,

--- a/static/to_compile/js/iframe_functions.ts
+++ b/static/to_compile/js/iframe_functions.ts
@@ -52,7 +52,9 @@ export function getIframeAttributesAndExtra(
   const BASE_URL = new URL(scriptTag.getAttribute("src")!).origin
   const urlParams = new URLSearchParams()
 
-  let iframeExtraAttributes: { [Property in keyof HTMLScriptElement]?: unknown } = {}
+  let iframeExtraAttributes: { [Property in keyof HTMLScriptElement]?: unknown } = {
+    id: `quefairedemesdechets-${baseRoute}`,
+  }
 
   for (const param in scriptTag.dataset) {
     if (param == "epci_codes" && scriptTag.dataset[param]?.includes(",")) {

--- a/static/to_compile/js/iframe_functions.ts
+++ b/static/to_compile/js/iframe_functions.ts
@@ -52,9 +52,7 @@ export function getIframeAttributesAndExtra(
   const BASE_URL = new URL(scriptTag.getAttribute("src")!).origin
   const urlParams = new URLSearchParams()
 
-  let iframeExtraAttributes: { [Property in keyof HTMLScriptElement]?: unknown } = {
-    id: `quefairedemesdechets-${baseRoute}`,
-  }
+  let iframeExtraAttributes: { [Property in keyof HTMLScriptElement]?: unknown } = {}
 
   for (const param in scriptTag.dataset) {
     if (param == "epci_codes" && scriptTag.dataset[param]?.includes(",")) {


### PR DESCRIPTION
# Description succincte du problème résolu

https://www.notion.so/accelerateur-transition-ecologique-ademe/Les-iFrames-ne-poss-dent-pas-d-identifiant-ce-qui-emp-che-leur-redimensionnement-21b6523d57d78012b238f26ee33ba028?source=copy_link

**🗺️ contexte**: iframe 

**💡 quoi**: ajout d'un id sur l'iframe de l'assistant pour éviter des conflits avec d'autres iframes

**🎯 pourquoi**: 
- Les iFrame n’ont pas d’ID par défaut, alors que iframe-resizer, dépendance utilisé pour redimensionner automatiquement les iframes en ajoute un par défaut
- Cela peut entrer en conflit si une autre iframe est présente sur la page, et qui n’a pas non plus d’id, et qui utilise également iframe resizer

**🤔 comment**:

- utilisation des options de iframe resizer pour ajouter un `id` à l'initialisation 

## Exemple résultats / UI / Data

<img width="479" height="136" alt="image" src="https://github.com/user-attachments/assets/3affbd15-e6b5-4d35-af37-fdbe3cd2dd6e" />


## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
