### PR TITLE
Permettre de faire des clusters sur les latutides et longitudes exactement identiques

### DIFF
--- a/data-platform/dags/cluster/tasks/business_logic/cluster_acteurs_clusters.py
+++ b/data-platform/dags/cluster/tasks/business_logic/cluster_acteurs_clusters.py
@@ -205,7 +205,7 @@ def cluster_acteurs_clusters(
             cols_ids_codes
             + cluster_fields_exact
             + cluster_fields_fuzzy
-            + ["nom", "source_codes"]
+            + ["source_codes"]
         )
     )
     df = df[cols_to_keep]

--- a/data-platform/dbt/macros/table/macro_acteur_sources.sql
+++ b/data-platform/dbt/macros/table/macro_acteur_sources.sql
@@ -15,7 +15,7 @@ parentacteur_labels AS (
         a.source_id AS source_id,
         a.identifiant_externe AS identifiant_externe
     FROM {{ ref(ephemeral_filtered_acteur) }} AS a
-    WHERE a.parent_id is not null
+    WHERE a.parent_id is not null AND a.statut = 'ACTIF'
     GROUP BY a.parent_id, a.source_id, a.identifiant_externe
 ),
 acteur_sources AS (

--- a/webapp/qfdmo/admin/acteur.py
+++ b/webapp/qfdmo/admin/acteur.py
@@ -683,7 +683,25 @@ class RevisionPropositionServiceAdmin(ImportExportMixin, BasePropositionServiceA
 # endregion RevisionPropositionService
 
 
-class FinalActeurAdminMixin(admin.ModelAdmin):
+class FinalActeurAdminMixin(BaseActeurAdmin):
+    list_display = list(BaseActeurAdmin.list_display) + ["uuid"]
+    search_fields = list(BaseActeurAdmin.search_fields) + ["uuid"]
+    change_form_template = "admin/acteur/change_form.html"
+
+    base_fields = [
+        field
+        for field in BaseActeurAdmin.fields
+        if field not in ["identifiant_unique", "source"]
+    ]
+    fields = [
+        "uuid",
+        "identifiant_unique",
+        "sources",
+        *base_fields,
+        "epci",
+        "code_commune_insee",
+    ]
+
     # We need this class to display the map for the location field
     # even if it is readonly
     def get_readonly_fields(self, request, obj=None):
@@ -704,25 +722,9 @@ class DisplayedActeurResource(ActeurResource):
 
 
 class DisplayedActeurAdmin(ExportMixin, FinalActeurAdminMixin, BaseActeurAdmin):
-    list_display = list(BaseActeurAdmin.list_display) + ["uuid"]
-    search_fields = list(BaseActeurAdmin.search_fields) + ["uuid"]
-    change_form_template = "admin/acteur/change_form.html"
     gis_widget = CustomOSMWidget
     # DisplayedActeur has one or many sources, then we need to displayed the sources
     # field instead source field from BaseActeurAdmin
-    base_fields = [
-        field
-        for field in BaseActeurAdmin.fields
-        if field not in ["identifiant_unique", "source"]
-    ]
-    fields = [
-        "uuid",
-        "identifiant_unique",
-        "sources",
-        *base_fields,
-        "epci",
-        "code_commune_insee",
-    ]
 
     inlines = [
         DisplayedPropositionServiceInline,
@@ -755,14 +757,11 @@ class VueActeurAdmin(FinalActeurAdminMixin, BaseActeurAdmin):
     ]
     fields = [
         "est_parent",
-        "uuid",
-        *BaseActeurAdmin.fields,
+        *FinalActeurAdminMixin.fields,
         "parent",
         "revision_existe",
         "est_dans_carte",
         "est_dans_opendata",
-        "epci",
-        "code_commune_insee",
     ]
     autocomplete_fields = ["parent"]
 


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [[Clustering] Ne trouve pas les parents existants et/ou n’arrive plus à clusteriser sur Latitude + Longitude](https://www.notion.so/accelerateur-transition-ecologique-ademe/Clustering-Ne-trouve-pas-les-parents-existants-et-ou-n-arrive-plus-clusteriser-sur-Latitude-Lon-32d6523d57d780ecbfe2ecae96658b71?source=copy_link)

**🗺️ contexte**: Airflow Clustering

**💡 quoi**: Le clustering exacte de latitude + longitude ne fonctionne pas bien

**🎯 pourquoi**: 2 problème identifié

1. impossible de faire un clustering sans avoir le champ nom dans les champs de compaaison exact ou fuzzy, du coup, impossible de faire un cluster lat/long exact sans le nom en fuzzy et donc avec des nom qui ne correspondent pas du tout
2. Les `sources` des VueActeurs incluent les enfants avec un statut non actif, du coup si le parent a un enfant au statut supprimé pour une source donnée, il n'était pas possible de rapprocher ce parent d'un acteur de cette même source

**🤔 comment**: 

1. Ne pas inclure le champs "nom" dnas le dataframe quand ce n'est pas nécessaire
2. associer uniquement les sources des enfants actifs au VueActeur (cohérent avec la collecte de proposition de services)
3. J'en profite pour mutualiser quelques champs entre les admin de DisplayedActeur et VueActeur pour faire apparaitre les sources coté VueActeur

**🤓 comment tester**: 

- Faire tourner le DAG de rafraichissement des acteurs
- Faire tourner le DAG de clustering avec les paramètres suivants

```json
{
    "apply_include_acteur_types_to_parents": true,
    "apply_include_if_all_fields_filled_to_parents": true,
    "apply_include_only_if_regex_matches_nom_to_parents": true,
    "apply_include_sources_to_parents": false,
    "cluster_fields_exact": [
        "latitude",
        "longitude"
    ],
    "cluster_fields_fuzzy": null,
    "cluster_fuzzy_threshold": 0.5,
    "cluster_intra_source_is_allowed": false,
    "dedup_enrich_exclude_sources": null,
    "dedup_enrich_fields": [
        "acteur_type",
        "action_principale",
        "adresse",
        "adresse_complement",
        "code_postal",
        "commentaires",
        "consignes_dacces",
        "description",
        "email",
        "exclusivite_de_reprisereparation",
        "horaires_description",
        "horaires_osm",
        "location",
        "naf_principal",
        "nom",
        "nom_commercial",
        "nom_officiel",
        "parent",
        "public_accueilli",
        "reprise",
        "siren",
        "siret",
        "siret_is_closed",
        "telephone",
        "uniquement_sur_rdv",
        "url",
        "ville"
    ],
    "dedup_enrich_keep_empty": false,
    "dedup_enrich_keep_parent_data_by_default": true,
    "dedup_enrich_priority_sources": [
        "ecodds (id=92)"
    ],
    "dry_run": false,
    "include_acteur_types": [
        "decheterie (id=7)"
    ],
    "include_if_all_fields_filled": [
        "code_postal"
    ],
    "include_only_if_regex_matches_nom": null,
    "include_sources": [
        "ecodds (id=92)",
        "ecopae (id=252)",
        "refashion (id=45)",
        "ecosystem (id=95)",
        "corepile (id=88)"
    ],
    "normalize_fields_basic": null,
    "normalize_fields_no_words_size1": null,
    "normalize_fields_no_words_size2_or_less": null,
    "normalize_fields_no_words_size3_or_less": null,
    "normalize_fields_order_unique_words": null
}
```

-> Il doit ressortir plus de 200 resultats
-> Il est possible de tester avec d'autres types d'acteur


## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)
