### PR TITLE
Gestion d'une nouvelle DB stats sur le serveur webapp

### DIFF
--- a/infrastructure/environments/preprod/database_sample/terragrunt.hcl
+++ b/infrastructure/environments/preprod/database_sample/terragrunt.hcl
@@ -17,11 +17,11 @@ dependency "database" {
 }
 
 inputs = {
-  webapp_instance_id = dependency.database.outputs.webapp_instance_id
+  instance_id = dependency.database.outputs.webapp_instance_id
 
-  webapp_db_sample_name     = "webapp_sample"
-  webapp_db_sample_username = "[webapp_db_sample_username]"
-  webapp_db_sample_password = "[webapp_db_sample_password]"
+  db_name     = "webapp_sample"
+  db_username = "[webapp_db_sample_username]"
+  db_password = "[webapp_db_sample_password]"
 
   # Path to the create_extensions.sql script
   # From infrastructure/environments/preprod/database_sample/, we go up 4 levels to the root

--- a/infrastructure/environments/root.hcl
+++ b/infrastructure/environments/root.hcl
@@ -12,8 +12,6 @@ terraform {
 }
 
 provider "scaleway" {
-  zone   = "fr-par-1" # Zone de Paris
-  region = "fr-par"   # Région de Paris
 }
 EOF
 }

--- a/infrastructure/modules/database_sample/main.tf
+++ b/infrastructure/modules/database_sample/main.tf
@@ -1,41 +1,41 @@
-data "scaleway_rdb_instance" "webapp" {
-  instance_id = var.webapp_instance_id
+data "scaleway_rdb_instance" "instance" {
+  instance_id = var.instance_id
 }
 
-resource "scaleway_rdb_database" "webapp_sample" {
-  instance_id = var.webapp_instance_id
-  name        = var.webapp_db_sample_name
+resource "scaleway_rdb_database" "addeddb" {
+  instance_id = var.instance_id
+  name        = var.db_name
 }
 
-resource "scaleway_rdb_user" "webapp_sample" {
-  instance_id = var.webapp_instance_id
-  name        = var.webapp_db_sample_username
-  password    = var.webapp_db_sample_password
+resource "scaleway_rdb_user" "addeddb" {
+  instance_id = var.instance_id
+  name        = var.db_username
+  password    = var.db_password
 }
 
-resource "scaleway_rdb_privilege" "webapp_sample_privilege" {
-  instance_id   = var.webapp_instance_id
-  user_name     = var.webapp_db_sample_username
-  database_name = scaleway_rdb_database.webapp_sample.name
+resource "scaleway_rdb_privilege" "addeddb_privilege" {
+  instance_id   = var.instance_id
+  user_name     = var.db_username
+  database_name = scaleway_rdb_database.addeddb.name
   permission    = "all"
 }
 
 resource "null_resource" "create_extensions" {
   depends_on = [
-    scaleway_rdb_database.webapp_sample,
-    scaleway_rdb_user.webapp_sample,
-    scaleway_rdb_privilege.webapp_sample_privilege
+    scaleway_rdb_database.addeddb,
+    scaleway_rdb_user.addeddb,
+    scaleway_rdb_privilege.addeddb_privilege
   ]
 
   provisioner "local-exec" {
     command = <<-EOT
-      psql "postgresql://${var.webapp_db_sample_username}:${var.webapp_db_sample_password}@${data.scaleway_rdb_instance.webapp.load_balancer.0.ip}:${data.scaleway_rdb_instance.webapp.load_balancer.0.port}/${scaleway_rdb_database.webapp_sample.name}?sslmode=require" -f ${var.create_extensions_script_path}
+      psql "postgresql://${var.db_username}:${var.db_password}@${data.scaleway_rdb_instance.instance.load_balancer.0.ip}:${data.scaleway_rdb_instance.instance.load_balancer.0.port}/${scaleway_rdb_database.addeddb.name}?sslmode=require" -f ${var.create_extensions_script_path}
     EOT
   }
 
   triggers = {
-    database_id  = scaleway_rdb_database.webapp_sample.id
-    user_id      = scaleway_rdb_user.webapp_sample.id
-    privilege_id = scaleway_rdb_privilege.webapp_sample_privilege.id
+    database_id  = scaleway_rdb_database.addeddb.id
+    user_id      = scaleway_rdb_user.addeddb.id
+    privilege_id = scaleway_rdb_privilege.addeddb_privilege.id
   }
 }

--- a/infrastructure/modules/database_sample/variables.tf
+++ b/infrastructure/modules/database_sample/variables.tf
@@ -1,21 +1,21 @@
-variable "webapp_instance_id" {
-  description = "ID de l'instance RDB webapp (depuis le module database)"
+variable "instance_id" {
+  description = "ID de l'instance RDB existante"
   type        = string
 }
 
-variable "webapp_db_sample_name" {
-  description = "Nom de la base de données sample pour webapp (optionnel)"
+variable "db_name" {
+  description = "Nom de la base de données à ajouter sur l'instance (optionnel)"
   type        = string
   default     = null
 }
 
-variable "webapp_db_sample_username" {
-  description = "Nom d'utilisateur de la base de données sample webapp"
+variable "db_username" {
+  description = "Nom d'utilisateur de la base de données ajoutée"
   type        = string
 }
 
-variable "webapp_db_sample_password" {
-  description = "Mot de passe de la base de données sample webapp"
+variable "db_password" {
+  description = "Mot de passe de la base de données ajoutée"
   type        = string
   sensitive   = true
 }


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [Nouveaux indicateurs de suivi data](https://www.notion.so/accelerateur-transition-ecologique-ademe/Nouveaux-indicateurs-de-suivi-data-2f66523d57d78024b485d5698f561d90?source=copy_link)

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Airflow - DBT - Stats - infrastructure

**💡 quoi**: Création d'une nouvelle base de données `stats` sur l'instance `webapp`

**🎯 pourquoi**: Pour y copier les stats à conserver, On ne veut pas les perdre, du coup, une fois copiées, elles seront sauvegardé régulièrement

**🤔 comment**: 

- Rendre générique la création de DB sur une instance existante
- Adapter la generation de webapp_sample à ce module plus générique
- Ajouter la génération de la base stats

**🤓 comment tester**: <!-- Descrire les étapes pour tester la fonctionnalité -->


## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
