### PR TITLE
le clustering ne fonctionne plus depuis la v6.4.0

### DIFF
--- a/dags/cluster/config/constants.py
+++ b/dags/cluster/config/constants.py
@@ -25,6 +25,8 @@ FIELDS_PARENT_DATA_EXCLUDED = [
     "source_id",
     "statut",
     "perimetre_adomiciles",
+    "suggestion_groupes",
+    "suggestion_unitaires",
     # TODO: we can't set cree_le consistently
     # (see test_data_serialize_reconstruct), thus
     # we exclude it for now (maybe solution is to compute)


### PR DESCRIPTION
# Description succincte du problème résolu

bug fix car j'ai oublié d'exclure les nouveau objets lié (suggestion) lors de la création du parent du cluster

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Airflow - Clustering

**💡 quoi**: Correction du clustering

**🎯 pourquoi**: car il est cassé

**🤔 comment**: ne pas prendre en compte les objets de type suggestion lors de la création des données du parent

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
