### PR TITLE
L'import s3 est cassé depuis l'intégration des service à domicile

### DIFF
--- a/data/models/suggestion.py
+++ b/data/models/suggestion.py
@@ -283,28 +283,35 @@ class Suggestion(models.Model):
     # FIXME: this acteur management will be reviewed with PYDANTIC classes which will
     # be used to handle all specificities of self.suggestions
     def _create_acteur_linked_objects(self, acteur):
-        for proposition_service_code in self.suggestion["proposition_service_codes"]:
-            proposition_service = PropositionService.objects.create(
-                action=Action.objects.get(code=proposition_service_code["action"]),
-                acteur=acteur,
-            )
-            for sous_categorie_code in proposition_service_code["sous_categories"]:
-                proposition_service.sous_categories.add(
-                    SousCategorieObjet.objects.get(code=sous_categorie_code)
+        if "proposition_service_codes" in self.suggestion:
+            for proposition_service_code in self.suggestion[
+                "proposition_service_codes"
+            ]:
+                proposition_service = PropositionService.objects.create(
+                    action=Action.objects.get(code=proposition_service_code["action"]),
+                    acteur=acteur,
                 )
-        for perimetre_adomicile_code in self.suggestion["perimetre_adomicile_codes"]:
-            PerimetreADomicile.objects.create(
-                type=perimetre_adomicile_code["type"],
-                valeur=perimetre_adomicile_code["valeur"],
-                acteur=acteur,
-            )
-        for label_code in self.suggestion["label_codes"]:
-            label = LabelQualite.objects.get(code=label_code)
-            acteur.labels.add(label.id)
-
-        for acteurservice_code in self.suggestion["acteur_service_codes"]:
-            acteur_service = ActeurService.objects.get(code=acteurservice_code)
-            acteur.acteur_services.add(acteur_service.id)
+                for sous_categorie_code in proposition_service_code["sous_categories"]:
+                    proposition_service.sous_categories.add(
+                        SousCategorieObjet.objects.get(code=sous_categorie_code)
+                    )
+        if "perimetre_adomicile_codes" in self.suggestion:
+            for perimetre_adomicile_code in self.suggestion[
+                "perimetre_adomicile_codes"
+            ]:
+                PerimetreADomicile.objects.create(
+                    type=perimetre_adomicile_code["type"],
+                    valeur=perimetre_adomicile_code["valeur"],
+                    acteur=acteur,
+                )
+        if "label_codes" in self.suggestion:
+            for label_code in self.suggestion["label_codes"]:
+                label = LabelQualite.objects.get(code=label_code)
+                acteur.labels.add(label.id)
+        if "acteur_service_codes" in self.suggestion:
+            for acteurservice_code in self.suggestion["acteur_service_codes"]:
+                acteur_service = ActeurService.objects.get(code=acteurservice_code)
+                acteur.acteur_services.add(acteur_service.id)
 
     # FIXME: this acteur management will be reviewed with PYDANTIC classes which will
     # be used to handle all specificities of self.suggestions

--- a/unit_tests/qfdmd/test_synonyme.py
+++ b/unit_tests/qfdmd/test_synonyme.py
@@ -1,6 +1,6 @@
 import pytest
 
-from unit_tests.qfdmd.qfdmod_factory import SynonymeFactory
+from unit_tests.qfdmd.qfdmod_factory import ProduitFactory, SynonymeFactory
 
 
 class TestSynonyme:
@@ -12,8 +12,9 @@ class TestSynonyme:
 
     @pytest.mark.django_db
     def test_slug_max_length(self):
-        synonyme255 = SynonymeFactory(nom="X" * 255)
+        produit = ProduitFactory(nom="Produit")
+        synonyme255 = SynonymeFactory(nom="X" * 255, produit=produit)
         assert synonyme255.slug == "x" * 255
 
-        synonyme256 = SynonymeFactory(nom="Y" * 256)
+        synonyme256 = SynonymeFactory(nom="Y" * 256, produit=produit)
         assert synonyme256.slug == "y" * 255


### PR DESCRIPTION
# Description succincte du problème résolu

Mattermost @chrischarousset  : [ah zut, nouvelle erreur](https://mattermost.incubateur.net/betagouv/pl/wejpbxfuk7ybufu1uxga6io6sc)

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Airflow Source S3

**💡 quoi**: tombe en erreur quand la colonne perimetre_adomicile_codes n'existe pas

**🎯 pourquoi**: On ne teste pas la présence de la colonne avant de la traitée

**🤔 comment**: 

- Vérifier que les clés `_codes` existent avant de les traiter
- correction d'un test qui tombait en erreur aléatoirement

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
