### PR TITLE
clicker sur le objet (après recherche) doit remplacer toute la page

### DIFF
--- a/templates/ui/components/search/_search_result.html
+++ b/templates/ui/components/search/_search_result.html
@@ -1,6 +1,6 @@
 <a
     href="{% block href %}{% url 'qfdmd:synonyme-detail' slug=result.slug %}{% endblock %}"
-    target="_self"
+    data-turbo-frame="_top"
     style="background-image: none;"
     class="
     focus:!no-underline


### PR DESCRIPTION
# Description succincte du problème résolu

Je ne sais pas pourquoi, j'ai un comportement différent en preprod, la page déchet ne s'ffiche pas car il cherche à remplacer la turbo frame quand on clique sur l'objet, or la page destination n'a pas la turbo frame target

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: QFDMD

**💡 quoi**: Cliquer sur un objet affiche l'erreur "missing conntent"

**🎯 pourquoi**: à cause de turbo frame

**🤔 comment**: changement de target

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
