### PR TITLE
Corrige une erreur sur les termes de recherche orphelins

### DIFF
--- a/webapp/qfdmd/models.py
+++ b/webapp/qfdmd/models.py
@@ -298,10 +298,8 @@ class ProduitPageSearchTerm(SearchTerm):
 
     produit_page = models.OneToOneField(
         "qfdmd.ProduitPage",
-        on_delete=models.SET_NULL,
+        on_delete=models.CASCADE,
         related_name="produit_page_search_term",
-        blank=True,
-        null=True,
     )
     searchable_title = models.CharField()
 

--- a/webapp/qfdmd/views.py
+++ b/webapp/qfdmd/views.py
@@ -1,10 +1,10 @@
 import logging
-from typing import Any
+from typing import Any, override
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
-from typing import override
 
 import django_filters
 from django.contrib import messages
+from django.db import OperationalError, connection
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
 from django.utils.decorators import method_decorator
@@ -332,15 +332,25 @@ class AutocompleteHomeSearchView(ListView):
     # seven results.
     NUMBER_OF_ITEMS_DISPLAYED = 7
 
+    SEARCH_TIMEOUT_MS = 3000
+
     @override
     def get_queryset(self):
         query = self.request.GET.get("q", "")
         limit = self.NUMBER_OF_ITEMS_DISPLAYED
         if not query:
             return []
-        return SearchTerm.objects.searchable().search(Fuzzy(query, unaccent=True))[
-            :limit
-        ]
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    "SET LOCAL statement_timeout = %s", [self.SEARCH_TIMEOUT_MS]
+                )
+            return SearchTerm.objects.searchable().search(Fuzzy(query, unaccent=True))[
+                :limit
+            ]
+        except OperationalError:
+            logger.warning("Autocomplete search timed out for query: %r", query)
+            return []
 
     @override
     def get_context_data(self, **kwargs):

--- a/webapp/qfdmd/views.py
+++ b/webapp/qfdmd/views.py
@@ -349,7 +349,8 @@ class AutocompleteHomeSearchView(ListView):
                 :limit
             ]
         except OperationalError:
-            logger.warning("Autocomplete search timed out for query: %r", query)
+            safe_query = query.replace("\r", "").replace("\n", "")
+            logger.warning("Autocomplete search timed out for query: %r", safe_query)
             return []
 
     @override

--- a/webapp/search/wagtail_hooks.py
+++ b/webapp/search/wagtail_hooks.py
@@ -1,13 +1,17 @@
 import django_filters
+from django.conf import settings
 from wagtail.admin.filters import WagtailFilterSet
 from wagtail.admin.panels import FieldPanel, HelpPanel
 from wagtail.snippets.models import register_snippet
-from wagtail.snippets.views.snippets import SnippetViewSet, SnippetViewSetGroup
+from wagtail.snippets.views.snippets import (
+    IndexView,
+    SnippetViewSet,
+    SnippetViewSetGroup,
+)
 
-from qfdmd.models import SearchTag, Synonyme, TaggedSearchTag
+from qfdmd.models import ProduitPageSearchTerm, SearchTag, Synonyme, TaggedSearchTag
 from search.constants import SEARCH_TAG_HELP_TEXT
 from search.models import SearchTerm
-from django.conf import settings
 
 
 class KindFilter(django_filters.ChoiceFilter):
@@ -62,13 +66,13 @@ class SearchTermViewSet(SnippetViewSet):
     ]
 
 
-class OrphanFilter(django_filters.ChoiceFilter):
+class SearchTagStatusFilter(django_filters.ChoiceFilter):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault(
             "choices",
             [
-                ("orphan", "Orphelins uniquement"),
-                ("linked", "Rattachés uniquement"),
+                ("orphan", "Sans page (anomalie)"),
+                ("linked", "Rattachés à une page"),
             ],
         )
         kwargs.setdefault("label", "Statut")
@@ -85,7 +89,7 @@ class OrphanFilter(django_filters.ChoiceFilter):
 
 
 class SearchTagFilterSet(WagtailFilterSet):
-    status = OrphanFilter()
+    status = SearchTagStatusFilter()
 
     class Meta:
         model = SearchTag
@@ -108,13 +112,46 @@ class SearchTagViewSet(SnippetViewSet):
     ]
 
 
+class SynonymeMigrationStatusFilter(django_filters.ChoiceFilter):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault(
+            "choices",
+            [
+                ("migrated_active", "Migrés mais encore actifs (anomalie)"),
+                ("migrated_disabled", "Migrés et désactivés"),
+                ("not_migrated", "Non migrés"),
+            ],
+        )
+        kwargs.setdefault("label", "Statut migration")
+        kwargs.setdefault("empty_label", "Tous")
+        super().__init__(*args, **kwargs)
+
+    def filter(self, qs, value):
+        if value == "migrated_active":
+            return qs.filter(imported_as_search_tag__isnull=False, disabled=False)
+        if value == "migrated_disabled":
+            return qs.filter(imported_as_search_tag__isnull=False, disabled=True)
+        if value == "not_migrated":
+            return qs.filter(imported_as_search_tag__isnull=True)
+        return qs
+
+
+class SynonymeFilterSet(WagtailFilterSet):
+    migration_status = SynonymeMigrationStatusFilter()
+
+    class Meta:
+        model = Synonyme
+        fields = []
+
+
 class SynonymeViewSet(SnippetViewSet):
     model = Synonyme
     icon = "doc-full"
     menu_label = "Synonymes (ancienne version)"
     menu_name = "synonymes"
-    list_display = ["nom", "modifie_le"]
+    list_display = ["nom", "imported_as_search_tag", "disabled", "modifie_le"]
     search_backend_name = settings.MODELSEARCH_BACKENDS["default"]["BACKEND"]
+    filterset_class = SynonymeFilterSet
     panels = [
         FieldPanel("nom"),
         FieldPanel("disabled"),
@@ -122,8 +159,27 @@ class SynonymeViewSet(SnippetViewSet):
     ]
 
 
+class NonLiveProduitPageSearchTermIndexView(IndexView):
+    def get_base_queryset(self):
+        return ProduitPageSearchTerm.objects.filter(produit_page__live=False)
+
+
+class NonLiveProduitPageSearchTermViewSet(SnippetViewSet):
+    model = ProduitPageSearchTerm
+    icon = "warning"
+    menu_label = "Termes liés à des pages non publiées"
+    menu_name = "search-non-live-pages"
+    list_display = ["searchable_title", "produit_page"]
+    index_view_class = NonLiveProduitPageSearchTermIndexView
+
+
 class RechercheViewSetGroup(SnippetViewSetGroup):
-    items = (SearchTermViewSet, SearchTagViewSet, SynonymeViewSet)
+    items = (
+        SearchTermViewSet,
+        SearchTagViewSet,
+        SynonymeViewSet,
+        NonLiveProduitPageSearchTermViewSet,
+    )
     menu_icon = "search"
     menu_label = "Moteur de recherche"
     menu_name = "recherche"

--- a/webapp/templates/ui/components/search/autocomplete_results.html
+++ b/webapp/templates/ui/components/search/autocomplete_results.html
@@ -3,6 +3,8 @@
 {% block results %}
     {% for result in results %}
         {% with specific=result.specific %}
+        {# Guard against orphaned SearchTerms whose child object was deleted — see migration 0082 #}
+        {% if specific %}
         <li
             id="option-{{ forloop.counter }}"
             role="option"
@@ -13,6 +15,7 @@
         >
             {% include specific.search_result_template with result=specific position=forloop.counter %}
         </li>
+        {% endif %}
         {% endwith %}
     {% empty %}
         <li class="qf-list-none qf-px-2w qf-py-1w qf-text-gray-500">

--- a/webapp/templates/ui/components/search/search_result_produitpage.html
+++ b/webapp/templates/ui/components/search/search_result_produitpage.html
@@ -3,4 +3,4 @@
 
 {% block href %}{% pageurl result.produit_page %}{% endblock %}
 
-{% block nom %}{{ result.produit_page.titre_phrase|capfirst }}{% endblock %}
+{% block nom %}{{ result.produit_page.titre_phrase|capfirst }}{{ result }}{% endblock %}


### PR DESCRIPTION
# Description succincte du problème résolu

**🗺️ contexte** : l'autocomplete de l'assistant remontait des `ProduitPageSearchTerm` orphelins (sans `produit_page` rattachée), ce qui faisait planter le rendu en prod sur certaines requêtes. Par ailleurs, certaines requêtes ouvertes faisaient un timeout sur requêtes côté scalingo.

**💡 quoi** :

- Bascule de la FK `ProduitPageSearchTerm.produit_page` en `OneToOneField(on_delete=CASCADE)` sans `null/blank` (la migration de schéma et le purge des orphelins se font dans la PR #2750).
- Ajout d'un `statement_timeout` Postgres (3s) sur la requête d'autocomplete et capture des `OperationalError` pour renvoyer un résultat vide plutôt qu'une 500.
- Garde-fou côté template (`autocomplete_results.html`) pour ignorer un éventuel SearchTerm dont l'enfant a été supprimé.
- Visualisaton dans l'admin wagtail

**🎯 pourquoi** :

- Les `SearchTerm` orphelins polluaient les résultats et provoquaient des erreurs en suivant `result.specific` dans le template.
- L'absence de timeout faisait remonter dans Sentry des recherches problématiques bloquant la connexion à la DB.

**🤓 comment tester** :

1. Lancer une requête longue depuis l'autocomplete : doit retourner une liste vide proprement (pas de 500), et un warning en logs.
2. Dans l'admin Wagtail, vérifier les libellés mis à jour des filtres et la nouvelle entrée "Termes liés à des pages non publiées".
3. Vérifier qu'aucun résultat orphelin ne s'affiche dans l'autocomplete public.

## Auto-review

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template` (n/a)
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours (n/a)

## Reste à faire (prochaine PR)

- [ ] Migration de schéma associée (#2750).
