### PR TITLE
Plus besoin de déployer un container après une mise à jour

### DIFF
--- a/.github/workflows/_scaleway-container-deploy.yml
+++ b/.github/workflows/_scaleway-container-deploy.yml
@@ -31,12 +31,6 @@ jobs:
           registry-image=$REGISTRY_IMAGE \
           region=$SCW_DEFAULT_REGION
 
-        # See https://www.scaleway.com/en/docs/serverless-containers/api-cli/deploy-container-cli/
-    - name: Deploy container
-      run: |
-        scw container container deploy $CONTAINER_ID \
-          region=$SCW_DEFAULT_REGION
-
     - name: Check deployment status
       run: |
         EXPECTED_VALUE="ready"


### PR DESCRIPTION
# Description succincte du problème résolu

Support Scaleway : [Le serverless container "lvao-prod-webserver" est indiqué en erreur mais il est quand même accessible](https://console.scaleway.com/support/tickets/1578884)
Github Action : [Scaleway deploy container](https://github.com/incubateur-ademe/quefairedemesobjets/actions/runs/24461922461/job/71663457285)
Doc Scaleway API : [v1 migration guide](https://www.scaleway.com/en/docs/serverless-containers/reference-content/v1-migration-guide/)

**🗺️ contexte**: Evolution v1beta vers v1 de l'API scaleway qui casse la CD

**💡 quoi**: le deploiement echoue

**🎯 pourquoi**: Car lors d'un update, le deploiement est lancer et on a une erreur lorsqu'on essaye de relancer le déploiement une seconde fois

**🤔 comment**: Suppression de l'étape de déploiement : l'update suffit

**🤓 comment tester**: Essayons un déploiement en preprod :)

Résultat : https://github.com/incubateur-ademe/quefairedemesobjets/actions/runs/24518290977

C'est pas encore hyper stabe mais c'est mieux

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien

## Reste à faire (prochaine PR)

- [ ] Pas besoin d'un création de release lors du déploiement d'une branche en preprod