### PR TITLE
Corrige les tests e2e en échec suite à une mise à jour de dépendances

### DIFF
--- a/webapp/playwright.config.ts
+++ b/webapp/playwright.config.ts
@@ -1,11 +1,13 @@
 import { defineConfig, devices, PlaywrightTestConfig } from "@playwright/test"
 import dotenv from "dotenv"
 import path from "path"
+import { fileURLToPath } from "url"
 
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 dotenv.config({ path: path.resolve(__dirname, ".env") })
 
 const PORT = 8888


### PR DESCRIPTION
# Description succincte du problème résolu

**🗺️ contexte** : depuis la mise à jour des dépendances (Playwright / configuration ESM), la variable globale `__dirname` n'est plus définie dans `playwright.config.ts`, faisant échouer le chargement du `.env` et donc tous les tests e2e.

**💡 quoi** : reconstruction explicite de `__dirname` à partir de `import.meta.url` via `fileURLToPath`.

**🎯 pourquoi** : `playwright.config.ts` est exécuté en mode ESM, et `__dirname` n'existe pas dans ce contexte. Sans cette définition, `dotenv.config({ path: path.resolve(__dirname, ".env") })` lève `ReferenceError: __dirname is not defined`.

**🤔 comment** :

- Import de `fileURLToPath` depuis `url`.
- `const __dirname = path.dirname(fileURLToPath(import.meta.url))` avant l'appel à `dotenv.config`.

**🤓 comment tester** :

- `cd webapp && npx playwright test --list` doit lister les tests sans erreur de config.
- Tout job E2E sur cette branche doit redevenir vert.

## Auto-review

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template` (n/a)
- [ ] J'ai ajouté des tests qui couvrent le nouveau code (correctif config, couvert par l'exécution e2e)
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours (n/a)
