### PR TITLE
Correctif sur le lien de la déclaration d'accessibilité

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -33,7 +33,7 @@ def global_context(request) -> dict:
             "POSTHOG_KEY": settings.ASSISTANT["POSTHOG_KEY"],
             "MATOMO_ID": settings.ASSISTANT["MATOMO_ID"],
         },
-        "carte": {
+        "CARTE": {
             "DECLARATION_ACCESSIBILITE_PAGE_ID": settings.CARTE[
                 "DECLARATION_ACCESSIBILITE_PAGE_ID"
             ],

--- a/qfdmd/templatetags/qfdmd_tags.py
+++ b/qfdmd/templatetags/qfdmd_tags.py
@@ -54,15 +54,13 @@ def canonical_url(context: dict) -> dict:
         return {"url": request.build_absolute_uri(request.path)}
 
 
-@register.simple_tag(takes_context=True)
-def pageurl_by_id(context, page_id):
-    request = context["request"]
-
+@register.filter
+def as_page(page_id):
     if not page_id:
         return ""
 
     try:
-        return Page.objects.get(id=page_id).get_full_url(request)
+        return Page.objects.get(id=page_id)
     except Page.DoesNotExist:
         return ""
 

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -31,7 +31,7 @@
         {% block css_extras %}{% endblock %}
 
         {# Js #}
-        {% matomo carte.MATOMO_ID %}
+        {% matomo CARTE.MATOMO_ID %}
 
         <script src="{% static 'qfdmo.js' %}"></script>
         {% block javascript_extras %}{% endblock %}
@@ -48,7 +48,7 @@
         data-state-address-autocomplete-outlet="[data-controller='address-autocomplete']"
         data-state-map-outlet="[data-controller='map']"
         data-state-search-solution-form-outlet="[data-controller='search-solution-form']"
-        {% posthog_data_attributes carte.POSTHOG_KEY %}
+        {% posthog_data_attributes CARTE.POSTHOG_KEY %}
         data-action="address-autocomplete:change->state#setLocation"
     >
         <main id="solutions" class="qf-h-full qf-overflow-auto qf-overscroll-none qf-scroll-smooth">

--- a/templates/qfdmo/carte/_declaration_accessibilite.html
+++ b/templates/qfdmo/carte/_declaration_accessibilite.html
@@ -1,8 +1,9 @@
 {% load qfdmd_tags %}
-{% page_bu_id carte.DECLARATION_ACCESSIBILITE_PAGE_ID as page %}
+{% with page=CARTE.DECLARATION_ACCESSIBILITE_PAGE_ID|as_page %}
 <a
     {# Ensure the link is not followed using turbo frame but works as a real link #}
     target="_top"
-    href="{{ page.get_full_url }}"
+    href="{{ page.full_url }}"
     class="qf-text-xs fr-link"
 >{{ page.title }}</a>
+{% endwith %}


### PR DESCRIPTION
# Description succincte du problème résolu

Suite à une régression, le lien fonctionnait mal 
J'en ai profité pour simplifier l'approche 

**🗺️ contexte**: Accessibilité

**💡 quoi**: Correction d'un bug

**🎯 pourquoi**: d'une parte la variable globale appelait `lvao` au lieu de `carte`, d'autre part la variable globale `carte` était _recouverte_ par une autre variable dans un template parent, donc l'id n'était pas récupéré en front. 

**🤔 comment**: 

- j'ai renommé `carte` en `CARTE`
- j'ai simplifié le template tag en filter pour ne prendre en paramètre que l'id d'une page et on traite ensuite la page dans le template directement 

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
