### PR TITLE
ajout du nom de l'EPCI dans les données open-data

### DIFF
--- a/dbt/models/exposure/acteurs/opendata/exposure_opendata_acteur.sql
+++ b/dbt/models/exposure/acteurs/opendata/exposure_opendata_acteur.sql
@@ -96,6 +96,7 @@ SELECT
   da.ville as "ville",
   epci.code_commune_insee as "code_commune",
   epci.code_epci as "code_epci",
+  epci.nom_epci as "nom_epci",
   ST_Y(da.location::geometry) as "latitude",
   ST_X(da.location::geometry) as "longitude",
   al.labels as "qualites_et_labels",

--- a/dbt/models/exposure/acteurs/opendata/schema.yml
+++ b/dbt/models/exposure/acteurs/opendata/schema.yml
@@ -6,6 +6,7 @@ models:
     columns:
       - name: identifiant
         description: "L'identifiant unique de l'acteur"
+        data_type: text
         tests:
           - unique
           - not_null
@@ -13,75 +14,112 @@ models:
           - not_empty_string
       - name: paternite
         description: "La paternité de l'acteur"
+        data_type: text
         tests:
           - not_null
           - dbt_expectations.expect_column_to_exist
           - not_empty_string
+      - name: identifiants_des_contributeurs
+        description: "Les identifiants des contributeurs de l'acteur"
+        data_type: jsonb
+        tests:
+          - dbt_expectations.expect_column_to_exist
       - name: nom
         description: "Le nom de l'acteur"
+        data_type: text
         tests:
           - not_null
           - dbt_expectations.expect_column_to_exist
           - not_empty_string
       - name: nom_commercial
         description: "Le nom commercial de l'acteur"
+        data_type: text
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: siren
         description: "Le SIREN de l'acteur"
+        data_type: text
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: siret
         description: "Le SIRET de l'acteur"
+        data_type: text
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: description
         description: "La description de l'acteur"
+        data_type: text
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: type_dacteur
         description: "Le type d'acteur"
+        data_type: text
         tests:
           - not_null
           - dbt_expectations.expect_column_to_exist
       - name: site_web
         description: "Le site web de l'acteur"
+        data_type: text
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: telephone
         description: "Le téléphone de l'acteur"
+        data_type: text
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: adresse
         description: "L'adresse de l'acteur"
+        data_type: text
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: complement_dadresse
         description: "Le complément d'adresse de l'acteur"
+        data_type: text
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: code_postal
         description: "Le code postal de l'acteur"
+        data_type: text
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: ville
         description: "La ville de l'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
+      - name: code_commune
+        description: "Le code commune de l'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
+      - name: code_epci
+        description: "Le code EPCI de l'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
+      - name: nom_epci
+        description: "Le nom EPCI de l'acteur"
+        data_type: text
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: latitude
         description: "La latitude de l'acteur"
+        data_type: float
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: longitude
         description: "La longitude de l'acteur"
+        data_type: float
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: qualites_et_labels
         description: "Les qualités et labels de l'acteur"
+        data_type: text
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: public_accueilli
         description: "Le public accueilli par l'acteur"
+        data_type: text
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: reprise
@@ -107,30 +145,27 @@ models:
               values: [true, false]
       - name: type_de_services
         description: "Le type de services de l'acteur"
-        tests:
-          - dbt_expectations.expect_column_to_exist
-      - name: propositions_de_services
-        description: "Les propositions de services de l'acteur"
-        tests:
-          - dbt_expectations.expect_column_to_exist
-      - name: date_de_derniere_modification
-        description: "La date de dernière modification de l'acteur"
+        data_type: text
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: consignes_dacces
         description: "Les consignes d'accès de l'acteur"
+        data_type: text
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: horaires_description
         description: "Les horaires de l'acteur sous forme de texte"
+        data_type: text
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: horaires_osm
         description: "Les horaires au format OSM de l'acteur"
+        data_type: text
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: lieu_prestation
         description: "Le lieu de prestation de l'acteur"
+        data_type: text
         tests:
           - dbt_expectations.expect_column_to_exist
       - name: perimetreadomicile
@@ -140,12 +175,74 @@ models:
           - dbt_expectations.expect_column_to_exist
           - dbt_expectations.expect_column_type_to_be:
               type: jsonb
+      - name: propositions_de_services
+        description: "Les propositions de services de l'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
+      - name: emprunter
+        description: "Les sous-categories associées à l'action emprunter de l'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
+      - name: preter
+        description: "Les sous-categories associées à l'action preter de l'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
+      - name: louer
+        description: "Les sous-categories associées à l'action louer de l'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
+      - name: mettreenlocation
+        description: "Les sous-categories associées à l'action mettreenlocation de l'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
+      - name: reparer
+        description: "Les sous-categories associées à l'action reparer de l'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
+      - name: donner
+        description: "Les sous-categories associées à l'action donner de l'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
+      - name: trier
+        description: "Les sous-categories associées à l'action trier de l'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
+      - name: echanger
+        description: "Les sous-categories associées à l'action echanger de l'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
+      - name: revendre
+        description: "Les sous-categories associées à l'action revendre de l'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
+      - name: acheter
+        description: "Les sous-categories associées à l'action acheter de l'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
+      - name: date_de_derniere_modification
+        description: "La date de dernière modification de l'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
     tests:
       - dbt_expectations.expect_table_row_count_to_be_between:
           min_value: 250000
       - dbt_expectations.expect_table_column_count_to_equal:
           value: 34
     config:
+      contract:
+        enforced: true
       tags:
         - exposure
         - opendata

--- a/dbt/models/marts/acteurs/opendata/marts_opendata_acteur_epci.sql
+++ b/dbt/models/marts/acteurs/opendata/marts_opendata_acteur_epci.sql
@@ -8,6 +8,7 @@ WITH acteur_with_best_match AS (
     REPLACE(UPPER(UNACCENT(epci.nom_commune)), ' ARRONDISSEMENT', '') AS upper_epci_nom_commune, -- pour débugger
     laposte.code_commune_insee,
     epci.code_epci,
+    epci.nom_epci,
     SIMILARITY(UPPER(UNACCENT(acteur.ville)), REPLACE(UPPER(UNACCENT(epci.nom_commune)), ' ARRONDISSEMENT', '')) as similarity_score,
     ROW_NUMBER() OVER (
       PARTITION BY acteur.identifiant_unique
@@ -22,6 +23,13 @@ WITH acteur_with_best_match AS (
 )
 
 SELECT
-  *
+  identifiant_unique,
+  code_postal,
+  upper_acteur_ville,
+  upper_epci_nom_commune,
+  code_commune_insee,
+  code_epci,
+  nom_epci,
+  similarity_score
 FROM acteur_with_best_match
 WHERE rank = 1 AND code_postal IS NOT NULL

--- a/dbt/models/marts/acteurs/opendata/schema.yml
+++ b/dbt/models/marts/acteurs/opendata/schema.yml
@@ -413,3 +413,30 @@ models:
         - opendata
         - acteurs
         - perimetreadomicile
+  - name: marts_opendata_acteur_epci
+    description: "Lien entre acteur les données  EPCI"
+    columns:
+      - name: identifiant_unique
+        description: "L'identifiant unique de l'acteur"
+        data_tests:
+          - not_null
+      - name: code_postal
+        description: "Le code postal de l'acteur"
+      - name: upper_acteur_ville
+        description: "La ville de l'acteur en majuscule"
+      - name: upper_epci_nom_commune
+        description: "Le nom de la commune de l'EPCI en majuscule"
+      - name: code_commune_insee
+        description: "Le code commune insee de l'acteur selon son code postal"
+      - name: code_epci
+        description: "Le code EPCI de l'acteur selon son code postal"
+      - name: nom_epci
+        description: "Le nom de l'EPCI de l'acteur selon son code postal"
+      - name: similarity_score
+        description: "Le score de similarité entre la ville de l'acteur et la commune de la DB EPCI"
+    config:
+      tags:
+        - marts
+        - opendata
+        - acteurs
+        - epci


### PR DESCRIPTION
# Description succincte du problème résolu

A destination des personne qui ne connaissentpas leur code EPCI

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Airflow - DBT

**💡 quoi**: ajout du nom de l'EPCI dans les données open-data

**🎯 pourquoi**: simplifier l'usage

**🤔 comment**: ajout du nom de l'EPCI dans les données open-data
On en profite pour faire un controle de robustesse des données open-data

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
