### PR TITLE
Création de tests e2e avec le MCP de playwright

### DIFF
--- a/e2e_tests/carte_resolution.spec.ts
+++ b/e2e_tests/carte_resolution.spec.ts
@@ -19,7 +19,7 @@ test.describe("🗺️ Check display of Carte according to resolutions", () => {
           width: resolution.width,
           height: resolution.height,
         })
-        await page.goto(`https://quefairedemesdechets.ademe.local/carte`, {
+        await page.goto(`/carte`, {
           waitUntil: "domcontentloaded",
         })
 
@@ -52,7 +52,7 @@ test.describe("🗺️ Check display of Carte according to resolutions", () => {
           width: resolution.width,
           height: resolution.height,
         })
-        await page.goto(`https://quefairedemesdechets.ademe.local/carte`, {
+        await page.goto(`/carte`, {
           waitUntil: "domcontentloaded",
         })
 
@@ -69,7 +69,7 @@ test.describe("🗺️ Check display of Carte according to resolutions", () => {
           width: resolution.width,
           height: resolution.height,
         })
-        await page.goto(`https://quefairedemesdechets.ademe.local/carte`, {
+        await page.goto(`/carte`, {
           waitUntil: "domcontentloaded",
         })
 
@@ -97,7 +97,7 @@ test.describe("🗺️ Check display of Carte according to resolutions", () => {
           width: resolution.width,
           height: resolution.height,
         })
-        await page.goto(`https://quefairedemesdechets.ademe.local/carte`, {
+        await page.goto(`/carte`, {
           waitUntil: "domcontentloaded",
         })
 
@@ -114,7 +114,7 @@ test.describe("🗺️ Check display of Carte according to resolutions", () => {
           width: resolution.width,
           height: resolution.height,
         })
-        await page.goto(`https://quefairedemesdechets.ademe.local/carte`, {
+        await page.goto(`/carte`, {
           waitUntil: "domcontentloaded",
         })
 

--- a/e2e_tests/carte_resolution.spec.ts
+++ b/e2e_tests/carte_resolution.spec.ts
@@ -1,0 +1,126 @@
+import { expect, test } from "@playwright/test"
+
+test.describe("🗺️ Check display of Carte according to resolutions", () => {
+  const smallResolutions = [
+    { width: 350, height: 700 },
+    { width: 800, height: 700 },
+  ]
+  const largeResolutions = [
+    { width: 1024, height: 900 },
+    { width: 1400, height: 900 },
+  ]
+  const RESOLUTIONS = [...smallResolutions, ...largeResolutions]
+  test.describe("Check inputs Carte/Liste", () => {
+    for (const resolution of RESOLUTIONS) {
+      test(`Inputs Carte/Liste à ${resolution.width}x${resolution.height}`, async ({
+        page,
+      }) => {
+        await page.setViewportSize({
+          width: resolution.width,
+          height: resolution.height,
+        })
+        await page.goto(`https://quefairedemesdechets.ademe.local/carte`, {
+          waitUntil: "domcontentloaded",
+        })
+
+        // Vérifier que l'input "Carte" est checked
+        const inputCarte = page.getByRole("radio", { name: "Carte" })
+        await expect(inputCarte).toBeChecked()
+
+        // Vérifier que l'input "Liste" n'est pas checked
+        const inputListe = page.getByRole("radio", { name: "Liste" })
+        await expect(inputListe).not.toBeChecked()
+      })
+    }
+  })
+
+  test.describe("Check logo visibility", () => {
+    const smallResolutions = [
+      { width: 350, height: 700 },
+      { width: 800, height: 700 },
+    ]
+    const largeResolutions = [
+      { width: 1024, height: 900 },
+      { width: 1400, height: 900 },
+    ]
+
+    for (const resolution of smallResolutions) {
+      test(`Logo should not be visible at ${resolution.width}x${resolution.height}`, async ({
+        page,
+      }) => {
+        await page.setViewportSize({
+          width: resolution.width,
+          height: resolution.height,
+        })
+        await page.goto(`https://quefairedemesdechets.ademe.local/carte`, {
+          waitUntil: "domcontentloaded",
+        })
+
+        const logo = page.locator("#logo")
+        await expect(logo).toBeHidden()
+      })
+    }
+
+    for (const resolution of largeResolutions) {
+      test(`Logo should be visible at ${resolution.width}x${resolution.height}`, async ({
+        page,
+      }) => {
+        await page.setViewportSize({
+          width: resolution.width,
+          height: resolution.height,
+        })
+        await page.goto(`https://quefairedemesdechets.ademe.local/carte`, {
+          waitUntil: "domcontentloaded",
+        })
+
+        const logo = page.locator("#logo")
+        await expect(logo).toBeVisible()
+      })
+    }
+  })
+
+  test.describe("Check filter button visibility", () => {
+    const smallResolutions = [
+      { width: 350, height: 700 },
+      { width: 800, height: 700 },
+    ]
+    const largeResolutions = [
+      { width: 1024, height: 900 },
+      { width: 1400, height: 900 },
+    ]
+
+    for (const resolution of smallResolutions) {
+      test(`Filter button should be visible at ${resolution.width}x${resolution.height}`, async ({
+        page,
+      }) => {
+        await page.setViewportSize({
+          width: resolution.width,
+          height: resolution.height,
+        })
+        await page.goto(`https://quefairedemesdechets.ademe.local/carte`, {
+          waitUntil: "domcontentloaded",
+        })
+
+        const filterButton = page.getByTestId("modal-button-carte:filtres")
+        await expect(filterButton).toBeVisible()
+      })
+    }
+
+    for (const resolution of largeResolutions) {
+      test(`Filter button should not be visible at ${resolution.width}x${resolution.height}`, async ({
+        page,
+      }) => {
+        await page.setViewportSize({
+          width: resolution.width,
+          height: resolution.height,
+        })
+        await page.goto(`https://quefairedemesdechets.ademe.local/carte`, {
+          waitUntil: "domcontentloaded",
+        })
+
+        const filterButton = page.getByTestId("modal-button-carte:filtres")
+        await expect(filterButton).toBeHidden()
+      })
+    }
+  })
+})


### PR DESCRIPTION
# Description succincte du problème résolu

Augmentation de la couverture de tests e2e en utilisant le MCP de playwright
C'est un POC, les valeur de résolutions sont arbitraire et mal choisies (voir : https://www.systeme-de-design.gouv.fr/version-courante/fr/fondamentaux/grille-et-points-de-rupture), il y a certainement des data-testid à ajouter et beaucoup plus de tests e2e à faire
On pourrait aussi enprofiter pour organiser mieux les tests e2e qui sont tous à plat et créer une sous doc pour les agent AI concernant les tests e2e

**🗺️ contexte**: Playwright

**💡 quoi**: POC : Ajouter des tests en utilisant le MCP de playwright

**🎯 pourquoi**: éviter les régression

**🤔 comment**:

- installation du MCP de playwright dans cursor (cf. https://www.npmjs.com/package/playwright-mcp)
  dans le fichier ~/.cursor/mcp.json

```json
{
  "mcpServers": {
    "playwright": {
      "command": "npx",
      "args": ["-y", "@executeautomation/playwright-mcp-server"]
    }
  }
}
```

- demande en prompt

```txt
avec playwright, ouvre le navigateur à l'adresse https://quefairedemesdechets.ademe.local/carte  avec les définition d'écran : 350 px x 700px , 800px x 700px, 1024px x 900 px et 1400px x 900px, pour chaque résolution vérifier qu'on a un input avec le label "Carte" qui est "checked" et un input "Liste" qui ne l'est pas
```


## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
