### PR TITLE
CD : déploiement de Airflow sur Clever en prod uniquement

### DIFF
--- a/.github/workflows/_deploy-airflow.yml
+++ b/.github/workflows/_deploy-airflow.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   deploy_airflow-webserver:
+    if: ${{ inputs.environment == 'prod' }}
     name: 🔄 Airflow webserver
     uses: ./.github/workflows/_deploy-on-clever-cloud.yml
     secrets: inherit # pragma: allowlist secret`
@@ -16,6 +17,7 @@ jobs:
       app_name_key: AIRFLOW_SCHEDULER_CLEVERCLOUD_APP_NAME
 
   deploy_airflow-scheduler:
+    if: ${{ inputs.environment == 'prod' }}
     name: ⏳ Airflow scheduler
     uses: ./.github/workflows/_deploy-on-clever-cloud.yml
     secrets: inherit # pragma: allowlist secret`


### PR DESCRIPTION
# Description succincte du problème résolu

Suite au déploiement des containers Airflow sur Scaleway en preprod puis prod, désactive le déploiement d'Airflow sur Clever Cloud en `preprod`. Seule la `prod` est conservée pour le moment, avant suppression et passage à Scaleway.


## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->