### PR TITLE
Désactiver le backlink temporairement

### DIFF
--- a/static/to_compile/embed/helpers.ts
+++ b/static/to_compile/embed/helpers.ts
@@ -9,6 +9,8 @@ export async function generateBackLink(
     return
   }
 
+  // Temporarily disable
+  return
   const backlinkTag = document.createElement("div")
   backlinkTag.setAttribute(
     "style",

--- a/static/to_compile/embed/helpers.ts
+++ b/static/to_compile/embed/helpers.ts
@@ -9,7 +9,7 @@ export async function generateBackLink(
     return
   }
 
-  // Temporarily disable
+  // Temporarily disabled
   return
   const backlinkTag = document.createElement("div")
   backlinkTag.setAttribute(


### PR DESCRIPTION
# Description succincte du problème résolu

Vu en pair : on désactive la fonctionnalité qui génère des erreurs CORS en front