### PR TITLE
refonte du tracking : pageView et events

### DIFF
--- a/webapp/e2e_tests/analytics.spec.ts
+++ b/webapp/e2e_tests/analytics.spec.ts
@@ -1,7 +1,129 @@
-import { test, expect } from "@playwright/test"
+import { test, expect, Page, Frame } from "@playwright/test"
 import { navigateTo, TIMEOUT } from "./helpers"
 
+// Helpers shared across iframe tracking tests
+// These use Playwright's Frame API to evaluate JS directly inside the iframe,
+// which works for both same-origin and cross-origin iframes (unlike contentWindow access).
+
+async function getIframeFrame(page: Page): Promise<Frame> {
+  // Wait until a child frame appears and has navigated to its URL
+  await page.waitForFunction(() => window.frames.length > 0, {
+    timeout: TIMEOUT.DEFAULT,
+  })
+  const frames = page.frames()
+  const frame = frames.find((f) => f !== page.mainFrame())
+  if (!frame) throw new Error("iframe frame not found")
+  // Wait for the iframe page to finish loading before returning
+  await frame.waitForLoadState("domcontentloaded", { timeout: TIMEOUT.LONG })
+  return frame
+}
+
+async function waitForAnalyticsController(frame: Frame) {
+  await frame.waitForFunction(
+    () => {
+      const w = window as any
+      if (!w.stimulus) return false
+      return !!w.stimulus.getControllerForElementAndIdentifier(
+        document.body,
+        "analytics",
+      )
+    },
+    { timeout: TIMEOUT.LONG },
+  )
+}
+
+async function installCaptureSpy(frame: Frame) {
+  await frame.evaluate(() => {
+    const w = window as any
+    const ctrl = w.stimulus.getControllerForElementAndIdentifier(
+      document.body,
+      "analytics",
+    )
+    w.__capturedEvents = []
+    const original = ctrl.capture.bind(ctrl)
+    ctrl.capture = (event: string, props?: Record<string, unknown>) => {
+      w.__capturedEvents.push({ event, props })
+      original(event, props)
+    }
+  })
+}
+
+async function getCapturedEvents(frame: Frame): Promise<{ event: string }[]> {
+  return frame.evaluate(() => {
+    return (window as any).__capturedEvents as { event: string }[]
+  })
+}
+
+async function waitForEvent(frame: Frame, eventName: string) {
+  await frame.waitForFunction(
+    (name) => {
+      return (((window as any).__capturedEvents as { event: string }[]) ?? []).some(
+        (e) => e.event === name,
+      )
+    },
+    eventName,
+    { timeout: TIMEOUT.DEFAULT },
+  )
+}
+
 test.describe("📊 Analytics & Tracking", () => {
+  test.describe("Tracking visibilité et interaction iframe (t_17)", () => {
+    const TEST_PATH = "/lookbook/preview/tests/t_17_iframe_page_viewed/"
+
+    test("iframe_page_viewed fires on scroll, interacted_with_iframe fires on hover, each only once", async ({
+      page,
+    }, testInfo) => {
+      testInfo.setTimeout(90000)
+      await navigateTo(page, TEST_PATH)
+
+      const iframeEl = page.locator("iframe").first()
+      await expect(iframeEl).toBeAttached({ timeout: TIMEOUT.DEFAULT })
+
+      // Get the Frame object — works for both same-origin and cross-origin iframes
+      const frame = await getIframeFrame(page)
+
+      await waitForAnalyticsController(frame)
+      await installCaptureSpy(frame)
+
+      // No events yet — iframe is off-screen (2000px top padding)
+      const eventsBefore = await getCapturedEvents(frame)
+      expect(eventsBefore).toEqual([])
+
+      // Scroll iframe into view on the parent page
+      await iframeEl.scrollIntoViewIfNeeded()
+
+      // iframe_page_viewed should fire via IntersectionObserver → postMessage
+      await waitForEvent(frame, "iframe_page_viewed")
+      const eventsAfterScroll = await getCapturedEvents(frame)
+      expect(
+        eventsAfterScroll.filter((e) => e.event === "iframe_page_viewed"),
+      ).toHaveLength(1)
+
+      // Hover inside the iframe body → interacted_with_iframe
+      await frame.locator("main").first().hover()
+
+      await waitForEvent(frame, "interacted_with_iframe")
+      const eventsAfterHover = await getCapturedEvents(frame)
+      expect(
+        eventsAfterHover.filter((e) => e.event === "interacted_with_iframe"),
+      ).toHaveLength(1)
+
+      // Deduplication: scroll away, back, hover again — counts must stay at 1
+      await page.evaluate(() => window.scrollTo(0, 0))
+      await iframeEl.scrollIntoViewIfNeeded()
+      await frame.locator("main").first().hover()
+      await page.waitForTimeout(500)
+
+      const finalEvents = await getCapturedEvents(frame)
+      expect(finalEvents.filter((e) => e.event === "iframe_page_viewed")).toHaveLength(
+        1,
+      )
+      expect(
+        finalEvents.filter((e) => e.event === "interacted_with_iframe"),
+      ).toHaveLength(1)
+    })
+  })
+
   test.describe("Tracking du referrer dans les iframes", () => {
     const scriptTypes = [
       { name: "carte", scriptType: "carte", iframeId: "carte", iframePath: "/carte" },

--- a/webapp/previews/template_preview.py
+++ b/webapp/previews/template_preview.py
@@ -1246,3 +1246,10 @@ class TestsPreview(LookbookPreview):
         return render_to_string(
             "ui/tests/t_16_infotri_configurator.html",
         )
+
+    def t_17_iframe_page_viewed(self, **kwargs):
+        """Test that the iframe_page_viewed PostHog event fires on hover/touch inside an iframe"""
+        return render_to_string(
+            "ui/tests/t_17_iframe_page_viewed.html",
+            {"base_url": base_url},
+        )

--- a/webapp/static/to_compile/controllers/shared/analytics.ts
+++ b/webapp/static/to_compile/controllers/shared/analytics.ts
@@ -41,6 +41,9 @@ export default class extends Controller<HTMLElement> {
     iframe: false,
   }
 
+  #iframePageViewedFired = false
+  #iframeInteractedFired = false
+
   static values = {
     initialAction: String,
     posthogDebug: Boolean,
@@ -53,12 +56,11 @@ export default class extends Controller<HTMLElement> {
     userUsername: String,
   }
 
-  intersectionObserverThreshold = 0.1
-
   posthogConfig: Partial<PostHogConfig> = {
     api_host: "https://eu.posthog.com",
     autocapture: false,
-    capture_pageview: false,
+    capture_pageview: true,
+    capture_pageleave: true,
     person_profiles: "always",
     persistence: "memory",
   }
@@ -84,7 +86,7 @@ export default class extends Controller<HTMLElement> {
     this.#identifyAuthenticatedUser()
     this.#initialiseIframeRelatedPersonProperties()
     this.#syncSessionStorageWithLocalConversionScore()
-    this.#setupIntersectionObserver()
+    this.#setupIframeTracking()
     this.#computeConversionScoreFromSessionStorage()
     this.#setInitialActionValue()
 
@@ -263,6 +265,10 @@ export default class extends Controller<HTMLElement> {
     this.#updateDebugInspectorUI()
   }
 
+  capture(event: string, properties?: Record<string, unknown>) {
+    posthog.capture(event, properties)
+  }
+
   #computeConversionScoreFromActions() {
     let score = 0
     for (const value of Object.values(this.userConversionScoreValue)) {
@@ -272,24 +278,37 @@ export default class extends Controller<HTMLElement> {
     return score
   }
 
-  #setupIntersectionObserver() {
-    const observer = new IntersectionObserver(
-      (entries, observer) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            posthog.capture("$pageview")
-            // TODO: increase userConversionScore
-            observer.unobserve(entry.target)
-          }
-        })
-      },
-      {
-        root: null,
-        threshold: this.intersectionObserverThreshold, // Trigger when at least 10% of the page is visible
-      },
-    )
+  #setupIframeTracking() {
+    if (!this.personProperties.iframe) return
+    this.#setupViewportTracking()
+    this.#setupInteractionTracking()
+  }
 
-    observer.observe(document.body)
+  // Fires iframe_page_viewed once when the parent page signals that this
+  // iframe has entered the viewport (via postMessage from iframe_functions.ts).
+  #setupViewportTracking() {
+    window.addEventListener("message", (event: MessageEvent) => {
+      if (this.#iframePageViewedFired) return
+      // Only accept messages from our direct parent frame.
+      // This prevents arbitrary third-party scripts on the embedding page
+      // from spoofing the iframe_in_viewport signal.
+      if (event.source !== window.parent) return
+      if (!event.data || event.data.type !== "iframe_in_viewport") return
+      this.#iframePageViewedFired = true
+      this.capture("iframe_page_viewed")
+    })
+  }
+
+  // Fires interacted_with_iframe once on first mouse or touch interaction
+  // inside the iframe body.
+  #setupInteractionTracking() {
+    const fireOnce = () => {
+      if (this.#iframeInteractedFired) return
+      this.#iframeInteractedFired = true
+      this.capture("interacted_with_iframe")
+    }
+    document.body.addEventListener("mouseover", fireOnce, { once: true })
+    document.body.addEventListener("touchstart", fireOnce, { once: true })
   }
 
   #captureUIInteraction(

--- a/webapp/static/to_compile/js/iframe_functions.ts
+++ b/webapp/static/to_compile/js/iframe_functions.ts
@@ -249,6 +249,20 @@ export async function buildAndInsertIframeFrom(
   // Insert iframe after script tag
   scriptTag.insertAdjacentElement("afterend", iframe)
 
+  // Notify the iframe when it enters the parent page's viewport.
+  // The analytics controller inside the iframe listens for this message
+  // to fire the iframe_page_viewed event exactly once.
+  const observer = new IntersectionObserver(
+    (entries, obs) => {
+      if (entries[0].intersectionRatio > 0) {
+        iframe.contentWindow?.postMessage({ type: "iframe_in_viewport" }, "*")
+        obs.disconnect()
+      }
+    },
+    { threshold: 0.01 },
+  )
+  observer.observe(iframe)
+
   // Generate and insert backlink
   await generateBackLink(iframe, backlinkKey, baseUrl)
 

--- a/webapp/templates/ui/tests/t_17_iframe_page_viewed.html
+++ b/webapp/templates/ui/tests/t_17_iframe_page_viewed.html
@@ -1,0 +1,9 @@
+{% load dsfr_tags %}
+
+<div style="padding-top: 2000px;">
+  {% dsfr_callout title="Test iframe_page_viewed" text="Cette page intègre la carte en iframe pour tester l'événement PostHog iframe_page_viewed et interacted_with_iframe." icon_class="fr-icon-flask-line" %}
+
+  <p>Scrollez jusqu'à l'iframe pour déclencher l'événement <code>iframe_page_viewed</code>. Survolez ou touchez ensuite l'iframe pour déclencher <code>interacted_with_iframe</code>.</p>
+
+  <script src="{{ base_url }}/static/carte.js"></script>
+</div>


### PR DESCRIPTION
# Refactor du tracking iframe : séparation vue / interaction

**🗺️ contexte**: Analytics PostHog / tracking d'usage des iframes

**💡 quoi**: Remplacement de l'événement pageview (déclenché manuellement avant, maintenant automatiquement) par deux événements distincts :
- `iframe_page_viewed` : déclenché quand l'iframe entre dans le viewport de la page parente
- `interacted_with_iframe` : déclenché au premier survol ou toucher à l'intérieur de l'iframe

**🎯 pourquoi**: L'ancienne implémentation déclenchait `$pageview` uniquement quand l'utilisateur interagissait avec l'iframe. On ratait donc tous les utilisateurs qui voient l'iframe sans jamais cliquer ou survoler. La nouvelle approche sépare clairement "l'iframe a été vue" de "l'utilisateur a interagi avec l'iframe", ce qui permet de mesurer les taux de conversion réels.

**🤔 comment**:

- `iframe_functions.ts` : ajout d'un `IntersectionObserver` sur l'élément `<iframe>` après son insertion dans le DOM. Quand l'iframe entre dans le viewport (`threshold: 0.01`), un `postMessage({ type: "iframe_in_viewport" })` est envoyé à la fenêtre de l'iframe
- `analytics.ts` : remplacement de `#setupIntersectionObserver` (qui capturait `$pageview` sur `document.body`) par deux méthodes :
  - `#setupViewportTracking()` : écoute le `message` envoyé par le parent
  - `#setupInteractionTracking()` : écoute `mouseover` + `touchstart` sur `document.body`, pour valider l'interaction avec une iframe
- Ajout d'une méthode publique `capture` pour permettre l'espionnage dans les tests e2e


**🤓 comment tester**:
- Ouvrir `/lookbook/preview/tests/t_17_iframe_page_viewed/`
- Ouvrir les DevTools, onglet Network, filtrer `/ph/`
- Vérifier qu'aucun événement iframe ne part au chargement
- Scroller jusqu'à l'iframe -> `iframe_page_viewed` doit apparaître dans le réseau
- Survoler l'iframe -> `interacted_with_iframe` doit apparaître
- Scroller puis re-survoler -> les deux événements ne doivent pas se redéclencher

## Auto-review

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Supply_Chain_Security_Cheat_Sheet.html)

## 📆 A faire (prochaine PR)

- [x] Brancher `interacted_with_iframe` sur le score de conversion utilisateur