### PR TITLE
Suppression de directives nginx en double sur scalingo

### DIFF
--- a/webapp/servers.conf.erb
+++ b/webapp/servers.conf.erb
@@ -1,12 +1,4 @@
-tcp_nopush on;
-tcp_nodelay on;
 keepalive_timeout 65;
-
-gzip on;
-gzip_vary on;
-gzip_proxied any;
-gzip_comp_level 6;
-gzip_types text/plain text/css text/javascript application/javascript application/json application/xml image/svg+xml;
 
 open_file_cache max=1000 inactive=20s;
 open_file_cache_valid 30s;

--- a/webapp/servers.conf.erb
+++ b/webapp/servers.conf.erb
@@ -1,4 +1,8 @@
-keepalive_timeout 65;
+gzip on;
+gzip_vary on;
+gzip_proxied any;
+gzip_comp_level 6;
+gzip_types text/plain text/css text/javascript application/javascript application/json application/xml image/svg+xml;
 
 open_file_cache max=1000 inactive=20s;
 open_file_cache_valid 30s;

--- a/webapp/servers.conf.erb
+++ b/webapp/servers.conf.erb
@@ -1,9 +1,3 @@
-gzip on;
-gzip_vary on;
-gzip_proxied any;
-gzip_comp_level 6;
-gzip_types text/plain text/css text/javascript application/javascript application/json application/xml image/svg+xml;
-
 open_file_cache max=1000 inactive=20s;
 open_file_cache_valid 30s;
 open_file_cache_min_uses 2;


### PR DESCRIPTION
# Description succincte du problème résolu

Suite #2717 
Ces directives nginx sont déjà déclarées par scalingo, ce qui génère une erreur au boot

J'ai déployé manuellement cette branche sur scalingo, et ca fonctionne 