### PR TITLE
Corrige un problème de tests e2e avec le renommage des tables de cache

### DIFF
--- a/.github/actions/prepare-django-db/action.yml
+++ b/.github/actions/prepare-django-db/action.yml
@@ -57,6 +57,7 @@ runs:
       shell: bash
       working-directory: webapp
       run: |
+        uv run python manage.py createcachetable
         # TODO: user make prepare-e2e-test here
         make migrate
         # TEMPORARY, required to have unaccent search function in CI

--- a/webapp/servers.conf.erb
+++ b/webapp/servers.conf.erb
@@ -1,4 +1,3 @@
-sendfile on;
 tcp_nopush on;
 tcp_nodelay on;
 keepalive_timeout 65;


### PR DESCRIPTION
# Description succincte du problème résolu

Suite de #2633 


**🗺️ contexte**: CI/CD

**💡 quoi**: correction d'une régression introduite du fait qu'on renomme les tables de cache

**🎯 pourquoi**: 
Car la table de cache n'est pas créée en CI et n'existe pas forcément dans la db source utilisée pour les tests e2e

**🤔 comment**: 
ajout du script django de création de la table

**🤓 comment tester**:
vérifier que les e2e sont au vert


## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
