### PR TITLE
Sortir avec un code d'erreur quand le déploiement de docker sur scaleway a planté

### DIFF
--- a/.github/workflows/_scaleway_container_deploy.yml
+++ b/.github/workflows/_scaleway_container_deploy.yml
@@ -28,6 +28,7 @@ jobs:
     - name: Check deployment status
       run: |
         EXPECTED_VALUE="ready"
+        ERROR_VALUE="error"
 
         while true; do
             RESPONSE_VALUE=$(curl -s -X GET -H "X-Auth-Token: $SCALEWAY_DEPLOY_KEY" "https://api.scaleway.com/containers/v1beta1/regions/fr-par/containers/$CONTAINER_ID/" | jq -r '.status')
@@ -37,6 +38,10 @@ jobs:
             if [ "$RESPONSE_VALUE" == "$EXPECTED_VALUE" ]; then
                 echo "🎉 The expected value '$EXPECTED_VALUE' was returned. Exiting."
                 break
+            fi
+            if [ "$RESPONSE_VALUE" == "$ERROR_VALUE" ]; then
+                echo "🚨 Ended with error : ERROR_VALUE."
+                exit 1
             fi
 
             sleep 5


### PR DESCRIPTION
# Description succincte du problème résolu

Quand le statut du déploiement du CaaS Scaleway retourne erreur, on ne sort pas en erreur, du coup, le déploiement continue à tourner dans le vide sur github alors qu'il est en erreur sur Scaleway

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Github action

**💡 quoi**: sortir avec un code d'erreur quand le statut du déploiement est `error`

**🎯 pourquoi**: Sinon ça continue de tourner et ça lant sur le timeout de github action 6 h plus tard

**🤔 comment**: exit 1 quand status = 'error'


## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
