### PR TITLE
Ajout de retry lors de l'apply atomic des suggestions

### DIFF
--- a/dags/suggestions/tasks/business_logic/db_apply_suggestion.py
+++ b/dags/suggestions/tasks/business_logic/db_apply_suggestion.py
@@ -1,12 +1,19 @@
 import logging
 
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from sources.config import shared_constants as constants
 from suggestions.tasks.business_logic.db_check_suggestion_to_process import (
     get_suggestions_toprocess,
 )
+from tenacity import retry, retry_if_exception_type, stop_after_attempt
 
 logger = logging.getLogger(__name__)
+
+
+@retry(stop=stop_after_attempt(3), retry=retry_if_exception_type(IntegrityError))
+def suggestion_apply_atomic(suggestion):
+    with transaction.atomic():
+        suggestion.apply()
 
 
 def db_apply_suggestion():
@@ -18,8 +25,7 @@ def db_apply_suggestion():
             suggestion.save()
 
             # Apply suggestion here
-            with transaction.atomic():
-                suggestion.apply()
+            suggestion_apply_atomic(suggestion)
 
             suggestion.statut = constants.SUGGESTION_SUCCES
             suggestion.save()

--- a/data/models/suggestion.py
+++ b/data/models/suggestion.py
@@ -358,12 +358,10 @@ class Suggestion(TimestampedModel):
             code=self.suggestion.get("acteur_type_code")
         )
         acteur.save()
-
         self._remove_acteur_linked_objects(acteur)
         self._create_acteur_linked_objects(acteur)
 
     def apply(self):
-
         # Suggestions leveraging the PYDANTIC SuggestionChange model
         if self.suggestion_cohorte.type_action in [
             SuggestionAction.CLUSTERING,


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [Des suggestions finissent en erreur “duplicate key value violates unique constraint” sans raison](https://www.notion.so/accelerateur-transition-ecologique-ademe/Des-suggestions-finissent-en-erreur-duplicate-key-value-violates-unique-constraint-sans-raison-2736523d57d78030acd2eb8925c89999?source=copy_link)


**🗺️ contexte**: Airflow - Suggestion

**💡 quoi**: Eviter les faux négatif

**🎯 pourquoi**: des erreurs sans raisons valable

**🤔 comment**: Mise en place d'un retry autour de la transaction


## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
