### PR TITLE
Commande qui peuple les propositions de service avec une sous-catégorie

### DIFF
--- a/docs/comment-faire/administration/admin_command.md
+++ b/docs/comment-faire/administration/admin_command.md
@@ -21,3 +21,19 @@ ex d'utilisation
 ```sh
 uv run python manage.py correction_acteur_field --field horaires_osm --old_value "Mo off; Tu off; We off; Th off; Fr off; Sa off; Su off" --new_value __empty__ --dry-run
 ```
+
+## Population des propositions de service avec une sous-catégorie
+
+Ajout d'une sous-catégorie aux propositions de service qui en contient une autre
+
+Cette commande est utile quand on ajoute une nouvelle sous-catégorie car on a besoin de plus de détails, on veut alors pouvoir ajouter cette nouvelle sous-catégorie en masse aux propositions de service qui en contient une sous-catégorie spécifique.
+
+```sh
+(uv run) python manage.py populate_propositionservice --new_sous_categorie_code sous_categorie_a_populer --origin_sous_categorie_code sous_categorie_pour_identifier_les_propositions_de_service_a_populer (--dry-run)
+```
+
+Par exemple : on souhaite ajouter la sous-catégorie "Poêle et Casserole" aux propositions de service qui en contiennent la sous-catégorie "Vaisselle"
+
+```sh
+uv run python manage.py populate_propositionservice --new_sous_categorie_code poele_casserole --origin_sous_categorie_code vaisselle --dry-run
+```

--- a/qfdmo/management/commands/enrich_revisionpropositionservice.py
+++ b/qfdmo/management/commands/enrich_revisionpropositionservice.py
@@ -20,7 +20,15 @@ def ps_by_action(propositionservices: QuerySet):
 
 
 class Command(BaseCommand):
-    help = "Suppression des parents qui n'ont pas d'enfants"
+    help = """
+    Correction des propositions de service révisiées d'une source
+    Pour l'ensemble des révision de proposition de service,
+    ajouter les propositions de service présenste dans l'acteur source si celle-ci
+    n'existe pas dans la révision de proposition de service.
+    Cette commande est utile quand une source à ajouté des propositions de service
+    dans l'acteur source et que ces proposition n'ont pas été ajoutées dans
+    la révision de proposition de service.
+    """
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/qfdmo/management/commands/populate_propositionservice.py
+++ b/qfdmo/management/commands/populate_propositionservice.py
@@ -1,0 +1,76 @@
+import argparse
+
+from django.core.management.base import BaseCommand
+
+from qfdmo.models.acteur import PropositionService, RevisionPropositionService
+from qfdmo.models.categorie_objet import SousCategorieObjet
+
+
+class Command(BaseCommand):
+    help = """
+    Ajout d'une sous-catégorie aux propositions de service qui en contient une autre
+    Cette commande est utile quand on ajoute une nouvelle sous-catégorie car on a besoin
+    de plus de détails, on veut alors pouvoir ajouter cette nouvelle sous-catégorie
+    en masse aux propositions de service qui en contient une sous-catégorie spécifique.
+
+    ex : on ajoute la sous-catégorie "Poêle et Casserole" aux propositions de service
+    qui en contiennent la sous-catégorie "Vaisselle"
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            help="Run command without writing changes to the database",
+            action=argparse.BooleanOptionalAction,
+            default=False,
+        )
+        parser.add_argument(
+            "--new_sous_categorie_code",
+            help="code de la nouvelle sous-catégorie à ajouter",
+            type=str,
+            required=True,
+        )
+        parser.add_argument(
+            "--origin_sous_categorie_code",
+            help="""
+            code de la sous-catégorie d'origine, on ajoutera la nouvelle sous-catégorie
+            à toutes les propositions de service qui en contiennent cette sous-catégorie
+            """,
+            type=str,
+            required=True,
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        new_sous_categorie_code = options["new_sous_categorie_code"]
+        origin_sous_categorie_code = options["origin_sous_categorie_code"]
+
+        ps_classes = [PropositionService, RevisionPropositionService]
+        nb_updated = {cls.__name__: 0 for cls in ps_classes}
+
+        new_sous_categorie = SousCategorieObjet.objects.get(
+            code=new_sous_categorie_code
+        )
+        for cls in ps_classes:
+            for ps in (
+                cls.objects.prefetch_related("action")
+                .filter(sous_categories__code=origin_sous_categorie_code)
+                .exclude(sous_categories__code=new_sous_categorie_code)
+            ):
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"{cls.__name__} {dry_run and 'DRY RUN ' or ''}: "
+                        f"Updating {ps.acteur_id} - {ps.action.code}"
+                    )
+                )
+                nb_updated[cls.__name__] += 1
+                if not dry_run:
+                    ps.sous_categories.add(new_sous_categorie)
+
+        for cls in ps_classes:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"{cls.__name__}: Updated {nb_updated[cls.__name__]}"
+                    " propositions de service"
+                )
+            )


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [Migration rétroactive : poêles & casseroles](https://www.notion.so/accelerateur-transition-ecologique-ademe/Migration-r-troactive-po-les-casseroles-28d6523d57d780ef86acd8c4c2d973f0?source=copy_link)

**🗺️ contexte**: Administration

**💡 quoi**: Ajout d'une commande qui peuple les propositions de service avec une sous-catégorie

**🎯 pourquoi**: Cette commande est utile quand on ajoute une nouvelle sous-catégorie car on a besoin de plus de détails, on veut alors pouvoir ajouter cette nouvelle sous-catégorie en masse aux propositions de service qui en contient une sous-catégorie spécifique.

**🤔 comment**: 

- Création d'une commande qui permettra de le rejouer sur d'autre sous-categorie
- Ajout de la doc dans `Commande Django d'administration`

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
