### PR TITLE
Supprimer le h1 des modales + lien contactez-nous

### DIFF
--- a/templates/components/header/header_menu.html
+++ b/templates/components/header/header_menu.html
@@ -22,16 +22,6 @@
               </a>
             </li>
             {% endfor %}
-            <li class="fr-nav__item">
-              <button
-                  class="fr-nav__link"
-                  data-fr-opened="false"
-                  aria-controls="fr-modal-{{ contact_modal_id }}"
-                  aria-labelledby="sidebar-action-{{ contact_modal_id }}"
-              >
-                Contactez-nous
-              </button>
-            </li>
           </ul>
         </nav>
       </div>

--- a/templates/modals/base.html
+++ b/templates/modals/base.html
@@ -22,11 +22,11 @@
                         <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-{{ id }}">Fermer</button>
                     </div>
                     <div class="fr-modal__content">
-                        <h1 id="fr-modal-title-{{ id }}" class=" fr-modal__title">
+                        <h2 id="fr-modal-title-{{ id }}" class=" fr-modal__title">
                             {% block modal_title %}
                             titre de la modale
                             {% endblock modal_title %}
-                        </h1>
+                        </h2>
                         {% block modal_content %}
                         <p>lorem ipsum dolor sit amet, consectetur adipiscing elit. maecenas varius tortor nibh, sit amet tempor nibh finibus et. aenean eu enim justo. vestibulum aliquam hendrerit molestie. mauris malesuada nisi sit amet augue accumsan tincidunt. maecenas tincidunt, velit ac porttitor pulvinar, tortor eros facilisis libero, vitae commodo nunc quam et ligula. ut nec ipsum sapien. interdum et malesuada fames ac ante ipsum primis in faucibus. integer id nisi nec nulla luctus lacinia non eu turpis. etiam in ex imperdiet justo tincidunt egestas. ut porttitor urna ac augue cursus tincidunt sit amet sed orci.</p>
                         {% endblock modal_content %}

--- a/templates/qfdmd/base.html
+++ b/templates/qfdmd/base.html
@@ -81,35 +81,6 @@
             {% block main %}
             {% endblock main %}
         </main>
-        <dialog
-            aria-labelledby="fr-modal-title-{{ contact_modal_id }}"
-            aria-modal="true"
-            role="dialog"
-            id="fr-modal-{{ contact_modal_id }}"
-            class="fr-modal z-50 qf-text-left"
-        >
-            <div class="fr-container fr-container--fluid fr-container-md">
-                <div class="fr-grid-row fr-grid-row--center">
-                    <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
-                        <div class="fr-modal__body">
-                            <div class="fr-modal__header">
-                                <button class="fr-btn--close fr-btn" title="fermer la fenêtre modale" aria-controls="fr-modal-{{ contact_modal_id }}">fermer</button>
-                            </div>
-                            <div class="fr-modal__content">
-                                <h1 id="fr-modal-title-{{ contact_modal_id }}" class=" fr-modal__title">
-                                  Nous contacter
-                                </h1>
-                                <turbo-frame id="contact-form"
-                                  src="{% url 'qfdmd:nous-contacter' %}"
-                                  loading="lazy"
-                                >
-                                </turbo-frame>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </dialog>
 
         {% block footer %}
         {% include "components/footer/footer.html" %}


### PR DESCRIPTION
# Description succincte du problème résolu

Cf https://www.notion.so/accelerateur-transition-ecologique-ademe/SEO-Enlever-le-titre-H1-sur-les-modales-int-gration-et-partage-2646523d57d7803a8422e85aca739715?source=copy_link 

**🗺️ contexte**: SEO

**💡 quoi**: Suppression des h1 des modal

**🎯 pourquoi**: pour améliorer le SEO

**🤔 comment**: 
- Remplacement du tag HTML

**En bonus**
- j'ai remarqué qu'on avait toujours le lien contactez-nous, il faudrait le supprimer, c'est une modal donc j'en ai profité ici 

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
