### PR TITLE
Le cache npm n'est plus effectif car package-lock.json est dans webapp

### DIFF
--- a/.github/actions/setup-frontend/action.yml
+++ b/.github/actions/setup-frontend/action.yml
@@ -28,7 +28,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ inputs.working-directory }}/node_modules
-        key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+        key: node-modules-${{ runner.os }}-${{ hashFiles(format('{0}/package-lock.json', inputs.working-directory)) }}
 
     - name: Install npm dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'

--- a/webapp/static/to_compile/controllers/carte/search_solution_form_controller.ts
+++ b/webapp/static/to_compile/controllers/carte/search_solution_form_controller.ts
@@ -1,5 +1,4 @@
 import { Controller } from "@hotwired/stimulus"
-import * as Turbo from "@hotwired/turbo"
 
 class SearchFormController extends Controller<HTMLFormElement> {
   #selectedOption: string = ""
@@ -168,14 +167,17 @@ class SearchFormController extends Controller<HTMLFormElement> {
     }
   }
 
-  updateBboxInput(event) {
+  updateBboxInput(event: CustomEvent<unknown>) {
     if (this.hasBboxTarget) {
       this.bboxTarget.value = JSON.stringify(event.detail)
     }
   }
 
-  displayDigitalActeur(event) {
-    event.currentTarget.setAttribute("aria-expanded", "true")
+  displayDigitalActeur(event: Event) {
+    const target = event.currentTarget
+    if (target instanceof Element) {
+      target.setAttribute("aria-expanded", "true")
+    }
   }
 
   displayActionList() {

--- a/webapp/static/to_compile/tests/iframe_functions.test.ts
+++ b/webapp/static/to_compile/tests/iframe_functions.test.ts
@@ -2,7 +2,7 @@ import { generateBackLink } from "../embed/helpers"
 import { getIframeAttributesAndExtra } from "../js/iframe_functions"
 
 describe("generateBackLink", () => {
-  let iframeMock
+  let iframeMock: HTMLIFrameElement
 
   beforeEach(() => {
     iframeMock = document.createElement("iframe")
@@ -35,9 +35,11 @@ describe("getIframeAttributesAndExtra function tests", () => {
   let scriptTag: HTMLScriptElement
 
   // Helper function to set dataset attributes
-  const setScriptDataset = (attributes: { [key: string]: string }) => {
+  const setScriptDataset = (attributes: Record<string, string | undefined>) => {
     Object.entries(attributes).forEach(([key, value]) => {
-      scriptTag.dataset[key] = value
+      if (value !== undefined) {
+        scriptTag.dataset[key] = value
+      }
     })
   }
 
@@ -100,9 +102,19 @@ describe("getIframeAttributesAndExtra function tests", () => {
     },
   ])(
     "should generate correct iframe attributes $description",
-    ({ dataset, route, options, expectedSrc }) => {
+    ({
+      dataset,
+      route,
+      options,
+      expectedSrc,
+    }: {
+      dataset: Record<string, string | undefined>
+      route: string
+      options: Record<string, unknown>
+      expectedSrc: string
+    }) => {
       // These are tests...any seems acceptable but we might want to type this at some point.
-      setScriptDataset(dataset as any)
+      setScriptDataset(dataset)
 
       const [iframeAttributes, iframeExtraAttributes] = getIframeAttributesAndExtra(
         scriptTag,

--- a/webapp/tsconfig.json
+++ b/webapp/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "strictNullChecks": true,
+    "types": ["jest", "node"],
     "module": "commonjs",
     "target": "ES6",
     "esModuleInterop": true


### PR DESCRIPTION
# Description succincte du problème résolu

[Mattermost](https://mattermost.incubateur.net/betagouv/pl/jgngrhze53rytxr3yqszz773ie)



**🗺️ contexte**: CI - Cache

**💡 quoi**: On hash un fichier qui a été déplacé

**🎯 pourquoi**: parce qu'on est maintenant organisé par dossier et on a oublié ce cache

**🤔 comment**: Passer le bon fichier au cache

**🤓 comment tester**: Inspecter la CI et l'action `setup frontend environmnet`, regarder que la clé du cache contient un hash


## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
