### PR TITLE
Fusion posthog carte et assistant

### DIFF
--- a/webapp/.env.template
+++ b/webapp/.env.template
@@ -49,9 +49,6 @@ ASSISTANT_MATOMO_ID=82
 # Posthog Assistant [DEV] project
 # pragma: allowlist nextline secret
 ASSISTANT_POSTHOG_KEY=phc_fSfhoWDOUxZdKWty16Z3XfRiAoWd1qdJK0N0z9kQHJr
-# Posthog Carte [DEV] project
-# pragma: allowlist nextline secret
-CARTE_POSTHOG_KEY=phc_SwcKewoXg9MZyAIdl8qsyvwz3Vij8Vlrbr2SjEeN3u9
 
 NOTION_TOKEN=
 NOTION_CONTACT_FORM_DATABASE_ID=17c6523d57d78140b87f000cd3ecef4b # Correspond à https://www.notion.so/accelerateur-transition-ecologique-ademe/17c6523d57d7808b8cc5f5ccae264f7c?v=17c6523d57d78140b87f000cd3ecef4b&pvs=4

--- a/webapp/core/context_processors.py
+++ b/webapp/core/context_processors.py
@@ -48,7 +48,6 @@ def global_context(request) -> dict:
             "DECLARATION_ACCESSIBILITE_PAGE_ID": settings.CARTE[
                 "DECLARATION_ACCESSIBILITE_PAGE_ID"
             ],
-            "POSTHOG_KEY": settings.CARTE["POSTHOG_KEY"],
             "MATOMO_ID": settings.CARTE["MATOMO_ID"],
             **constants.CARTE,
         },

--- a/webapp/core/settings.py
+++ b/webapp/core/settings.py
@@ -42,12 +42,6 @@ ASSISTANT = {
 CARTE = {
     "MATOMO_ID": decouple.config("LVAO_MATOMO_ID", default=50, cast=int),
     "GOOGLE_SEARCH_CONSOLE": "google9dfbbc61adbe3888.html",
-    "POSTHOG_KEY": decouple.config(
-        "CARTE_POSTHOG_KEY",
-        # Staging project by default
-        default="phc_L1dG5EsBjyMTTcQqFJTAQtEugtGz6C3Tdpf1g7O09si",  # pragma: allowlist secret  # noqa: E501
-        cast=str,
-    ),
     "DECLARATION_ACCESSIBILITE_PAGE_ID": decouple.config(
         "CARTE_DECLARATION_ACCESSBILITE_PAGE_ID",
         default=177,

--- a/webapp/e2e_tests/analytics.spec.ts
+++ b/webapp/e2e_tests/analytics.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect, Page, Frame } from "@playwright/test"
-import { navigateTo, TIMEOUT } from "./helpers"
+import {
+  navigateTo,
+  TIMEOUT,
+  searchCarteAndWaitForActeurs,
+  clickFirstClickableActeurMarker,
+  mockApiAdresse,
+} from "./helpers"
 
 // Helpers shared across iframe tracking tests
 // These use Playwright's Frame API to evaluate JS directly inside the iframe,
@@ -294,6 +300,72 @@ test.describe("📊 Analytics & Tracking", () => {
         }
       })
     }
+  })
+
+  test.describe("acteur_viewed event", () => {
+    test("acteur_viewed fires with acteurUuid, acteurType and sources when opening acteur detail", async ({
+      page,
+    }) => {
+      await mockApiAdresse(page)
+      await navigateTo(page, "/carte")
+
+      // Install capture spy on the page-level analytics controller
+      await page.waitForFunction(
+        () => {
+          const w = window as any
+          return !!w.stimulus?.getControllerForElementAndIdentifier(
+            document.body,
+            "analytics",
+          )
+        },
+        { timeout: TIMEOUT.LONG },
+      )
+      await page.evaluate(() => {
+        const w = window as any
+        const ctrl = w.stimulus.getControllerForElementAndIdentifier(
+          document.body,
+          "analytics",
+        )
+        w.__capturedEvents = []
+        const original = ctrl.capture.bind(ctrl)
+        ctrl.capture = (event: string, props?: Record<string, unknown>) => {
+          w.__capturedEvents.push({ event, props })
+          original(event, props)
+        }
+      })
+
+      await searchCarteAndWaitForActeurs(page, "Auray")
+      await clickFirstClickableActeurMarker(page)
+
+      // Wait for acteur_viewed to be captured
+      await page.waitForFunction(
+        () =>
+          (((window as any).__capturedEvents as { event: string }[]) ?? []).some(
+            (e) => e.event === "acteur_viewed",
+          ),
+        { timeout: TIMEOUT.DEFAULT },
+      )
+
+      const events = await page.evaluate(() =>
+        (
+          (window as any).__capturedEvents as {
+            event: string
+            props?: Record<string, unknown>
+          }[]
+        ).filter((e) => e.event === "acteur_viewed"),
+      )
+
+      expect(events).toHaveLength(1)
+      expect(typeof events[0].props?.acteurUuid).toBe("string")
+      expect((events[0].props?.acteurUuid as string).length).toBeGreaterThan(0)
+      expect(typeof events[0].props?.acteurType).toBe("string")
+      expect((events[0].props?.acteurType as string).length).toBeGreaterThan(0)
+      expect(Array.isArray(events[0].props?.sources)).toBe(true)
+      expect(typeof events[0].props?.searchAddress).toBe("string")
+      expect((events[0].props?.searchAddress as string).length).toBeGreaterThan(0)
+      expect(typeof events[0].props?.searchLatitude).toBe("string")
+      expect(typeof events[0].props?.searchLongitude).toBe("string")
+    })
   })
 
   test.describe("Tracking du referrer dans les iframes", () => {

--- a/webapp/e2e_tests/analytics.spec.ts
+++ b/webapp/e2e_tests/analytics.spec.ts
@@ -124,6 +124,111 @@ test.describe("📊 Analytics & Tracking", () => {
     })
   })
 
+  test.describe("pageType et pageSlug dans les événements iframe (t_18)", () => {
+    const TEST_PATH = "/lookbook/preview/tests/t_18_iframe_page_properties/"
+
+    const iframeCases = [
+      { testId: "iframe-carte", expectedPageType: "carte", expectedPageSlug: "" },
+      {
+        testId: "iframe-carte-sur-mesure",
+        expectedPageType: "carte_sur_mesure",
+        expectedPageSlug: null, // slug is dynamic, just check it's non-empty
+      },
+      {
+        testId: "iframe-formulaire",
+        expectedPageType: "formulaire",
+        expectedPageSlug: "",
+      },
+      {
+        testId: "iframe-assistant",
+        expectedPageType: "assistant",
+        expectedPageSlug: "",
+      },
+    ]
+
+    for (const { testId, expectedPageType, expectedPageSlug } of iframeCases) {
+      test(`${testId} — iframe_page_viewed et interacted_with_iframe contiennent pageType="${expectedPageType}"`, async ({
+        page,
+      }, testInfo) => {
+        testInfo.setTimeout(90000)
+        await navigateTo(page, TEST_PATH)
+
+        const iframeEl = page.locator(`[data-testid="${testId}"] iframe`).first()
+        await expect(iframeEl).toBeAttached({ timeout: TIMEOUT.LONG })
+
+        // Resolve Frame from src — poll until attached (iframes load lazily via script tag)
+        const iframeSrc = await iframeEl.getAttribute("src")
+        if (!iframeSrc) throw new Error(`No src on iframe for ${testId}`)
+
+        let frame: Frame | undefined
+        await expect
+          .poll(
+            () => {
+              frame = page
+                .frames()
+                .find((f) => f.url().split("?")[0] === iframeSrc.split("?")[0])
+              return !!frame
+            },
+            { timeout: TIMEOUT.LONG },
+          )
+          .toBe(true)
+
+        const resolvedFrame = frame!
+        await resolvedFrame.waitForLoadState("domcontentloaded", {
+          timeout: TIMEOUT.LONG,
+        })
+        await waitForAnalyticsController(resolvedFrame)
+        await installCaptureSpy(resolvedFrame)
+
+        // Scroll the iframe into view so the postMessage from the parent fires
+        await iframeEl.scrollIntoViewIfNeeded()
+
+        await waitForEvent(resolvedFrame, "iframe_page_viewed")
+        const pageViewedEvents = await resolvedFrame.evaluate(() =>
+          (
+            (window as any).__capturedEvents as {
+              event: string
+              props?: Record<string, unknown>
+            }[]
+          ).filter((e) => e.event === "iframe_page_viewed"),
+        )
+        expect(pageViewedEvents).toHaveLength(1)
+        expect(pageViewedEvents[0].props?.pageType).toBe(expectedPageType)
+        if (expectedPageSlug !== null) {
+          expect(pageViewedEvents[0].props?.pageSlug).toBe(expectedPageSlug)
+        } else {
+          // carte_sur_mesure: slug is dynamic, just verify it is a non-empty string
+          expect(typeof pageViewedEvents[0].props?.pageSlug).toBe("string")
+          expect(
+            (pageViewedEvents[0].props?.pageSlug as string).length,
+          ).toBeGreaterThan(0)
+        }
+
+        // Hover inside the iframe body to trigger interacted_with_iframe
+        await resolvedFrame.locator("main").first().hover()
+        await waitForEvent(resolvedFrame, "interacted_with_iframe")
+        const interactedEvents = await resolvedFrame.evaluate(() =>
+          (
+            (window as any).__capturedEvents as {
+              event: string
+              props?: Record<string, unknown>
+            }[]
+          ).filter((e) => e.event === "interacted_with_iframe"),
+        )
+        expect(interactedEvents).toHaveLength(1)
+        expect(interactedEvents[0].props?.pageType).toBe(expectedPageType)
+        if (expectedPageSlug !== null) {
+          expect(interactedEvents[0].props?.pageSlug).toBe(expectedPageSlug)
+        } else {
+          expect(typeof interactedEvents[0].props?.pageSlug).toBe("string")
+          expect(
+            (interactedEvents[0].props?.pageSlug as string).length,
+          ).toBeGreaterThan(0)
+        }
+      })
+    }
+  })
+
   test.describe("Tracking du referrer dans les iframes", () => {
     const scriptTypes = [
       { name: "carte", scriptType: "carte", iframeId: "carte", iframePath: "/carte" },

--- a/webapp/e2e_tests/analytics.spec.ts
+++ b/webapp/e2e_tests/analytics.spec.ts
@@ -147,7 +147,7 @@ test.describe("📊 Analytics & Tracking", () => {
       },
       {
         testId: "iframe-assistant",
-        expectedPageType: "assistant",
+        expectedPageType: "quefaire",
         expectedPageSlug: "",
       },
     ]

--- a/webapp/e2e_tests/analytics.spec.ts
+++ b/webapp/e2e_tests/analytics.spec.ts
@@ -229,6 +229,73 @@ test.describe("📊 Analytics & Tracking", () => {
     }
   })
 
+  test.describe("UTM links dans les iframes (t_18)", () => {
+    const TEST_PATH = "/lookbook/preview/tests/t_18_iframe_page_properties/"
+
+    const iframeCases = [
+      { testId: "iframe-carte", label: "carte" },
+      { testId: "iframe-formulaire", label: "formulaire" },
+      { testId: "iframe-assistant", label: "assistant" },
+    ]
+
+    for (const { testId, label } of iframeCases) {
+      test(`${label} — les liens internes ont utm_source=qfdmod`, async ({
+        page,
+      }, testInfo) => {
+        testInfo.setTimeout(90000)
+        await navigateTo(page, TEST_PATH)
+
+        const iframeEl = page.locator(`[data-testid="${testId}"] iframe`).first()
+        await expect(iframeEl).toBeAttached({ timeout: TIMEOUT.LONG })
+
+        const iframeSrc = await iframeEl.getAttribute("src")
+        if (!iframeSrc) throw new Error(`No src on iframe for ${testId}`)
+
+        let frame: Frame | undefined
+        await expect
+          .poll(
+            () => {
+              frame = page
+                .frames()
+                .find((f) => f.url().split("?")[0] === iframeSrc.split("?")[0])
+              return !!frame
+            },
+            { timeout: TIMEOUT.LONG },
+          )
+          .toBe(true)
+
+        const resolvedFrame = frame!
+        await resolvedFrame.waitForLoadState("domcontentloaded", {
+          timeout: TIMEOUT.LONG,
+        })
+
+        // Wait until at least one internal link exists in the iframe
+        await expect(resolvedFrame.locator("a[href]").first()).toBeAttached({
+          timeout: TIMEOUT.LONG,
+        })
+
+        // All same-origin links should carry utm_source=qfdmod
+        const hrefs = await resolvedFrame.evaluate(() =>
+          Array.from(document.querySelectorAll<HTMLAnchorElement>("a[href]"))
+            .map((a) => a.href)
+            .filter((href) => {
+              try {
+                return new URL(href).hostname === window.location.hostname
+              } catch {
+                return false
+              }
+            }),
+        )
+
+        expect(hrefs.length).toBeGreaterThan(0)
+        for (const href of hrefs) {
+          const url = new URL(href)
+          expect(url.searchParams.get("utm_source")).toBe("qfdmod")
+        }
+      })
+    }
+  })
+
   test.describe("Tracking du referrer dans les iframes", () => {
     const scriptTypes = [
       { name: "carte", scriptType: "carte", iframeId: "carte", iframePath: "/carte" },

--- a/webapp/previews/template_preview.py
+++ b/webapp/previews/template_preview.py
@@ -1253,3 +1253,16 @@ class TestsPreview(LookbookPreview):
             "ui/tests/t_17_iframe_page_viewed.html",
             {"base_url": base_url},
         )
+
+    def t_18_iframe_page_properties(self, **kwargs):
+        """Test that iframe events include correct pageType and pageSlug for each iframe type"""
+        slug = (
+            CarteConfig.objects.exclude(test=True)
+            .values_list("slug", flat=True)
+            .first()
+            or "angers-site-vitrine"
+        )
+        return render_to_string(
+            "ui/tests/t_18_iframe_page_properties.html",
+            {"base_url": base_url, "slug": slug},
+        )

--- a/webapp/static/to_compile/controllers/carte/acteur_details.ts
+++ b/webapp/static/to_compile/controllers/carte/acteur_details.ts
@@ -22,13 +22,29 @@ class ActeurController extends Controller {
     PinpointController.clearActivePinpoints()
   }
 
-  #showPanelWhenTurboFrameLoad(event) {
+  #showPanelWhenTurboFrameLoad(event: CustomEvent) {
     // TODO : fetch this variable from template, using turbo_tags.acteur_frame_id
     let acteurDetailTurboFrameId = `${this.mapContainerIdValue}:acteur-detail`
 
     if (event.target.id === acteurDetailTurboFrameId) {
       this.#show()
+      this.#dispatchActeurViewed(event.target as HTMLElement)
     }
+  }
+
+  #dispatchActeurViewed(frame: HTMLElement) {
+    const article = frame.querySelector<HTMLElement>("article[data-acteur-uuid]")
+    if (!article) return
+    this.element.dispatchEvent(
+      new CustomEvent("acteur-details:viewed", {
+        bubbles: true,
+        detail: {
+          acteurUuid: article.dataset.acteurUuid,
+          acteurType: article.dataset.acteurType,
+          sources: article.dataset.acteurSources?.split(",").filter(Boolean) ?? [],
+        },
+      }),
+    )
   }
 
   connect() {

--- a/webapp/static/to_compile/controllers/formulaire/ss_cat_object_autocomplete_controller.ts
+++ b/webapp/static/to_compile/controllers/formulaire/ss_cat_object_autocomplete_controller.ts
@@ -1,4 +1,3 @@
-import posthog from "posthog-js"
 import AutocompleteController from "../carte/autocomplete_controller"
 
 export default class extends AutocompleteController {
@@ -37,13 +36,6 @@ export default class extends AutocompleteController {
         if (this.autocompleteList.childElementCount > 0) {
           this.currentFocusedOptionIndexValue = 0
         }
-
-        posthog.capture("object_input", {
-          object_requested: inputTargetValue,
-          object_list: data ? data.slice(0, this.maxOptionDisplayedValue) : undefined,
-          first_object: data ? data[0]["label"] : undefined,
-          first_subcategory: data ? data[0]["sub_label"] : undefined,
-        })
       })
       .then(() => {
         this.spinnerTarget.classList.add("qf-hidden")

--- a/webapp/static/to_compile/controllers/shared/analytics.ts
+++ b/webapp/static/to_compile/controllers/shared/analytics.ts
@@ -100,7 +100,14 @@ export default class extends Controller<HTMLElement> {
   #setupActeurViewedListener() {
     this.element.addEventListener("acteur-details:viewed", (e: Event) => {
       const { acteurUuid, acteurType, sources } = (e as CustomEvent).detail
-      this.capture("acteur_viewed", { acteurUuid, acteurType, sources })
+      this.capture("acteur_viewed", {
+        acteurUuid,
+        acteurType,
+        sources,
+        searchAddress: sessionStorage.getItem("adresse") ?? undefined,
+        searchLatitude: sessionStorage.getItem("latitude") ?? undefined,
+        searchLongitude: sessionStorage.getItem("longitude") ?? undefined,
+      })
     })
   }
 
@@ -152,7 +159,7 @@ export default class extends Controller<HTMLElement> {
     const { pageType } = this.#iframePageProperties()
     posthog.register({
       isIframe: this.personProperties.iframe,
-      surface: pageType,
+      outil: pageType,
       ref: this.personProperties.iframeReferrer ?? null,
     })
   }
@@ -367,6 +374,9 @@ export default class extends Controller<HTMLElement> {
     }
     if (pathname.startsWith("/formulaire")) {
       return { pageType: "formulaire", pageSlug: "" }
+    }
+    if (pathname.startsWith("/infotri")) {
+      return { pageType: "infotri", pageSlug: "" }
     }
     return { pageType: "assistant", pageSlug: pathname.replace(/^\//, "") }
   }

--- a/webapp/static/to_compile/controllers/shared/analytics.ts
+++ b/webapp/static/to_compile/controllers/shared/analytics.ts
@@ -309,6 +309,21 @@ export default class extends Controller<HTMLElement> {
     this.#setupInteractionTracking()
   }
 
+  #iframePageProperties(): { pageType: string; pageSlug: string } {
+    const pathname = window.location.pathname
+    const carteSlugMatch = pathname.match(/^\/carte\/(.+)$/)
+    if (carteSlugMatch) {
+      return { pageType: "carte_sur_mesure", pageSlug: carteSlugMatch[1] }
+    }
+    if (pathname === "/carte" || pathname === "/carte/") {
+      return { pageType: "carte", pageSlug: "" }
+    }
+    if (pathname.startsWith("/formulaire")) {
+      return { pageType: "formulaire", pageSlug: "" }
+    }
+    return { pageType: "assistant", pageSlug: pathname.replace(/^\//, "") }
+  }
+
   // Fires iframe_page_viewed once when the parent page signals that this
   // iframe has entered the viewport (via postMessage from iframe_functions.ts).
   #setupViewportTracking() {
@@ -320,7 +335,7 @@ export default class extends Controller<HTMLElement> {
       if (event.source !== window.parent) return
       if (!event.data || event.data.type !== "iframe_in_viewport") return
       this.#iframePageViewedFired = true
-      this.capture("iframe_page_viewed")
+      this.capture("iframe_page_viewed", this.#iframePageProperties())
     })
   }
 
@@ -330,7 +345,7 @@ export default class extends Controller<HTMLElement> {
     const fireOnce = () => {
       if (this.#iframeInteractedFired) return
       this.#iframeInteractedFired = true
-      this.capture("interacted_with_iframe")
+      this.capture("interacted_with_iframe", this.#iframePageProperties())
     }
     document.body.addEventListener("mouseover", fireOnce, { once: true })
     document.body.addEventListener("touchstart", fireOnce, { once: true })

--- a/webapp/static/to_compile/controllers/shared/analytics.ts
+++ b/webapp/static/to_compile/controllers/shared/analytics.ts
@@ -63,7 +63,7 @@ export default class extends Controller<HTMLElement> {
     capture_pageview: true,
     capture_pageleave: true,
     person_profiles: "always",
-    persistence: "memory",
+    persistence: "sessionStorage",
   }
 
   // The user conversion score is computed from several actions : page views,
@@ -156,10 +156,11 @@ export default class extends Controller<HTMLElement> {
   }
 
   #registerSuperProperties() {
-    const { pageType } = this.#iframePageProperties()
+    const { pageType, pageSlug } = this.#iframePageProperties()
     posthog.register({
       isIframe: this.personProperties.iframe,
       outil: pageType,
+      pageSlug,
       ref: this.personProperties.iframeReferrer ?? null,
     })
   }
@@ -378,7 +379,7 @@ export default class extends Controller<HTMLElement> {
     if (pathname.startsWith("/infotri")) {
       return { pageType: "infotri", pageSlug: "" }
     }
-    return { pageType: "assistant", pageSlug: pathname.replace(/^\//, "") }
+    return { pageType: "quefaire", pageSlug: pathname.replace(/^\//, "") }
   }
 
   // Fires iframe_page_viewed once when the parent page signals that this

--- a/webapp/static/to_compile/controllers/shared/analytics.ts
+++ b/webapp/static/to_compile/controllers/shared/analytics.ts
@@ -86,6 +86,7 @@ export default class extends Controller<HTMLElement> {
     posthog.init(this.posthogKeyValue, this.posthogConfig)
     this.#identifyAuthenticatedUser()
     this.#initialiseIframeRelatedPersonProperties()
+    this.#registerSuperProperties()
     this.#syncSessionStorageWithLocalConversionScore()
     this.#setupIframeTracking()
     this.#computeConversionScoreFromSessionStorage()
@@ -137,6 +138,15 @@ export default class extends Controller<HTMLElement> {
         admin: this.userAdminValue,
       })
     }
+  }
+
+  #registerSuperProperties() {
+    const { pageType } = this.#iframePageProperties()
+    posthog.register({
+      isIframe: this.personProperties.iframe,
+      surface: pageType,
+      ref: this.personProperties.iframeReferrer ?? null,
+    })
   }
 
   // The iframe URL parameter is not always set :
@@ -307,6 +317,35 @@ export default class extends Controller<HTMLElement> {
     if (!this.personProperties.iframe) return
     this.#setupViewportTracking()
     this.#setupInteractionTracking()
+    this.#setupUtmLinks()
+  }
+
+  #setupUtmLinks() {
+    const decorate = (a: HTMLAnchorElement) => {
+      try {
+        const url = new URL(a.href, window.location.href)
+        if (url.hostname !== window.location.hostname) return
+        if (url.searchParams.has("utm_source")) return
+        url.searchParams.set("utm_source", "qfdmod")
+        a.href = url.toString()
+      } catch {
+        // malformed href — skip
+      }
+    }
+
+    document.querySelectorAll<HTMLAnchorElement>("a[href]").forEach(decorate)
+
+    new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        for (const node of mutation.addedNodes) {
+          if (node instanceof HTMLAnchorElement) {
+            decorate(node)
+          } else if (node instanceof Element) {
+            node.querySelectorAll<HTMLAnchorElement>("a[href]").forEach(decorate)
+          }
+        }
+      }
+    }).observe(document.body, { childList: true, subtree: true })
   }
 
   #iframePageProperties(): { pageType: string; pageSlug: string } {

--- a/webapp/static/to_compile/controllers/shared/analytics.ts
+++ b/webapp/static/to_compile/controllers/shared/analytics.ts
@@ -94,6 +94,14 @@ export default class extends Controller<HTMLElement> {
 
     posthog.debug(!!this.posthogDebugValue)
     this.#setupAutocompleteResultClickListener()
+    this.#setupActeurViewedListener()
+  }
+
+  #setupActeurViewedListener() {
+    this.element.addEventListener("acteur-details:viewed", (e: Event) => {
+      const { acteurUuid, acteurType, sources } = (e as CustomEvent).detail
+      this.capture("acteur_viewed", { acteurUuid, acteurType, sources })
+    })
   }
 
   userConversionScoreValueChanged(value) {

--- a/webapp/templates/ui/layout/base.html
+++ b/webapp/templates/ui/layout/base.html
@@ -51,7 +51,7 @@
         data-state-address-autocomplete-outlet="[data-controller='address-autocomplete']"
         data-state-map-outlet="[data-controller='map']"
         data-state-search-solution-form-outlet="[data-controller='search-solution-form']"
-        {% posthog_data_attributes CARTE.POSTHOG_KEY %}
+        {% posthog_data_attributes assistant.POSTHOG_KEY %}
         {% sentry_data_attributes %}
         data-action="address-autocomplete:change->state#setLocation"
         {% if STIMULUS_DEBUG %}data-stimulus-debug="true"{% endif %}

--- a/webapp/templates/ui/pages/acteur.html
+++ b/webapp/templates/ui/pages/acteur.html
@@ -17,7 +17,12 @@
     <turbo-frame
         id="{% acteur_frame_id %}"
     >
-        <article {% if turbo %}class='qf-animate-in qf-fade-in qf-duration-400'{% endif %}>
+        <article
+            {% if turbo %}class='qf-animate-in qf-fade-in qf-duration-400'{% endif %}
+            data-acteur-uuid="{{ object.uuid }}"
+            data-acteur-type="{{ object.acteur_type.code }}"
+            data-acteur-sources="{% for s in object.sources.all %}{{ s.code }}{% if not forloop.last %},{% endif %}{% endfor %}"
+        >
             <header class="qf-mb-2w">
                 <div class="qf-flex qf-flex-col qf-gap-1w">
                     {% acteur_label %}


### PR DESCRIPTION
# Description succincte du problème résolu

**🗺️ contexte** : le tracking PostHog était scindé en deux clés selon la page, ce qui empêchait d'avoir une vue unifiée du parcours utilisateur entre l'assistant et la carte.

**💡 quoi** : fusion des deux instances PostHog en une seule clé (assistant) et enrichissement des événements avec `pageType` et `pageSlug`

**🎯 pourquoi** : permettre de suivre le parcours complet d'un utilisateur (assistant puis carte) sur le même projet PostHog et différencier les types de pages (`carte`, `carte_sur_mesure`, `quefaire`) via des super-properties stables.

**🤔 comment** :

- Suppression de `CARTE_POSTHOG_KEY` (`.env.template`, `settings.py`, `context_processors.py`, `base.html`, `acteur.html`) et utilisation unique de la clé assistant.
- `analytics.ts` : `posthog.register()` des super-properties `pageType` / `pageSlug` calculées à partir du `pathname` (`/carte`, `/carte/<slug>`, autre).
- Suppression du `posthog.capture("object_input")` direct depuis `acteur_details.ts` et `ss_cat_object_autocomplete_controller.ts` au profit du contrôleur analytics partagé.
- Ajout des UTM cohérentes côté carte / assistant.
- Tests e2e : nouvelle suite t_18 dans `analytics.spec.ts` qui vérifie la présence et la valeur de `pageType` / `pageSlug` sur les événements iframe (`carte`, `carte_sur_mesure`, `assistant`).

**🤓 comment tester** :

1. `cd webapp && npm run build`.
2. `npx playwright test e2e_tests/analytics.spec.ts --project=chromium`.
3. En local, vérifier dans les events PostHog (network) que `pageType` et `pageSlug` sont bien présents sur la carte (`/carte`, `/carte/<slug>`) et l'assistant.

## Auto-review

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [x] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template` (suppression de `CARTE_POSTHOG_KEY`)
- [x] J'ai ajouté des tests qui couvrent le nouveau code (suite t_18)
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours (n/a)
