### PR TITLE
Retrouver les labels de la carte et différencier les labels de recherche d'objet

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -39,6 +39,7 @@ def global_context(request) -> dict:
             ],
             "POSTHOG_KEY": settings.CARTE["POSTHOG_KEY"],
             "MATOMO_ID": settings.CARTE["MATOMO_ID"],
+            **constants.CARTE,
         },
     }
 

--- a/qfdmo/forms.py
+++ b/qfdmo/forms.py
@@ -47,12 +47,12 @@ class AddressesForm(forms.Form):
             attrs={
                 "class": "fr-input fr-icon-search-line sm:qf-w-[596px]",
                 "autocomplete": "off",
-                "aria-label": "Indiquer un objet ou déchet - obligatoire",
+                "aria-label": "Indiquer un objet - obligatoire",
             },
             data_controller="ss-cat-object-autocomplete",
         ),
         help_text="pantalon, perceuse, canapé...",
-        label="Indiquer un objet ou déchet ",
+        label="Indiquer un objet ",
         empty_label="",
         required=False,
     )
@@ -265,6 +265,15 @@ def get_epcis_for_carte_form():
 
 
 class CarteForm(AddressesForm):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Override the label and aria-label for the sous_categorie_objet field
+        self.fields["sous_categorie_objet"].label = "Indiquer un objet ou déchet "
+        self.fields["sous_categorie_objet"].widget.attrs[
+            "aria-label"
+        ] = "Indiquer un objet ou déchet"
+
     def load_choices(
         self,
         request: HttpRequest,


### PR DESCRIPTION
# Description succincte du problème résolu

Bug : 

<img width="1444" height="834" alt="CleanShot 2025-09-26 at 09 20 17" src="https://github.com/user-attachments/assets/7313a3e9-1fd5-4d6d-a49c-80964870a1cb" />

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Carte

**💡 quoi**: Les labels à affiché ne sont pas accessible dans le contexte

**🎯 pourquoi**: un petit raté

**🤔 comment**:

- Ajout des labels à afficher dans le context globale
- J'en profite pour différencier les labels des sélecteur d'objets entre la carte et le formulaire

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
