### PR TITLE
Proxy PostHog via notre domaine 

### DIFF
--- a/webapp/servers.conf.erb
+++ b/webapp/servers.conf.erb
@@ -70,6 +70,24 @@ server {
         add_header X-Cache-Status $upstream_cache_status always;
     }
 
+    # PostHog proxy - keeps analytics traffic on our domain, bypasses ad-blockers
+    location /ph/static/ {
+        proxy_pass https://eu-assets.i.posthog.com/static/;
+        proxy_ssl_server_name on;
+        proxy_set_header Host eu-assets.i.posthog.com;
+    }
+
+    location /ph/ {
+        proxy_pass https://eu.i.posthog.com/;
+        proxy_ssl_server_name on;
+        proxy_set_header Host eu.i.posthog.com;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
+        # Strip Origin/Referer so PostHog doesn't reject requests from local/unknown domains
+        proxy_set_header Origin "";
+        proxy_set_header Referer "";
+    }
+
     location / {
         # HTTP/1.1 + empty Connection header required for upstream keepalive
         proxy_pass http://gunicorn;

--- a/webapp/static/to_compile/controllers/shared/analytics.ts
+++ b/webapp/static/to_compile/controllers/shared/analytics.ts
@@ -56,7 +56,8 @@ export default class extends Controller<HTMLElement> {
   intersectionObserverThreshold = 0.1
 
   posthogConfig: Partial<PostHogConfig> = {
-    api_host: "https://eu.posthog.com",
+    api_host: "/ph",
+    ui_host: "https://eu.posthog.com",
     autocapture: false,
     capture_pageview: false,
     person_profiles: "always",


### PR DESCRIPTION
# Proxy PostHog via notre domaine pour contourner les bloqueurs de pub

**🗺️ contexte**: Tracking PostHog

**💡 quoi**: Ajout d'un proxy nginx `/ph` qui relaie les requêtes vers `eu.i.posthog.com`

**🎯 pourquoi**: Les bloqueurs de publicité (uBlock, Brave...) bloquent les requêtes directes vers posthog.com. En passant par notre propre domaine, les événements arrivent même chez les utilisateurs qui bloquent les trackers tiers.

**🤔 comment**:

- Deux blocs dans la conf nginx: un pour les assets statiques PostHog, un pour l'API
- Suppression des headers `Origin` et `Referer` pour éviter les rejets côté PostHog sur les domaines locaux/inconnus
- mise à jour en conséquence de la config client posthog

**🤓 comment tester**: 
- Ouvrir les DevTools, onglet Network, filtrer `/ph/` ->  les requêtes PostHog doivent passer par notre domaine.
- aller dans posthog sur le projet [dev] > vérifier qu'on a bien des evenements qui arrivent

## Auto-review

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)