### PR TITLE
Suppression des exports open-source s3 de plus de 30 jours

### DIFF
--- a/dags/acteurs/dags/export_opendata.py
+++ b/dags/acteurs/dags/export_opendata.py
@@ -4,6 +4,9 @@ import pendulum
 from acteurs.tasks.airflow_logic.export_opendata_csv_to_s3_task import (
     export_opendata_csv_to_s3_task,
 )
+from acteurs.tasks.airflow_logic.remove_old_s3_opendata_csv_task import (
+    remove_old_s3_opendata_csv_task,
+)
 from airflow import DAG
 from decouple import config
 from shared.config.schedules import SCHEDULES
@@ -41,4 +44,4 @@ with DAG(
     max_active_runs=1,
 ) as dag:
 
-    export_opendata_csv_to_s3_task(dag=dag)
+    export_opendata_csv_to_s3_task(dag=dag) >> remove_old_s3_opendata_csv_task(dag=dag)

--- a/dags/acteurs/tasks/airflow_logic/remove_old_s3_opendata_csv_task.py
+++ b/dags/acteurs/tasks/airflow_logic/remove_old_s3_opendata_csv_task.py
@@ -1,0 +1,45 @@
+"""Performs crawl checks on the URLs"""
+
+import logging
+
+from acteurs.tasks.airflow_logic.config_management import ExportOpendataConfig
+from acteurs.tasks.business_logic.remove_old_s3_opendata_csv import (
+    remove_old_s3_opendata_csv,
+)
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from utils import logging_utils as log
+
+logger = logging.getLogger(__name__)
+
+TASK_NAME = "remove_old_s3_opendata_csv"
+
+
+def task_info_get():
+    return f"""
+    ============================================================
+    Description de la tâche "{TASK_NAME}"
+    ============================================================
+    💡 quoi: Supprimer les fichiers anciens de S3
+
+    🎯 pourquoi: Nettoyer le bucket S3
+
+    🏗️ comment: Utilisation d'une commande S3 pour supprimer les fichiers
+    vieux de plus de 30 jours
+    """
+
+
+def remove_old_s3_opendata_csv_wrapper(ti, params) -> None:
+    logger.info(task_info_get())
+    export_opendata_config = ExportOpendataConfig(**params)
+
+    log.preview("paramètres du DAG", export_opendata_config)
+    remove_old_s3_opendata_csv(export_opendata_config=export_opendata_config)
+
+
+def remove_old_s3_opendata_csv_task(dag: DAG) -> PythonOperator:
+    return PythonOperator(
+        task_id=TASK_NAME,
+        python_callable=remove_old_s3_opendata_csv_wrapper,
+        dag=dag,
+    )

--- a/dags/acteurs/tasks/business_logic/export_opendata_csv_to_s3.py
+++ b/dags/acteurs/tasks/business_logic/export_opendata_csv_to_s3.py
@@ -2,17 +2,18 @@ import logging
 import os
 import subprocess
 import tempfile
-from datetime import datetime
 from pathlib import Path
 
+import pendulum
 from acteurs.tasks.airflow_logic.config_management import ExportOpendataConfig
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
-
 from utils.django import django_setup_full
 
 logger = logging.getLogger(__name__)
 
 django_setup_full()
+
+MAIN_OPENDATA_FILENAME = "acteurs.csv"
 
 
 def export_opendata_csv_to_s3(export_opendata_config: ExportOpendataConfig):
@@ -20,9 +21,9 @@ def export_opendata_csv_to_s3(export_opendata_config: ExportOpendataConfig):
     from django.conf import settings
 
     with tempfile.TemporaryDirectory() as temp_dir:
-        timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+        timestamp = pendulum.now("UTC").strftime("%Y%m%d%H%M%S")
         filename = f"{timestamp}.csv"
-        permatent_filename = "acteurs.csv"
+        permatent_filename = MAIN_OPENDATA_FILENAME
         tempfile_path = Path(temp_dir, filename)
         with open(tempfile_path, "w") as f:
             subprocess.run(

--- a/dags/acteurs/tasks/business_logic/remove_old_s3_opendata_csv.py
+++ b/dags/acteurs/tasks/business_logic/remove_old_s3_opendata_csv.py
@@ -1,0 +1,29 @@
+import logging
+
+import pendulum
+from acteurs.tasks.airflow_logic.config_management import ExportOpendataConfig
+from acteurs.tasks.business_logic.export_opendata_csv_to_s3 import (
+    MAIN_OPENDATA_FILENAME,
+)
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+
+logger = logging.getLogger(__name__)
+
+
+def remove_old_s3_opendata_csv(export_opendata_config: ExportOpendataConfig):
+    # Récupérer la liste des fichiers existants dans le répertoire
+    s3_hook = S3Hook(aws_conn_id=export_opendata_config.s3_connection_id)
+    older_than_one_month_files = s3_hook.list_keys(
+        bucket_name=export_opendata_config.bucket_name,
+        prefix=export_opendata_config.remote_dir,
+        to_datetime=pendulum.now("UTC").subtract(days=30),
+    )
+    older_than_one_month_files = [
+        f for f in older_than_one_month_files if not f.endswith(MAIN_OPENDATA_FILENAME)
+    ]
+    logger.warning(f"🟠 Suppression des fichiers: {older_than_one_month_files}")
+    if older_than_one_month_files:
+        s3_hook.delete_objects(
+            bucket=export_opendata_config.bucket_name,
+            keys=older_than_one_month_files,
+        )


### PR DESCRIPTION
# Description succincte du problème résolu

Suppression des exports open-source s3 de plus de 30 jours
Pour ne pas stocker trop de données inutilement

**🗺️ contexte**: Airflow - OpenSource

**💡 quoi**: Suppression des exports open-source s3 de plus de 30 jours

**🎯 pourquoi**: Pour ne pas stocker trop de données inutilement

**🤔 comment**: Nouvelle tache du DAG : «Acteurs Open-Data - Exporter les Acteurs en Open-Data»


## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
