### PR TITLE
utilisé stream_directly par défaut lors du clone de AE

### DIFF
--- a/dags/clone/dags/clone_ae_etablissement.py
+++ b/dags/clone/dags/clone_ae_etablissement.py
@@ -52,7 +52,7 @@ with DAG(
             description_md="📥 URL pour télécharger les données",
         ),
         "clone_method": Param(
-            "download_to_disk_first",
+            "stream_directly",
             type="string",
             description_md=r"""📥 **Méthode de création** de la table:
             - `download_to_disk_first`: télécharge/unpack sur disque avant import DB


### PR DESCRIPTION
# Description succincte du problème résolu

Suite aux tests de cluster Airflow sur Scaleway, l'option `stream_directly est plus stable, donc autant la sélectionner par défaut

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Airflow - Clone Annuaire Entreprise

**💡 quoi**: ☝️

**🎯 pourquoi**: ☝️

**🤔 comment**: Changement de la valeur par défaut

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
