### PR TITLE
Corrige les boutons de partage : Plus de None, meilleur alignement sur la home de l'assistant

### DIFF
--- a/core/templatetags/share_tags.py
+++ b/core/templatetags/share_tags.py
@@ -18,9 +18,6 @@ def get_sharer_content(request, object, social_network=None):
         return {}
     carte = request.resolver_match.view_name in ["qfdmo:carte", "qfdmo:carte_custom"]
 
-    if not object:
-        object = ""
-
     url = request.build_absolute_uri()
 
     share_body = ""

--- a/core/templatetags/share_tags.py
+++ b/core/templatetags/share_tags.py
@@ -67,17 +67,18 @@ def get_sharer_content(request, object, social_network=None):
     return template[social_network]
 
 
-def _configure_sharer(context):
+def _configure_sharer(context, object_class):
     shared_object = context.get("object")
     request = context.get("request")
     context["sharer"] = get_sharer_content(request, shared_object)
+    return ""
 
 
 @register.simple_tag(takes_context=True)
 def configure_acteur_sharer(context):
-    _configure_sharer(context)
+    return _configure_sharer(context)
 
 
 @register.simple_tag(takes_context=True)
 def configure_produit_sharer(context):
-    _configure_sharer(context)
+    return _configure_sharer(context)

--- a/core/templatetags/share_tags.py
+++ b/core/templatetags/share_tags.py
@@ -67,7 +67,7 @@ def get_sharer_content(request, object, social_network=None):
     return template[social_network]
 
 
-def _configure_sharer(context, object_class):
+def _configure_sharer(context):
     shared_object = context.get("object")
     request = context.get("request")
     context["sharer"] = get_sharer_content(request, shared_object)

--- a/core/templatetags/share_tags.py
+++ b/core/templatetags/share_tags.py
@@ -75,9 +75,9 @@ def _configure_sharer(context):
 
 @register.simple_tag(takes_context=True)
 def configure_acteur_sharer(context):
-    return _configure_sharer(context)
+    _configure_sharer(context)
 
 
 @register.simple_tag(takes_context=True)
 def configure_produit_sharer(context):
-    return _configure_sharer
+    _configure_sharer(context)

--- a/core/templatetags/share_tags.py
+++ b/core/templatetags/share_tags.py
@@ -18,6 +18,9 @@ def get_sharer_content(request, object, social_network=None):
         return {}
     carte = request.resolver_match.view_name in ["qfdmo:carte", "qfdmo:carte_custom"]
 
+    if not object:
+        object = ""
+
     url = request.build_absolute_uri()
 
     share_body = ""
@@ -64,21 +67,17 @@ def get_sharer_content(request, object, social_network=None):
     return template[social_network]
 
 
+def _configure_sharer(context):
+    shared_object = context.get("object")
+    request = context.get("request")
+    context["sharer"] = get_sharer_content(request, shared_object)
+
+
 @register.simple_tag(takes_context=True)
 def configure_acteur_sharer(context):
-    try:
-        object = context.get("object")
-    except AttributeError:
-        object = None
-    request = context.get("request")
-    context["sharer"] = get_sharer_content(request, object)
+    return _configure_sharer(context)
 
 
 @register.simple_tag(takes_context=True)
 def configure_produit_sharer(context):
-    try:
-        object = context.get("object").produit
-    except AttributeError:
-        object = None
-    request = context.get("request")
-    context["sharer"] = get_sharer_content(request, object)
+    return _configure_sharer

--- a/core/templatetags/share_tags.py
+++ b/core/templatetags/share_tags.py
@@ -68,7 +68,7 @@ def get_sharer_content(request, object, social_network=None):
 
 
 def _configure_sharer(context):
-    shared_object = context.get("object")
+    shared_object = context.get("object", "")
     request = context.get("request")
     context["sharer"] = get_sharer_content(request, shared_object)
     return ""

--- a/integration_tests/assistant/home.py
+++ b/integration_tests/assistant/home.py
@@ -53,6 +53,11 @@ class TestHomepage:
         )
         assert soup.css.select("[data-testid=patchwork-icon]")[0]
 
+    def test_none_in_modal(self, get_response):
+        response, soup = get_response()
+        modal = soup.find(id="fr-modal-partager-le-site")
+        assert "None" not in modal.get_text()
+
     def test_suggestions(self, get_response, tmp_path):
         produit = ProduitFactory(nom="Coucou le produit")
         synonyme = SynonymeFactory(produit=produit, nom="Youpi le synonyme")

--- a/integration_tests/core/test_sharer.py
+++ b/integration_tests/core/test_sharer.py
@@ -5,7 +5,7 @@
 
 import pytest
 from django.test import RequestFactory
-from django.urls import resolve, reverse
+from django.urls import resolve
 
 from core.templatetags.share_tags import get_sharer_content
 from unit_tests.qfdmd.qfdmod_factory import SynonymeFactory
@@ -39,13 +39,6 @@ class TestSharer:
                 "url": "mailto:?subject=D%C3%A9couvrez%20le%20site%20de%20l%27ADEME%20%E2%80%9CQue%20faire%20de%20mes%20objets%20%26%20d%C3%A9chets%E2%80%9D&body=Bonjour%2C%0A%20Vous%20souhaitez%20encourager%20au%20tri%20et%20la%20consommation%20responsable%2C%20le%20site%20de%20l%E2%80%99ADEME%20Que%20faire%20de%20mes%20objets%20%26%20d%C3%A9chets%20accompagne%20les%20citoyens%20gr%C3%A2ce%20%C3%A0%20des%20bonnes%20pratiques%20et%20adresses%20pr%C3%A8s%20de%20chez%20eux%2C%20pour%20%C3%A9viter%20l%27achat%20neuf%20et%20r%C3%A9duire%20les%20d%C3%A9chets.%0AD%C3%A9couvrez%20le%20ici%20%3A%20http%3A//testserver/dechet/nom-du-synonyme/",
             },
         }
-
-    def test_sharer_without_object(self):
-        url = reverse("qfdmd:home")
-        request = RequestFactory().get(url)
-        request.resolver_match = resolve(url)
-        sharer = get_sharer_content(request, None)
-        assert "None" not in str(sharer)
 
     def test_sharer(self):
         displayed_acteur = DisplayedActeurFactory(nom="Coucou", uuid="un-coucou-unique")

--- a/integration_tests/core/test_sharer.py
+++ b/integration_tests/core/test_sharer.py
@@ -5,7 +5,7 @@
 
 import pytest
 from django.test import RequestFactory
-from django.urls import resolve
+from django.urls import resolve, reverse
 
 from core.templatetags.share_tags import get_sharer_content
 from unit_tests.qfdmd.qfdmod_factory import SynonymeFactory
@@ -39,6 +39,13 @@ class TestSharer:
                 "url": "mailto:?subject=D%C3%A9couvrez%20le%20site%20de%20l%27ADEME%20%E2%80%9CQue%20faire%20de%20mes%20objets%20%26%20d%C3%A9chets%E2%80%9D&body=Bonjour%2C%0A%20Vous%20souhaitez%20encourager%20au%20tri%20et%20la%20consommation%20responsable%2C%20le%20site%20de%20l%E2%80%99ADEME%20Que%20faire%20de%20mes%20objets%20%26%20d%C3%A9chets%20accompagne%20les%20citoyens%20gr%C3%A2ce%20%C3%A0%20des%20bonnes%20pratiques%20et%20adresses%20pr%C3%A8s%20de%20chez%20eux%2C%20pour%20%C3%A9viter%20l%27achat%20neuf%20et%20r%C3%A9duire%20les%20d%C3%A9chets.%0AD%C3%A9couvrez%20le%20ici%20%3A%20http%3A//testserver/dechet/nom-du-synonyme/",
             },
         }
+
+    def test_sharer_without_object(self):
+        url = reverse("qfdmd:home")
+        request = RequestFactory().get(url)
+        request.resolver_match = resolve(url)
+        sharer = get_sharer_content(request, None)
+        assert "None" not in str(sharer)
 
     def test_sharer(self):
         displayed_acteur = DisplayedActeurFactory(nom="Coucou", uuid="un-coucou-unique")

--- a/templates/modals/base.html
+++ b/templates/modals/base.html
@@ -1,6 +1,6 @@
 {% block modal_wrapper_for_id %}
 <button
-    class="fr-btn {{ button_extra_classes }}"
+    class="fr-btn {{ button_extra_classes }} qf-whitespace-nowrap"
     data-fr-opened="false"
     aria-controls="fr-modal-{{ id }}"
     aria-labelledby="sidebar-action-{{ id }}"


### PR DESCRIPTION
# Description succincte du problème résolu

https://www.notion.so/accelerateur-transition-ecologique-ademe/AST-2-Mobile-Les-boutons-partager-et-int-grer-doivent-tre-l-un-en-dessous-de-l-autre-libell-s-lo-2256523d57d78039a241d38b3e77db86?source=copy_link

**🗺️ contexte**: Régressions sur le partage

**💡 quoi**: on affiche un `None` dans le template

**🎯 pourquoi**: en basculant sur de jinja à DTL il y a eu un raté

**🤔 comment**:

- on retourne une string vide dans les templates tags plutot que none. C'est une convention pas forcément écrite mais souvent retrouvée dans les templates tags built in de django 

## Exemple résultats / UI / Data
<img width="608" height="4194" alt="Capture d’écran 2025-09-12 à 12 32 10-fullpage" src="https://github.com/user-attachments/assets/55160605-36d2-4234-97ce-2fb61d16c69c" />
<img width="917" height="420" alt="image" src="https://github.com/user-attachments/assets/63e66602-799b-472e-b0cf-204824d8b578" />



## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
