### PR TITLE
Ajout des sous-cat Vaisselle et Poele et casserolle dans le mapping SINOE

### DIFF
--- a/dags/sources/config/db_mapping.json
+++ b/dags/sources/config/db_mapping.json
@@ -376,7 +376,7 @@
       "autres_emballages_menagers"
     ],
     "emballages souillés par une substance dangereuse": "dechets_de_produits_chimiques",
-    "encombrants ménagers divers": "encombrants_menagers_divers",
+    "encombrants ménagers divers": ["encombrants_menagers_divers", "vaisselle", "poele_casserole"],
     "equipements électriques et électroniques hors d'usage": "petit_electromenager",
     "films plastiques": "emballage_plastique",
     "films plastiques emballages ménagers": "emballage_plastique",


### PR DESCRIPTION
# Description succincte du problème résolu

Vi avec @chrischarousset 

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Airflow - source SINOE

**💡 quoi**: Ajout du mapping "embombrant" -> "vaisselle", "poele & casserole"

**🎯 pourquoi**: Car les déchèteries acceptent la vaiselle et les poêle et les casseroles quand elles accepte le tout venant (presque tout le temps)

**🤔 comment**: Ajout dans le mapping


## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
