### PR TITLE
Corrige l'affichage dupliqué du nom dans les résultats de recherche (Vélovélo)

### DIFF
--- a/webapp/templates/ui/components/search/search_result_produitpage.html
+++ b/webapp/templates/ui/components/search/search_result_produitpage.html
@@ -4,4 +4,4 @@
 {% block href %}{% pageurl result.produit_page %}{% endblock %}
 {% block anchor_attrs %}data-search-term-name="{{ result.produit_page.titre_phrase|urlencode }}"{% endblock %}
 
-{% block nom %}{{ result.produit_page.titre_phrase|capfirst }}{{ result }}{% endblock %}
+{% block nom %}{{ result.produit_page.titre_phrase|capfirst }}{% endblock %}


### PR DESCRIPTION
# Description succincte du problème résolu

**🗺️ contexte** : régression introduite dans #2749 sur le template des résultats `ProduitPageSearchTerm` de l'autocomplete assistant.

**💡 quoi** : suppression du `{{ result }}` ajouté par erreur à côté de `titre_phrase` 

**🤓 comment tester** :

1. aller sur la page d'accueil de l'assistant.
2. Taper `velo` dans la barre de recherche : le premier résultat doit s'afficher "Vélo".

## Auto-review

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template` (n/a)
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours (n/a)
