### PR TITLE
Le pinpoint rouge (home) n'est plus pris en compte dans le calcul du fitBounds de la carte.

### DIFF
--- a/webapp/core/settings.py
+++ b/webapp/core/settings.py
@@ -168,6 +168,13 @@ CACHES = {
         "BACKEND": "django.core.cache.backends.db.DatabaseCache",
         "LOCATION": "qf_django_cache",
     },
+    # Per-process in-memory cache for hot, read-only reference data (the action
+    # / groupe_action catalog). DatabaseCache adds a SQL roundtrip on every
+    # `get_or_set`, which becomes an N+1 inside per-acteur loops.
+    "actions": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "actions",
+    },
 }
 
 X_FRAME_OPTIONS = "ALLOWALL"

--- a/webapp/core/test_settings.py
+++ b/webapp/core/test_settings.py
@@ -21,6 +21,11 @@ CACHES = {
     "database": {
         "BACKEND": "django.core.cache.backends.dummy.DummyCache",
     },
+    # Mirror the named cache from core.settings so callers using
+    # caches["actions"] don't fall over in tests.
+    "actions": {
+        "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+    },
 }
 
 STORAGES["default"]["BACKEND"] = "django.core.files.storage.InMemoryStorage"

--- a/webapp/e2e_tests/accessibility.spec.ts
+++ b/webapp/e2e_tests/accessibility.spec.ts
@@ -1,5 +1,5 @@
 import { AxeBuilder } from "@axe-core/playwright"
-import { test, expect } from "@playwright/test"
+import { test, expect, Page } from "@playwright/test"
 import { navigateTo } from "./helpers"
 
 test.describe("♿ Conformité Accessibilité WCAG", () => {
@@ -62,5 +62,593 @@ test.describe("♿ Conformité Accessibilité WCAG", () => {
 
       expect(accessibilityScanResults.violations).toEqual([])
     })
+  })
+
+  test.describe("Vérifications RGAA génériques", () => {
+    // -----------------------------------------------------------------------
+    // Routes représentatives utilisées pour les contrôles génériques.
+    // -----------------------------------------------------------------------
+    const ROUTES_PRINCIPALES = [
+      "/",
+      "/qui-sommes-nous/",
+      "/bonus-reparation/",
+      "/dechet/smartphone/",
+    ] as const
+
+    const ROUTES_SITES_FACILES = ["/qui-sommes-nous/", "/bonus-reparation/"] as const
+
+    const ROUTES_PRODUIT_SANS_FIL_ARIANE = [
+      "/categories/meubles/canape/",
+      "/dechet/smartphone/",
+    ] as const
+
+    // Lien vers le suivi des NCs RGAA encore ouvertes
+    const NOTION_BACKLOG_RGAA =
+      "https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a"
+
+    // -----------------------------------------------------------------------
+    // Petits utilitaires partagés (volontairement locaux à ce describe).
+    // -----------------------------------------------------------------------
+
+    /**
+     * Récupère la liste ordonnée des niveaux de titres du DOM (ex: [1, 2, 2, 3]).
+     */
+    async function getHeadingLevels(page: Page): Promise<number[]> {
+      return await page.evaluate(() => {
+        const headings = Array.from(
+          document.querySelectorAll("h1, h2, h3, h4, h5, h6"),
+        ) as HTMLElement[]
+        return headings
+          .filter((h) => {
+            // Ignore les titres masqués via aria-hidden, qui ne participent pas
+            // à la structure exposée aux technologies d'assistance.
+            const ariaHidden = h.closest('[aria-hidden="true"]')
+            return ariaHidden === null
+          })
+          .map((h) => parseInt(h.tagName.substring(1), 10))
+      })
+    }
+
+    /**
+     * Détecte le premier saut de niveau (ex: h1 -> h3 sans h2 intermédiaire).
+     * Retourne null si l'enchaînement est correct.
+     */
+    function findHeadingSkip(levels: number[]): { from: number; to: number } | null {
+      for (let i = 1; i < levels.length; i++) {
+        const previous = levels[i - 1]
+        const current = levels[i]
+        // On peut redescendre de plusieurs niveaux, mais on ne peut monter
+        // que d'un seul niveau à la fois.
+        if (current > previous + 1) {
+          return { from: previous, to: current }
+        }
+      }
+      return null
+    }
+
+    // -----------------------------------------------------------------------
+    // 1. Liens d'évitement (RGAA 12.7)
+    // -----------------------------------------------------------------------
+    for (const route of ROUTES_PRINCIPALES) {
+      test(`Liens d'évitement présents sur ${route} (RGAA 12.7)`, async ({ page }) => {
+        await navigateTo(page, route)
+        const skipLink = page.locator(
+          'nav[aria-label="Accès rapide"] a[href="#content"]',
+        )
+        await expect(skipLink).toBeAttached()
+      })
+    }
+
+    // -----------------------------------------------------------------------
+    // 2. Landmarks ARIA (RGAA 12.6)
+    // -----------------------------------------------------------------------
+    for (const route of ROUTES_PRINCIPALES) {
+      test(`Landmarks ARIA présents sur ${route} (RGAA 12.6)`, async ({ page }) => {
+        await navigateTo(page, route)
+
+        // Exactement un banner
+        const banners = page.locator('[role="banner"], header[role="banner"]')
+        await expect(banners).toHaveCount(1)
+
+        // Exactement un main (role="main" ou <main>)
+        const mains = page.locator('main, [role="main"]')
+        await expect(mains).toHaveCount(1)
+
+        // Au moins un <nav> avec un aria-label non vide
+        const navsWithLabel = page.locator("nav[aria-label]")
+        const labelledNavCount = await navsWithLabel.count()
+        expect(labelledNavCount).toBeGreaterThan(0)
+
+        // Vérifie qu'au moins un nav a un aria-label réellement renseigné
+        const labels = await navsWithLabel.evaluateAll((nodes) =>
+          nodes.map((n) => (n.getAttribute("aria-label") ?? "").trim()),
+        )
+        expect(labels.some((label) => label.length > 0)).toBe(true)
+      })
+    }
+
+    // -----------------------------------------------------------------------
+    // 3. Pied de page : au moins un <nav> (RGAA 9.2)
+    //    NC connue : actuellement aucun <nav> dans le footer en production.
+    //    Test marqué `test.fail()` pour suivre la régression sans bloquer la CI.
+    //    Voir [Backlog RGAA Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)
+    // -----------------------------------------------------------------------
+    test.fail(
+      "Le pied de page contient au moins un <nav> (RGAA 9.2)",
+      async ({ page }) => {
+        // NC connue : le footer DSFR n'expose pas encore de landmark <nav>.
+        // Lien : https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a
+        // Le test passera quand le footer aura été corrigé.
+        expect(NOTION_BACKLOG_RGAA).toBeTruthy()
+        await navigateTo(page, "/")
+        const footerNav = page.locator("footer nav")
+        await expect(footerNav.first()).toBeAttached()
+      },
+    )
+
+    // -----------------------------------------------------------------------
+    // 4. Fil d'Ariane (RGAA 7.1, 7.3, 12.2)
+    // -----------------------------------------------------------------------
+    for (const route of ROUTES_SITES_FACILES) {
+      test(`Fil d'Ariane présent et correct sur ${route} (RGAA 7.1, 7.3, 12.2)`, async ({
+        page,
+      }) => {
+        await navigateTo(page, route)
+
+        const breadcrumb = page
+          .locator('.fr-breadcrumb, nav[aria-label*="riane" i]')
+          .first()
+        await expect(breadcrumb).toBeAttached()
+
+        // Vérifie que le dernier item est :
+        //  - soit un <a> avec un href non nul
+        //  - soit marqué [aria-current="page"] et focusable (tabindex >= 0)
+        // ET qu'il porte aria-current="page"
+        const lastItemInfo = await breadcrumb.evaluate((node) => {
+          const items = Array.from(
+            node.querySelectorAll("li, .fr-breadcrumb__item"),
+          ) as HTMLElement[]
+          if (items.length === 0) return null
+          const last = items[items.length - 1]
+          const link = last.querySelector("a") as HTMLAnchorElement | null
+          const ariaCurrent =
+            last.getAttribute("aria-current") ??
+            link?.getAttribute("aria-current") ??
+            null
+          const href = link?.getAttribute("href") ?? null
+          const tabindexRaw =
+            last.getAttribute("tabindex") ?? link?.getAttribute("tabindex") ?? null
+          const tabindex = tabindexRaw === null ? null : parseInt(tabindexRaw, 10)
+          return { hasLink: !!link, href, ariaCurrent, tabindex }
+        })
+
+        expect(lastItemInfo).not.toBeNull()
+        expect(lastItemInfo!.ariaCurrent).toBe("page")
+
+        const isReachableViaLink =
+          lastItemInfo!.hasLink &&
+          lastItemInfo!.href !== null &&
+          lastItemInfo!.href.length > 0
+        const isReachableViaTabindex =
+          lastItemInfo!.tabindex === null || lastItemInfo!.tabindex >= 0
+        expect(isReachableViaLink || isReachableViaTabindex).toBe(true)
+      })
+    }
+
+    // -----------------------------------------------------------------------
+    // 4 bis. Fil d'Ariane manquant sur les pages produit (RGAA 12.2)
+    //        NC connue : ces gabarits n'embarquent pas encore de fil d'Ariane.
+    //        Voir [Backlog RGAA Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)
+    // -----------------------------------------------------------------------
+    for (const route of ROUTES_PRODUIT_SANS_FIL_ARIANE) {
+      test.fail(
+        `Fil d'Ariane présent sur ${route} (RGAA 12.2)`,
+        async ({ page }) => {
+          // NC connue : les gabarits produit (nouveau et ancien) ne contiennent
+          // pas de fil d'Ariane. Le test échoue volontairement tant que la NC
+          // n'est pas corrigée.
+          // Suivi : https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a
+          await navigateTo(page, route)
+          const breadcrumb = page.locator(
+            '.fr-breadcrumb, nav[aria-label*="riane" i]',
+          )
+          await expect(breadcrumb.first()).toBeAttached()
+        },
+      )
+    }
+
+    // -----------------------------------------------------------------------
+    // 5. Hiérarchie des titres (RGAA 9.1)
+    // -----------------------------------------------------------------------
+    for (const route of ROUTES_PRINCIPALES) {
+      test(`Hiérarchie des titres correcte sur ${route} (RGAA 9.1)`, async ({
+        page,
+      }) => {
+        await navigateTo(page, route)
+
+        // Exactement un <h1>
+        const h1Count = await page.locator("h1").count()
+        expect(h1Count, `${route} doit contenir exactement un <h1>`).toBe(1)
+
+        // Pas de saut de niveau dans la hiérarchie des titres
+        const levels = await getHeadingLevels(page)
+        const skip = findHeadingSkip(levels)
+        expect(
+          skip,
+          `${route} : saut de niveau détecté h${skip?.from} -> h${skip?.to} (séquence ${levels.join(",")})`,
+        ).toBeNull()
+      })
+    }
+
+    // -----------------------------------------------------------------------
+    // 6. Alternatives textuelles des images et SVG (RGAA 1.1)
+    // -----------------------------------------------------------------------
+    for (const route of ROUTES_PRINCIPALES) {
+      test(`Toutes les images et SVG ont une alternative textuelle sur ${route} (RGAA 1.1)`, async ({
+        page,
+      }) => {
+        await navigateTo(page, route)
+
+        const imagesSansAlternative = await page.evaluate(() => {
+          const offenders: string[] = []
+          const imgs = Array.from(document.querySelectorAll("img")) as HTMLImageElement[]
+          for (const img of imgs) {
+            const alt = img.getAttribute("alt")
+            const ariaHidden = img.getAttribute("aria-hidden") === "true"
+            // alt="" est valide (image décorative). alt absent ne l'est pas.
+            const hasAlt = alt !== null
+            if (!hasAlt && !ariaHidden) {
+              offenders.push(`<img src="${img.getAttribute("src") ?? ""}">`)
+            }
+          }
+          return offenders
+        })
+        expect(
+          imagesSansAlternative,
+          `Images sans alt ni aria-hidden : ${imagesSansAlternative.join(", ")}`,
+        ).toEqual([])
+
+        const svgsSansAlternative = await page.evaluate(() => {
+          const offenders: string[] = []
+          const svgs = Array.from(document.querySelectorAll("svg")) as SVGElement[]
+          for (const svg of svgs) {
+            const ariaHidden = svg.getAttribute("aria-hidden") === "true"
+            const ariaLabel = (svg.getAttribute("aria-label") ?? "").trim()
+            const ariaLabelledby = (
+              svg.getAttribute("aria-labelledby") ?? ""
+            ).trim()
+            const hasTitle = svg.querySelector("title") !== null
+            const hasRolePresentation =
+              svg.getAttribute("role") === "presentation" ||
+              svg.getAttribute("role") === "none"
+            if (
+              !ariaHidden &&
+              !ariaLabel &&
+              !ariaLabelledby &&
+              !hasTitle &&
+              !hasRolePresentation
+            ) {
+              const cls = svg.getAttribute("class") ?? ""
+              offenders.push(`<svg class="${cls}">`)
+            }
+          }
+          return offenders
+        })
+        expect(
+          svgsSansAlternative,
+          `SVG sans alternative : ${svgsSansAlternative.join(", ")}`,
+        ).toEqual([])
+      })
+    }
+
+    // -----------------------------------------------------------------------
+    // 7. Pas de tabindex="-1" sur <a>/<button> dans une boîte de dialogue
+    //    (RGAA 7.3 / 12.7) : garde-fou de non-régression.
+    // -----------------------------------------------------------------------
+    for (const route of ROUTES_PRINCIPALES) {
+      test(`Aucun <a>/<button> avec tabindex="-1" dans un dialog sur ${route} (RGAA 7.3)`, async ({
+        page,
+      }) => {
+        await navigateTo(page, route)
+
+        const offenders = await page.evaluate(() => {
+          const dialogs = Array.from(
+            document.querySelectorAll('dialog, [role="dialog"]'),
+          )
+          const out: string[] = []
+          for (const dlg of dialogs) {
+            const focusables = Array.from(
+              dlg.querySelectorAll('a[tabindex="-1"], button[tabindex="-1"]'),
+            )
+            for (const node of focusables) {
+              out.push(`${node.tagName.toLowerCase()} dans ${dlg.tagName.toLowerCase()}`)
+            }
+          }
+          return out
+        })
+        expect(offenders, `Éléments fautifs : ${offenders.join(", ")}`).toEqual([])
+      })
+    }
+
+    // -----------------------------------------------------------------------
+    // 8. Indicateur de focus visible sur les champs de formulaire (RGAA 10.7)
+    // -----------------------------------------------------------------------
+    test("Indicateur de focus visible sur les champs interactifs de la page d'accueil (RGAA 10.7)", async ({
+      page,
+    }) => {
+      await navigateTo(page, "/")
+
+      const interactiveSelectors =
+        'input:not([type="hidden"]):not([disabled]), select:not([disabled]), textarea:not([disabled])'
+      const handles = await page
+        .locator(interactiveSelectors)
+        .elementHandles()
+      const sample = handles.slice(0, 5)
+
+      // Aucun champ interactif sur la home : on évite un faux positif.
+      if (sample.length === 0) {
+        test.skip(true, "Aucun champ interactif sur la page d'accueil")
+        return
+      }
+
+      for (const handle of sample) {
+        // Un champ peut être en dehors du viewport (footer) ou non focusable :
+        // on tente le focus mais on tolère l'erreur, on vérifie ensuite l'état.
+        try {
+          await handle.focus()
+        } catch {
+          continue
+        }
+
+        const focusInfo = await handle.evaluate((node) => {
+          const el = node as HTMLElement
+          const style = window.getComputedStyle(el)
+          const outlineWidth = parseFloat(style.outlineWidth || "0")
+          const outlineStyle = style.outlineStyle
+          const boxShadow = style.boxShadow
+          return {
+            outlineWidth,
+            outlineStyle,
+            boxShadow,
+            tag: el.tagName.toLowerCase(),
+            name: (el as HTMLInputElement).name ?? "",
+          }
+        })
+
+        const hasOutline =
+          focusInfo.outlineStyle !== "none" && focusInfo.outlineWidth > 0
+        const hasBoxShadow =
+          focusInfo.boxShadow !== "none" && focusInfo.boxShadow.trim().length > 0
+
+        expect(
+          hasOutline || hasBoxShadow,
+          `Le champ <${focusInfo.tag} name="${focusInfo.name}"> n'a pas d'indicateur de focus visible (outline:${focusInfo.outlineStyle} ${focusInfo.outlineWidth}px, box-shadow:${focusInfo.boxShadow})`,
+        ).toBe(true)
+      }
+    })
+
+    // -----------------------------------------------------------------------
+    // 9. Ordre de tabulation : le premier focusable est le lien d'évitement
+    //    (RGAA 12.7 fonctionnel)
+    // -----------------------------------------------------------------------
+    test("Le premier élément focusable est le lien d'évitement \"Contenu\" (RGAA 12.7)", async ({
+      page,
+    }) => {
+      await navigateTo(page, "/")
+
+      // Pose le focus dans le <body> avant de presser Tab pour que le focus
+      // démarre bien depuis le tout début du document.
+      await page.evaluate(() => {
+        if (document.body) {
+          (document.body as HTMLBodyElement).focus()
+        }
+      })
+
+      await page.keyboard.press("Tab")
+
+      const focused = await page.evaluate(() => {
+        const el = document.activeElement as HTMLElement | null
+        if (!el) return null
+        return {
+          tag: el.tagName.toLowerCase(),
+          href: el.getAttribute("href"),
+          text: (el.textContent ?? "").trim(),
+        }
+      })
+      expect(focused).not.toBeNull()
+      expect(focused!.tag).toBe("a")
+      expect(focused!.href).toBe("#content")
+      expect(focused!.text.toLowerCase()).toContain("contenu")
+    })
+
+    // -----------------------------------------------------------------------
+    // 10. Titres d'iframes (RGAA 2.2)
+    // -----------------------------------------------------------------------
+    for (const route of ROUTES_PRINCIPALES) {
+      test(`Toutes les iframes ont un title non vide et distinct sur ${route} (RGAA 2.2)`, async ({
+        page,
+      }) => {
+        await navigateTo(page, route)
+
+        const titles = await page.evaluate(() => {
+          const iframes = Array.from(document.querySelectorAll("iframe"))
+          return iframes.map((f) => (f.getAttribute("title") ?? "").trim())
+        })
+
+        // Aucune iframe : pas de NC possible.
+        if (titles.length === 0) {
+          return
+        }
+
+        const empty = titles.filter((t) => t.length === 0)
+        expect(empty, `${empty.length} iframe(s) sans title`).toEqual([])
+
+        const seen = new Set<string>()
+        const duplicates: string[] = []
+        for (const t of titles) {
+          if (seen.has(t)) {
+            duplicates.push(t)
+          }
+          seen.add(t)
+        }
+        expect(
+          duplicates,
+          `Titres d'iframes en doublon : ${duplicates.join(", ")}`,
+        ).toEqual([])
+      })
+    }
+
+    // -----------------------------------------------------------------------
+    // 11. Étiquetage des champs de formulaire (RGAA 11.1)
+    // -----------------------------------------------------------------------
+    for (const route of ROUTES_PRINCIPALES) {
+      test(`Tous les champs de formulaire ont un libellé sur ${route} (RGAA 11.1)`, async ({
+        page,
+      }) => {
+        await navigateTo(page, route)
+
+        const offenders = await page.evaluate(() => {
+          const fields = Array.from(
+            document.querySelectorAll("input, select, textarea"),
+          ) as (HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement)[]
+          const ignoredTypes = new Set([
+            "hidden",
+            "button",
+            "submit",
+            "reset",
+            "image",
+          ])
+          const out: string[] = []
+          for (const field of fields) {
+            const type = (field.getAttribute("type") ?? "").toLowerCase()
+            if (ignoredTypes.has(type)) continue
+
+            const id = field.getAttribute("id")
+            const ariaLabel = (field.getAttribute("aria-label") ?? "").trim()
+            const ariaLabelledby = (
+              field.getAttribute("aria-labelledby") ?? ""
+            ).trim()
+
+            // <label> associé via for=id
+            let labelled = false
+            if (id) {
+              const escapedId = (window as any).CSS?.escape
+                ? (window as any).CSS.escape(id)
+                : id.replace(/"/g, '\\"')
+              if (document.querySelector(`label[for="${escapedId}"]`)) {
+                labelled = true
+              }
+            }
+            // <label> englobant
+            if (!labelled && field.closest("label")) {
+              labelled = true
+            }
+            // aria-label
+            if (!labelled && ariaLabel.length > 0) {
+              labelled = true
+            }
+            // aria-labelledby pointant vers un élément existant
+            if (!labelled && ariaLabelledby.length > 0) {
+              const ids = ariaLabelledby.split(/\s+/).filter(Boolean)
+              const allFound = ids.every((refId) =>
+                document.getElementById(refId) !== null,
+              )
+              if (allFound) labelled = true
+            }
+            // <fieldset><legend> (cas des radios/checkbox groupées)
+            if (!labelled && (type === "radio" || type === "checkbox")) {
+              const fs = field.closest("fieldset")
+              if (fs && fs.querySelector("legend")) {
+                labelled = true
+              }
+            }
+
+            if (!labelled) {
+              out.push(
+                `<${field.tagName.toLowerCase()} type="${type}" name="${field.getAttribute("name") ?? ""}" id="${id ?? ""}">`,
+              )
+            }
+          }
+          return out
+        })
+
+        expect(
+          offenders,
+          `Champs sans libellé accessible : ${offenders.join(" | ")}`,
+        ).toEqual([])
+      })
+    }
+
+    // -----------------------------------------------------------------------
+    // 12. Liens externes : indication "nouvelle fenêtre" (RGAA 13.x / 10.2)
+    // -----------------------------------------------------------------------
+    for (const route of ROUTES_PRINCIPALES) {
+      test(`Les liens target=_blank indiquent une nouvelle fenêtre sur ${route} (RGAA 13.x)`, async ({
+        page,
+      }) => {
+        await navigateTo(page, route)
+
+        const offenders = await page.evaluate(() => {
+          const out: string[] = []
+          const anchors = Array.from(
+            document.querySelectorAll('a[target="_blank"]'),
+          ) as HTMLAnchorElement[]
+          for (const a of anchors) {
+            // On agrège le texte visible + aria-label + title, en français.
+            const visible = (a.textContent ?? "").toLowerCase()
+            const ariaLabel = (a.getAttribute("aria-label") ?? "").toLowerCase()
+            const title = (a.getAttribute("title") ?? "").toLowerCase()
+            const haystack = `${visible} ${ariaLabel} ${title}`
+            if (!haystack.includes("nouvelle fenêtre")) {
+              out.push(a.getAttribute("href") ?? "(no href)")
+            }
+          }
+          return out
+        })
+
+        expect(
+          offenders,
+          `Liens externes sans mention "nouvelle fenêtre" : ${offenders.join(", ")}`,
+        ).toEqual([])
+      })
+    }
+
+    // -----------------------------------------------------------------------
+    // 13. Sweep axe sur le nouveau gabarit produit (post-audit mai 2025)
+    // -----------------------------------------------------------------------
+    test("Le nouveau gabarit produit /categories/meubles/canape/ respecte WCAG 2.1 AA", async ({
+      page,
+    }) => {
+      await navigateTo(page, "/categories/meubles/canape/")
+
+      const accessibilityScanResults = await new AxeBuilder({ page })
+        .exclude("[data-disable-axe]")
+        .exclude('iframe[src*="impactco2.fr"]')
+        .withTags(WCAG_TAGS)
+        .analyze()
+
+      expect(accessibilityScanResults.violations).toEqual([])
+    })
+
+    // -----------------------------------------------------------------------
+    // 14. Sweep axe sur les pages Sites Faciles les plus visitées
+    // -----------------------------------------------------------------------
+    for (const route of ROUTES_SITES_FACILES) {
+      test(`La page Sites Faciles ${route} respecte WCAG 2.1 AA`, async ({
+        page,
+      }) => {
+        await navigateTo(page, route)
+
+        const accessibilityScanResults = await new AxeBuilder({ page })
+          .exclude("[data-disable-axe]")
+          .exclude('iframe[src*="impactco2.fr"]')
+          .exclude('iframe[src*="youtube.com"]')
+          .exclude('iframe[src*="youtube-nocookie.com"]')
+          .withTags(WCAG_TAGS)
+          .analyze()
+
+        expect(accessibilityScanResults.violations).toEqual([])
+      })
+    }
   })
 })

--- a/webapp/e2e_tests/carte.spec.ts
+++ b/webapp/e2e_tests/carte.spec.ts
@@ -437,6 +437,80 @@ test.describe("🗺️ Bouton 'Rechercher dans cette zone'", () => {
     // The button should be hidden again after clicking
     await expect(searchInZoneButton).toHaveClass(/qf-hidden/)
   })
+
+  test("Le home pinpoint n'est pas inclus dans le fitBounds après une recherche", async ({
+    page,
+  }) => {
+    await navigateTo(page, "/carte")
+    await mockApiAdresse(page)
+    await searchForAuray(page)
+
+    // Wait for markers to be attached
+    const acteurMarkers = page.locator(
+      '.maplibregl-marker[data-controller="pinpoint"]:not(#pinpoint-home)',
+    )
+    await expect(acteurMarkers.first()).toBeAttached({ timeout: TIMEOUT.LONG })
+    await page.waitForTimeout(2000)
+
+    // Read the map bounds and the home marker position
+    const mapInfo = await page.evaluate(() => {
+      const mapElement = document.querySelector('[data-controller*="map"]') as any
+      const map = mapElement?.actorsMap?.map
+      if (!map) return null
+      const bounds = map.getBounds()
+      const homeEl = document.getElementById("pinpoint-home") as HTMLElement | null
+      const transform = homeEl?.style.transform ?? ""
+      const markers = Array.from(
+        document.querySelectorAll(
+          '.maplibregl-marker[data-controller="pinpoint"]:not(#pinpoint-home)',
+        ),
+      ).length
+      return {
+        sw: { lat: bounds.getSouthWest().lat, lng: bounds.getSouthWest().lng },
+        ne: { lat: bounds.getNorthEast().lat, lng: bounds.getNorthEast().lng },
+        homeTransform: transform,
+        markers,
+      }
+    })
+
+    expect(mapInfo).not.toBeNull()
+    expect(mapInfo!.markers).toBeGreaterThan(0)
+
+    // Simulate the "search in zone" scenario: move the map far from the searched
+    // address, then confirm that when the map is fit again its bounds are based
+    // on the new zone only. We do this by programmatically fitting to a
+    // bbox far from Auray and checking the map center moves away from the
+    // home marker's coordinates without snapping back.
+    const afterMove = await page.evaluate(() => {
+      const mapElement = document.querySelector('[data-controller*="map"]') as any
+      const solutionMap = mapElement?.actorsMap
+      if (!solutionMap) return null
+
+      // Noirmoutier bbox (far from Auray)
+      const farBbox = {
+        southWest: { lat: 46.95, lng: -2.3 },
+        northEast: { lat: 47.05, lng: -2.15 },
+      }
+      solutionMap.fitBounds(solutionMap.points, farBbox)
+      const bounds = solutionMap.map.getBounds()
+      return {
+        sw: { lat: bounds.getSouthWest().lat, lng: bounds.getSouthWest().lng },
+        ne: { lat: bounds.getNorthEast().lat, lng: bounds.getNorthEast().lng },
+      }
+    })
+
+    expect(afterMove).not.toBeNull()
+    // When a bbox is provided, the map fits to that bbox only; the old home
+    // point at Auray (~47.66N, -2.99E) must not be inside the new bounds.
+    const aurayLat = 47.668099
+    const aurayLng = -2.990838
+    const inBounds =
+      aurayLat >= afterMove!.sw.lat &&
+      aurayLat <= afterMove!.ne.lat &&
+      aurayLng >= afterMove!.sw.lng &&
+      aurayLng <= afterMove!.ne.lng
+    expect(inBounds).toBe(false)
+  })
 })
 
 test.describe("🗺️ CarteConfig Bounding Box", () => {

--- a/webapp/e2e_tests/carte.spec.ts
+++ b/webapp/e2e_tests/carte.spec.ts
@@ -445,31 +445,26 @@ test.describe("🗺️ Bouton 'Rechercher dans cette zone'", () => {
     await mockApiAdresse(page)
     await searchForAuray(page)
 
-    // Wait for markers to be attached
-    const acteurMarkers = page.locator(
-      '.maplibregl-marker[data-controller="pinpoint"]:not(#pinpoint-home)',
-    )
-    await expect(acteurMarkers.first()).toBeAttached({ timeout: TIMEOUT.LONG })
+    // searchForAuray already waits until at least one acteur feature is on the
+    // GeoJSON symbol layer, so we can read the map state immediately.
     await page.waitForTimeout(2000)
 
     // Read the map bounds and the home marker position
     const mapInfo = await page.evaluate(() => {
-      const mapElement = document.querySelector('[data-controller*="map"]') as any
-      const map = mapElement?.actorsMap?.map
+      const ctrl = (window as any).stimulus?.getControllerForElementAndIdentifier(
+        document.querySelector('[data-controller~="map"]'),
+        "map",
+      )
+      const map = ctrl?.actorsMap?.map
       if (!map) return null
       const bounds = map.getBounds()
       const homeEl = document.getElementById("pinpoint-home") as HTMLElement | null
       const transform = homeEl?.style.transform ?? ""
-      const markers = Array.from(
-        document.querySelectorAll(
-          '.maplibregl-marker[data-controller="pinpoint"]:not(#pinpoint-home)',
-        ),
-      ).length
       return {
         sw: { lat: bounds.getSouthWest().lat, lng: bounds.getSouthWest().lng },
         ne: { lat: bounds.getNorthEast().lat, lng: bounds.getNorthEast().lng },
         homeTransform: transform,
-        markers,
+        markers: ctrl?.actorsMap?.displayedUuids?.size ?? 0,
       }
     })
 
@@ -482,8 +477,11 @@ test.describe("🗺️ Bouton 'Rechercher dans cette zone'", () => {
     // bbox far from Auray and checking the map center moves away from the
     // home marker's coordinates without snapping back.
     const afterMove = await page.evaluate(() => {
-      const mapElement = document.querySelector('[data-controller*="map"]') as any
-      const solutionMap = mapElement?.actorsMap
+      const ctrl = (window as any).stimulus?.getControllerForElementAndIdentifier(
+        document.querySelector('[data-controller~="map"]'),
+        "map",
+      )
+      const solutionMap = ctrl?.actorsMap
       if (!solutionMap) return null
 
       // Noirmoutier bbox (far from Auray)

--- a/webapp/e2e_tests/carte_geojson_flow.spec.ts
+++ b/webapp/e2e_tests/carte_geojson_flow.spec.ts
@@ -1,0 +1,147 @@
+import { expect } from "@playwright/test"
+import { test } from "./fixtures"
+import {
+  mockApiAdresse,
+  navigateTo,
+  searchForAuray,
+  TIMEOUT,
+} from "./helpers"
+
+test.describe("🗺️ GeoJSON acteur layer (post-migration flow)", () => {
+  test(
+    "Searching a municipality fetches /carte/acteurs.geojson and renders markers",
+    async ({ page }) => {
+      await navigateTo(page, "/carte")
+      await mockApiAdresse(page)
+
+      const geojsonResponsePromise = page.waitForResponse(
+        (r) =>
+          r.url().includes("/carte/acteurs.geojson") &&
+          r.status() === 200,
+        { timeout: TIMEOUT.LONG },
+      )
+
+      await searchForAuray(page)
+      const geojsonResponse = await geojsonResponsePromise
+
+      const url = new URL(geojsonResponse.url())
+      expect(url.searchParams.get("bbox")).toBeTruthy()
+      expect(url.searchParams.get("zoom")).toBeTruthy()
+
+      const payload = await geojsonResponse.json()
+      expect(payload.type).toBe("FeatureCollection")
+      expect(Array.isArray(payload.features)).toBe(true)
+      expect(typeof payload.truncated).toBe("boolean")
+    },
+  )
+
+  test(
+    "Municipality search fetches the commune polygon proxy and persists the citycode in sessionStorage",
+    async ({ page }) => {
+      await navigateTo(page, "/carte")
+      await mockApiAdresse(page)
+
+      // Auray's INSEE citycode is 56007 (see mockApiAdresse fixture).
+      const polygonPromise = page.waitForResponse(
+        (r) =>
+          r.url().includes("/carte/communes/56007") && r.status() === 200,
+        { timeout: TIMEOUT.LONG },
+      )
+
+      await searchForAuray(page)
+      await polygonPromise
+
+      const citycode = await page.evaluate(() =>
+        sessionStorage.getItem("citycode"),
+      )
+      expect(citycode).toBe("56007")
+
+      const hiddenInputValue = await page
+        .locator('input[name$="-search_area_citycode"]')
+        .first()
+        .inputValue()
+      expect(hiddenInputValue).toBe("56007")
+    },
+  )
+
+  test(
+    "Reload after a municipality search restores the citycode hidden input from sessionStorage",
+    async ({ page }) => {
+      await navigateTo(page, "/carte")
+      await mockApiAdresse(page)
+      await searchForAuray(page)
+
+      // Confirm citycode landed in sessionStorage as a precondition.
+      await expect
+        .poll(async () => page.evaluate(() => sessionStorage.getItem("citycode")))
+        .toBe("56007")
+
+      // Full reload: wipes JS state but sessionStorage survives.
+      await page.reload()
+
+      // The hidden form field should rehydrate from sessionStorage by the
+      // assistant `state` controller's `updateUIFromGlobalState`.
+      await expect(
+        page.locator('input[name$="-search_area_citycode"]').first(),
+      ).toHaveValue("56007", { timeout: TIMEOUT.LONG })
+    },
+  )
+
+  test(
+    "Picking a non-municipality address fires the KNN endpoint instead of the bbox one",
+    async ({ page }) => {
+      await navigateTo(page, "/carte")
+      await mockApiAdresse(page)
+
+      // Listen for the KNN call BEFORE clicking the autocomplete option, so
+      // we don't race the post-Turbo-swap fetch. The street-typed BAN result
+      // routes through /carte/acteurs-near.geojson (KNN), not the bbox one.
+      const knnPromise = page.waitForResponse(
+        (r) =>
+          r.url().includes("/carte/acteurs-near.geojson") &&
+          r.status() === 200,
+        { timeout: TIMEOUT.LONG },
+      )
+
+      // Type a fragment that surfaces street-typed suggestions, then pick the
+      // "Avenue d'Auray … Nantes" entry (type=street in the mock).
+      const inputLocator = page.locator('[data-testid="carte-adresse-input"]')
+      await inputLocator.click()
+      await inputLocator.clear()
+      await inputLocator.pressSequentially("Auray", { delay: 30 })
+
+      const streetOption = page
+        .locator(
+          ".autocomplete-items div[data-action*='address-autocomplete#selectOption']",
+        )
+        .filter({ hasText: "Avenue d'Auray" })
+        .first()
+      await expect(streetOption).toBeVisible({ timeout: TIMEOUT.DEFAULT })
+      await streetOption.click()
+
+      const knnResponse = await knnPromise
+      const knnUrl = new URL(knnResponse.url())
+      expect(knnUrl.searchParams.get("lat")).toBeTruthy()
+      expect(knnUrl.searchParams.get("lng")).toBeTruthy()
+    },
+  )
+
+  test(
+    "Cap and truncated flag are honored by the bbox endpoint",
+    async ({ page }) => {
+      await navigateTo(page, "/carte")
+
+      // Hit the endpoint directly with a wide France-wide bbox at a high zoom
+      // to force the 200-feature cap + truncation flag.
+      const r = await page.request.get(
+        "/carte/acteurs.geojson?bbox=-5.5,41.0,9.5,51.5&zoom=13",
+      )
+      expect(r.status()).toBe(200)
+      const payload = await r.json()
+      expect(payload.features.length).toBeLessThanOrEqual(200)
+      // At France-wide zoom 13 there are vastly more than 200 acteurs, so the
+      // response should advertise truncation.
+      expect(payload.truncated).toBe(true)
+    },
+  )
+})

--- a/webapp/e2e_tests/helpers.ts
+++ b/webapp/e2e_tests/helpers.ts
@@ -107,24 +107,13 @@ export async function searchAddress(
 /**
  * Search for an address in the carte and wait until acteur markers are ready.
  *
- * This is the preferred way to trigger an address search in carte tests because
- * it waits for the right network signal instead of polling the loading spinner:
- *
- * 1. Types the address text into the autocomplete input
- * 2. Registers a response listener BEFORE clicking (avoids race conditions)
- * 3. Clicks the matching suggestion → triggers a Turbo Frame fetch to /carte
- * 4. Awaits the fetch response (identified by the Turbo-Frame request header)
- * 5. Waits for MapLibre to attach .maplibregl-marker to the pinpoint elements
- *
- * Live-confirmed behavior (Playwright MCP exploration):
- * - Selecting an address sends `Turbo-Frame: <map_container_id>` in the request
- * - The response HTML (~365 KB) contains the acteur pinpoints
- * - MapLibre adds .maplibregl-marker directly to each <a data-controller="pinpoint">
- *
- * @param page       - The Playwright Page (used for network interception)
- * @param searchText - Address text to type (e.g. "Auray")
- * @param context    - DOM context for locators: either the Page or an iframe FrameLocator
- * @param options    - parentSelector / parentLocator to scope the input locator
+ * Flow (post-GeoJSON-layer migration):
+ * 1. Types the address text into the autocomplete input.
+ * 2. Awaits the Turbo Frame response that re-renders the carte for the new
+ *    address (identified by the Turbo-Frame request header).
+ * 3. Awaits the GeoJSON fetch fired by the freshly-mounted MapController to
+ *    populate the symbol layer with acteurs.
+ * 4. Confirms at least one acteur feature is rendered on the layer.
  */
 export async function searchCarteAndWaitForActeurs(
   page: Page,
@@ -139,7 +128,6 @@ export async function searchCarteAndWaitForActeurs(
   const autocompleteSelector =
     ".autocomplete-items div[data-action*='address-autocomplete#selectOption']"
 
-  // Build the input locator, respecting optional parent scoping
   const inputLocator = options.parentLocator
     ? options.parentLocator.locator(inputSelector)
     : options.parentSelector
@@ -150,7 +138,6 @@ export async function searchCarteAndWaitForActeurs(
   await inputLocator.clear()
   await inputLocator.pressSequentially(searchText, { delay: 30 })
 
-  // Wait for the autocomplete suggestion containing the search text
   const autocompleteLocator = options.parentLocator
     ? options.parentLocator.locator(autocompleteSelector)
     : options.parentSelector
@@ -160,15 +147,15 @@ export async function searchCarteAndWaitForActeurs(
   const optionWithText = autocompleteLocator.filter({ hasText: searchText })
   await expect(optionWithText.first()).toBeVisible({ timeout: TIMEOUT.DEFAULT })
 
-  // Register the network listener BEFORE clicking to avoid a race condition.
-  // The click triggers a Turbo Frame fetch to /carte.
-  // We identify the right response by the presence of the Turbo-Frame request header
-  // (its value is the map_container_id, e.g. "carte" or a custom id for embedded maps).
+  // Register both response listeners BEFORE clicking. The click triggers two
+  // sequential network calls: the Turbo Frame re-render of /carte, then the
+  // GeoJSON fetch from the newly-mounted MapController.
   const carteResponsePromise = page.waitForResponse(
     (response) => {
       const turboFrame = response.request().headers()["turbo-frame"]
       return (
         response.url().includes("/carte") &&
+        !response.url().includes("/carte/acteurs.geojson") &&
         turboFrame !== undefined &&
         turboFrame !== "" &&
         response.status() === 200
@@ -176,17 +163,30 @@ export async function searchCarteAndWaitForActeurs(
     },
     { timeout: TIMEOUT.LONG },
   )
+  const geojsonResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes("/carte/acteurs.geojson") && response.status() === 200,
+    { timeout: TIMEOUT.LONG },
+  )
 
   await optionWithText.first().click()
   await carteResponsePromise
+  await geojsonResponsePromise
 
-  // Wait for MapLibre to attach .maplibregl-marker to the pinpoint <a> elements.
-  // This class is added by MapLibre after reading the rendered Turbo Frame HTML,
-  // and signals that the markers are positioned on the map and ready to be clicked.
-  const acteurMarkers = context.locator(
-    '.maplibregl-marker[data-controller="pinpoint"]:not(#pinpoint-home)',
-  )
-  await expect(acteurMarkers.first()).toBeAttached({ timeout: TIMEOUT.LONG })
+  // Verify at least one acteur feature has been rendered on the symbol layer.
+  await expect
+    .poll(
+      async () =>
+        await context.locator(":root").evaluate(() => {
+          const ctrl = (window as any).stimulus?.getControllerForElementAndIdentifier(
+            document.querySelector('[data-controller~="map"]'),
+            "map",
+          )
+          return ctrl?.actorsMap?.displayedUuids?.size ?? 0
+        }),
+      { timeout: TIMEOUT.LONG },
+    )
+    .toBeGreaterThan(0)
 }
 
 /**
@@ -603,61 +603,61 @@ export async function moveMap(
 }
 
 /**
- * Click on the first acteur marker that is not obstructed by other elements.
- * Cycles through markers and attempts to click each one until successful.
- * Excludes the home marker (#pinpoint-home) which often overlaps acteur markers.
- *
- * For iframe contexts, if all normal clicks fail, falls back to using
- * dispatchEvent on the actual link element inside the marker.
+ * Click on the first acteur on the MapLibre symbol layer and wait for the
+ * detail panel to open. Synthesizes a `click` event on the layer through the
+ * MapLibre API since the symbols are painted on a WebGL canvas and aren't
+ * directly clickable through Playwright's element-level click API.
  */
 export async function clickFirstClickableActeurMarker(
   context: Page | FrameLocator,
-  options: { timeout?: number } = {},
+  // Kept for backward compatibility with callers that still pass options.
+  _options: { timeout?: number } = {},
 ) {
-  const { timeout = 2500 } = options
+  // locator(":root").evaluate works for both Page and FrameLocator;
+  // FrameLocator has no .evaluate of its own.
+  await context.locator(":root").evaluate(() => {
+    const ctrl = (window as any).stimulus?.getControllerForElementAndIdentifier(
+      document.querySelector('[data-controller~="map"]'),
+      "map",
+    )
+    const map = ctrl?.actorsMap?.map
+    if (!map) throw new Error("map controller not mounted")
+    const features = map.queryRenderedFeatures(undefined, {
+      layers: ["acteurs-layer"],
+    })
+    if (features.length === 0) throw new Error("no acteur features on the layer")
+    const feature = features[0]
+    const lngLat = feature.geometry.coordinates as [number, number]
+    const point = map.project({ lng: lngLat[0], lat: lngLat[1] })
+    map.fire("click", {
+      point,
+      lngLat: map.unproject(point),
+      originalEvent: new MouseEvent("click"),
+    })
+  })
 
-  // Select markers that contain a pinpoint controller link (not the home marker)
-  const acteurMarkers = context.locator(
-    '.maplibregl-marker[data-controller="pinpoint"]:not(#pinpoint-home)',
-  )
-
-  // Wait for at least one marker to appear before attempting clicks
-  await expect(acteurMarkers.first()).toBeVisible({ timeout: TIMEOUT.LONG })
-
-  const count = await acteurMarkers.count()
-
-  // We start from the end to ensure markers are not too close to each other
-  // because this could be harder for playwright to click
-  for (let i = count; i > 0; i--) {
-    const marker = acteurMarkers.nth(i)
-    try {
-      // Try to click without force - this will fail if element is obstructed
-      await marker.click({ timeout })
-      await expect(context.locator("#acteurDetailsPanel")).toHaveAttribute(
-        "aria-hidden",
-        "false",
-        { timeout: TIMEOUT.DEFAULT },
-      )
-      return // Success - exit the function
-    } catch {
-      // This marker is obstructed, try the next one
-      continue
-    }
-  }
-
-  // If all markers failed with normal click, try using evaluate to trigger click
-  // This is a fallback for iframe contexts where overlay detection may fail
-  const firstLink = context
-    .locator('[data-controller="pinpoint"]:not(#pinpoint-home)')
-    .first()
-
-  // Use evaluate to trigger a proper click event that will go through event handlers
-  await firstLink.evaluate((el: HTMLElement) => el.click())
   await expect(context.locator("#acteurDetailsPanel")).toHaveAttribute(
     "aria-hidden",
     "false",
     { timeout: TIMEOUT.DEFAULT },
   )
+}
+
+/**
+ * Returns how many acteur features are currently rendered on the carte's
+ * MapLibre symbol layer (post-GeoJSON-layer migration). Excludes the home
+ * marker, which is rendered separately as a DOM element.
+ */
+export async function countActeurFeaturesOnLayer(
+  context: Page | FrameLocator,
+): Promise<number> {
+  return await context.locator(":root").evaluate(() => {
+    const ctrl = (window as any).stimulus?.getControllerForElementAndIdentifier(
+      document.querySelector('[data-controller~="map"]'),
+      "map",
+    )
+    return ctrl?.actorsMap?.displayedUuids?.size ?? 0
+  })
 }
 
 /**

--- a/webapp/previews/template_preview.py
+++ b/webapp/previews/template_preview.py
@@ -1047,14 +1047,72 @@ class IframePreview(LookbookPreview):
 
 
 class AccessibilitePreview(LookbookPreview):
+    """
+    Backlog RGAA — une preview par ticket auditeur.
+
+    Convention de nommage :
+    `<page_code>_<critere_rgaa>` avec les points remplacés par des underscores.
+    Quand un ticket couvre plusieurs critères inséparables (ex. 7.1 + 7.3 sur
+    le breadcrumb), on utilise un double underscore comme séparateur :
+    `P02_7_1__P02_7_3`.
+    Quand un ticket couvre plusieurs pages avec le même critère, on regroupe
+    les codes pages dans le nom : `P05_10_2__P06_10_2`.
+
+    Chaque preview est associée à un fichier markdown
+    `templates/ui/components/accessibilite/<NAME>.md` qui contient le retour
+    auditeur verbatim, le correctif recommandé, le scope (Webapp Django /
+    Sites Faciles CMS / Carte iframe / Mixte) et un lien vers le ticket Notion.
+
+    Quand la vérification implique plusieurs landmarks (header + main + footer)
+    ou un comportement difficile à isoler, la preview embarque la page dans un
+    `<iframe>` plutôt que de tout re-rendre côté Django, pour rester légère.
+    """
+
+    # ---------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------
+
+    @staticmethod
+    def _iframe(src, title, height=600):
+        """Render a full-width iframe pointing at a live URL."""
+        return Template(
+            f"""
+            <iframe
+                src="{src}"
+                title="{title}"
+                style="width:100%;height:{height}px;border:1px solid #ddd;"
+                loading="lazy"
+            ></iframe>
+            """,
+        ).render(Context({}))
+
+    # ---------------------------------------------------------------------
+    # Existing entries
+    # ---------------------------------------------------------------------
+
     @component_docs("ui/components/accessibilite/P01_7_3.md")
     def P01_7_3(self, **kwargs):
-        return render_to_string("ui/modals/share.html")
+        return render_to_string("ui/components/modals/share.html")
 
     @component_docs("ui/components/accessibilite/P01_3_3.md")
     def P01_3_3(self, **kwargs):
-        context = {"search_form": QfSearchForm()}
-        return render_to_string("ui/components/search/view.html", context)
+        legacy = render_to_string(
+            "ui/components/search/view.html",
+            {"search_form": QfSearchForm()},
+        )
+        header_dsfr = render_to_string(
+            "ui/components/header/header.html",
+            {"request": None, "iframe": False},
+        )
+        return Template(
+            """
+            <h2 class="fr-h3">Ancien composant — ui/components/search/view.html</h2>
+            {{ legacy|safe }}
+            <hr class="fr-mt-3w fr-mb-3w">
+            <h2 class="fr-h3">Nouveau composant — recherche du header DSFR</h2>
+            {{ header_dsfr|safe }}
+            """,
+        ).render(Context({"legacy": legacy, "header_dsfr": header_dsfr}))
 
     @component_docs("ui/components/accessibilite/P01_10_2.md")
     def P01_10_2(self, **kwargs):
@@ -1095,6 +1153,401 @@ class AccessibilitePreview(LookbookPreview):
         return render_to_string(
             "sites_conformes_content_manager/blocks/breadcrumbs.html",
             context,
+        )
+
+    # ---------------------------------------------------------------------
+    # New tickets (RGAA backlog)
+    # ---------------------------------------------------------------------
+
+    @component_docs("ui/components/accessibilite/P01_1_2.md")
+    def P01_1_2(self, **kwargs):
+        """Images décoratives sans aria-hidden (header + hero homepage)."""
+        return self._iframe(
+            "https://quefairedemesdechets.ademe.fr/",
+            "Accueil — vérification des images décoratives (P01 1.2)",
+            height=700,
+        )
+
+    @component_docs("ui/components/accessibilite/P08_1_2.md")
+    def P08_1_2(self, **kwargs):
+        """Alt trop long sur l'image bonus + pictos non décoratifs."""
+        return self._iframe(
+            "https://quefairedemesdechets.ademe.fr/bonus-reparation",
+            "Bonus réparation — image et pictos (P08 1.2)",
+            height=700,
+        )
+
+    @component_docs("ui/components/accessibilite/P09_1_8.md")
+    def P09_1_8(self, **kwargs):
+        """Image-texte fast fashion sur la page produit."""
+        return self._iframe(
+            "https://quefairedemesdechets.ademe.fr/dechet/manteau/",
+            "Produit manteau — image-texte fast fashion (P09 1.8)",
+            height=800,
+        )
+
+    @component_docs("ui/components/accessibilite/P07_2_2__P08_2_2__P09_2_2.md")
+    def P07_2_2__P08_2_2__P09_2_2(self, **kwargs):
+        """Titres iframes carte / vidéo non descriptifs (multi-pages)."""
+        return Template(
+            """
+            <h2 class="fr-h3">P07 — iframe carte sur "Comment ça marche"</h2>
+            <iframe src="https://quefairedemesdechets.ademe.fr/static/carte.js" title="iframe"
+                    style="width:100%;height:200px;border:1px dashed #c00;"></iframe>
+            <p class="fr-text--sm"><em>Titre observé : "iframe" (générique). Recommandation :
+            "Carte des points de collecte près de chez moi".</em></p>
+            <hr>
+            <h2 class="fr-h3">P08 — iframe carte bonus-réparation</h2>
+            <iframe src="about:blank" title="iframe"
+                    style="width:100%;height:200px;border:1px dashed #c00;"></iframe>
+            <p class="fr-text--sm"><em>Recommandation : "Carte des artisans labellisés bonus
+            réparation".</em></p>
+            <hr>
+            <h2 class="fr-h3">P09 — iframe vidéo Consomag sur la page produit</h2>
+            <iframe src="about:blank" title="iframe"
+                    style="width:100%;height:200px;border:1px dashed #c00;"></iframe>
+            <p class="fr-text--sm"><em>Recommandation : "Vidéo Consomag — Que faire de mes
+            objets et déchets ?".</em></p>
+            """,
+        ).render(Context({}))
+
+    @component_docs("ui/components/accessibilite/P06_4_1__P06_4_3.md")
+    def P06_4_1__P06_4_3(self, **kwargs):
+        """Vidéo Consomag : transcription + sous-titres (page comment-ça-marche)."""
+        return Template(
+            """
+            <iframe
+                width="100%"
+                height="500"
+                src="https://www.youtube.com/embed/4f2Zky4xZdE"
+                title="Vidéo Consomag — Que faire de mes objets et déchets ?"
+                frameborder="0"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowfullscreen
+            ></iframe>
+            <p class="fr-mt-2w">
+                Voir la transcription complète et la liste des sous-titres à corriger
+                dans le markdown associé.
+            </p>
+            """,
+        ).render(Context({}))
+
+    @component_docs("ui/components/accessibilite/P01_6_1.md")
+    def P01_6_1(self, **kwargs):
+        """Liens explicites — bloc-marque Ademe & République française dans le footer."""
+        return render_to_string(
+            "ui/components/footer/footer.html",
+            {"iframe": False},
+        )
+
+    @component_docs("ui/components/accessibilite/P07_6_1.md")
+    def P07_6_1(self, **kwargs):
+        """Liens explicites — sources de données du bonus réparation."""
+        return self._iframe(
+            "https://quefairedemesdechets.ademe.fr/bonus-reparation",
+            "Bonus réparation — sources de données (P07 6.1)",
+            height=700,
+        )
+
+    @component_docs("ui/components/accessibilite/P08_6_1.md")
+    def P08_6_1(self, **kwargs):
+        """Liens explicites — bouton "Voir sur le site" sur la fiche acteur."""
+        acteur = DisplayedActeur.objects.first()
+        if not acteur:
+            return "<p>Pas d'acteur disponible en base pour cette preview.</p>"
+        return Template(
+            """
+            <p>Bouton "Voir sur le site" tel qu'il apparaît sur la fiche acteur :</p>
+            <a class="fr-btn fr-btn--secondary" href="{{ url|default:'#' }}"
+               target="_blank" rel="noreferrer">
+                Voir sur le site
+            </a>
+            <p class="fr-text--sm fr-mt-2w">
+                Recommandation : intituler explicitement le lien, par exemple
+                "Voir la fiche de {{ nom }} sur son site officiel (nouvelle fenêtre)".
+            </p>
+            """,
+        ).render(
+            Context(
+                {
+                    "url": getattr(acteur, "url", "") or "",
+                    "nom": getattr(acteur, "nom", "") or "l'acteur",
+                },
+            ),
+        )
+
+    @component_docs("ui/components/accessibilite/P08_7_5.md")
+    def P08_7_5(self, **kwargs):
+        """Message de statut recherche objet réparable sans role="status"."""
+        return self._iframe(
+            "https://quefairedemesdechets.ademe.fr/bonus-reparation",
+            "Recherche objet réparable — message de statut (P08 7.5)",
+            height=700,
+        )
+
+    @component_docs("ui/components/accessibilite/P06_8_7.md")
+    def P06_8_7(self, **kwargs):
+        """Sélecteur de langue Impact CO2 sans attribut lang sur les options."""
+        return Template(
+            """
+            <p>Widget Impact CO2 (Ademe). Le sélecteur de langue interne ne précise
+            pas l'attribut <code>lang</code> sur ses options.</p>
+            <iframe
+                src="https://impactco2.fr/outils/comparateur"
+                title="Widget Impact CO2"
+                style="width:100%;height:500px;border:1px solid #ddd;"
+                loading="lazy"
+            ></iframe>
+            <p class="fr-text--sm fr-mt-2w">Widget tiers : nous ne pouvons que documenter
+            le défaut.</p>
+            """,
+        ).render(Context({}))
+
+    @component_docs("ui/components/accessibilite/P06_8_9__P09_8_9.md")
+    def P06_8_9__P09_8_9(self, **kwargs):
+        """<br> utilisés pour faire des paragraphes (RichText Sites Faciles)."""
+        return Template(
+            """
+            <article class="fr-mb-4w">
+                <h2 class="fr-h3">Reproduction du bloc RichText fautif</h2>
+                <div>
+                    Premier paragraphe utilisé en simple ligne.<br><br>
+                    Deuxième "paragraphe" en réalité séparé par deux &lt;br&gt;.<br><br>
+                    Troisième "paragraphe" idem.
+                </div>
+            </article>
+            <p class="fr-text--sm">
+                À corriger via contribution Sites Faciles (RichText), pas dans la webapp.
+                Le rédacteur doit utiliser de vrais &lt;p&gt; depuis l'éditeur Wagtail.
+            </p>
+            """,
+        ).render(Context({}))
+
+    @component_docs("ui/components/accessibilite/P06_9_1__P08_9_1.md")
+    def P06_9_1__P08_9_1(self, **kwargs):
+        """Niveaux de titres incohérents dans les accordéons (h3/h4/h5)."""
+        return Template(
+            """
+            <section class="fr-accordions-group">
+                <div class="fr-accordion">
+                    <h3 class="fr-accordion__title">
+                        <button class="fr-accordion__btn" aria-expanded="false"
+                                aria-controls="acc-1">Premier accordéon (h3)</button>
+                    </h3>
+                    <div class="fr-collapse" id="acc-1">Contenu</div>
+                </div>
+                <div class="fr-accordion">
+                    <h5 class="fr-accordion__title">
+                        <button class="fr-accordion__btn" aria-expanded="false"
+                                aria-controls="acc-2">Deuxième accordéon (h5 — incohérent)</button>
+                    </h5>
+                    <div class="fr-collapse" id="acc-2">Contenu</div>
+                </div>
+                <div class="fr-accordion">
+                    <h4 class="fr-accordion__title">
+                        <button class="fr-accordion__btn" aria-expanded="false"
+                                aria-controls="acc-3">Troisième accordéon (h4 — incohérent)</button>
+                    </h4>
+                    <div class="fr-collapse" id="acc-3">Contenu</div>
+                </div>
+            </section>
+            <p class="fr-text--sm fr-mt-2w">
+                Tous les titres d'accordéons d'un même groupe doivent être au même niveau,
+                cohérent avec la hiérarchie de la page (typiquement h3 si la page a un h2
+                au-dessus du groupe).
+            </p>
+            """,
+        ).render(Context({}))
+
+    @component_docs("ui/components/accessibilite/P01_9_2.md")
+    def P01_9_2(self, **kwargs):
+        """Footer sans <nav>."""
+        return render_to_string(
+            "ui/components/footer/footer.html",
+            {"iframe": False},
+        )
+
+    @component_docs("ui/components/accessibilite/P06_9_3__P07_9_3__P08_9_3__P09_9_3.md")
+    def P06_9_3__P07_9_3__P08_9_3__P09_9_3(self, **kwargs):
+        """Éléments visuellement énumérés mais non <ul><li>."""
+        return Template(
+            """
+            <article>
+                <h2 class="fr-h3">Reproduction du bloc fautif (Sites Faciles)</h2>
+                <p>Voici les étapes à suivre :</p>
+                <p>- Première étape</p>
+                <p>- Deuxième étape</p>
+                <p>- Troisième étape</p>
+            </article>
+            <hr>
+            <article>
+                <h2 class="fr-h3">Correctif attendu</h2>
+                <ul>
+                    <li>Première étape</li>
+                    <li>Deuxième étape</li>
+                    <li>Troisième étape</li>
+                </ul>
+            </article>
+            <p class="fr-text--sm">
+                À corriger dans les blocs Sites Faciles : utiliser une vraie liste
+                <code>&lt;ul&gt;&lt;li&gt;</code> dès qu'on a une énumération.
+            </p>
+            """,
+        ).render(Context({}))
+
+    @component_docs("ui/components/accessibilite/P05_10_2__P06_10_2.md")
+    def P05_10_2__P06_10_2(self, **kwargs):
+        """Sans CSS, l'icône "Nouvelle fenêtre" disparaît."""
+        return Template(
+            """
+            <p>Lien externe tel qu'utilisé dans le footer / qui-sommes-nous :</p>
+            <p>
+                <a href="https://www.ademe.fr/" target="_blank" rel="noreferrer"
+                   class="fr-link">
+                    Site de l'Ademe
+                </a>
+            </p>
+            <p class="fr-text--sm">
+                Sans CSS, l'icône "nouvelle fenêtre" disparaît, l'utilisateur ne sait
+                plus que le lien ouvre dans un nouvel onglet. Correctif : ajouter un
+                attribut <code>title="Site de l'Ademe (nouvelle fenêtre)"</code>
+                pour que l'information soit textuelle.
+            </p>
+            <hr>
+            <p>Version corrigée :</p>
+            <p>
+                <a href="https://www.ademe.fr/" target="_blank" rel="noreferrer"
+                   title="Site de l'Ademe (nouvelle fenêtre)" class="fr-link">
+                    Site de l'Ademe
+                </a>
+            </p>
+            """,
+        ).render(Context({}))
+
+    @component_docs("ui/components/accessibilite/P01_11_10__P01_11_11.md")
+    def P01_11_10__P01_11_11(self, **kwargs):
+        """Modale contact (astérisques, format mail, message d'erreur)."""
+        return self._iframe(
+            "https://quefairedemesdechets.ademe.fr/?contact=1",
+            "Modale contact (P01 11.10 + 11.11)",
+            height=700,
+        )
+
+    @component_docs("ui/components/accessibilite/P06_12_2__P09_12_2__P10_12_2.md")
+    def P06_12_2__P09_12_2__P10_12_2(self, **kwargs):
+        """Fil d'ariane absent sur certaines pages."""
+        breadcrumbs_html = render_to_string(
+            "sites_conformes_content_manager/blocks/breadcrumbs.html",
+            {
+                "self": {
+                    "get_ancestors": [
+                        {"title": "Accueil", "is_site_root": True},
+                        {"title": "Section parente", "is_root": False},
+                    ],
+                    "title": "Page courante",
+                },
+            },
+        )
+        return Template(
+            """
+            <h2 class="fr-h3">Composant breadcrumb attendu</h2>
+            {{ breadcrumbs|safe }}
+            <hr>
+            <h2 class="fr-h3">Pages où le breadcrumb est manquant</h2>
+            <ul>
+                <li>P06 — Comment ça marche</li>
+                <li>P09 — Page produit / objet (ex. /dechet/manteau/)</li>
+                <li>P10 — Guide PDF Smartphone</li>
+            </ul>
+            """,
+        ).render(Context({"breadcrumbs": breadcrumbs_html}))
+
+    @component_docs("ui/components/accessibilite/P01_12_6.md")
+    def P01_12_6(self, **kwargs):
+        """Rôles ARIA banner/main/navigation manquants."""
+        return self._iframe(
+            "https://quefairedemesdechets.ademe.fr/",
+            "Accueil — landmarks ARIA (P01 12.6)",
+            height=800,
+        )
+
+    @component_docs("ui/components/accessibilite/P01_12_7.md")
+    def P01_12_7(self, **kwargs):
+        """Lien d'évitement (regression check)."""
+        return self._iframe(
+            "https://quefairedemesdechets.ademe.fr/",
+            "Accueil — lien d'évitement (P01 12.7)",
+            height=400,
+        )
+
+    @component_docs("ui/components/accessibilite/P10_13_3.md")
+    def P10_13_3(self, **kwargs):
+        """PDF non accessible (guide Smartphone)."""
+        return Template(
+            """
+            <p>Lien vers le guide PDF Smartphone :</p>
+            <p>
+                <a href="#" class="fr-link fr-link--download"
+                   title="Guide Smartphone (PDF, à vérifier)">
+                    Télécharger le guide Smartphone (PDF)
+                </a>
+            </p>
+            <p class="fr-text--sm">
+                Marqué FAIT côté audit, mais à vérifier que tout PDF futur est testé
+                (balisage, ordre de lecture, alternatives textuelles).
+            </p>
+            """,
+        ).render(Context({}))
+
+    @component_docs("ui/components/accessibilite/P06_13_5.md")
+    def P06_13_5(self, **kwargs):
+        """Émojis non encapsulés (page comment-ça-marche)."""
+        return Template(
+            """
+            <article>
+                <h2 class="fr-h3">Reproduction du bloc fautif</h2>
+                <p>Bravo 🎉 vous venez de trier vos déchets correctement 👍</p>
+            </article>
+            <hr>
+            <article>
+                <h2 class="fr-h3">Correctif</h2>
+                <p>Bravo <span aria-hidden="true">🎉</span> vous venez de trier vos
+                déchets correctement <span aria-hidden="true">👍</span></p>
+                <p class="fr-text--sm">
+                    Si l'émoji porte une information, lui donner un texte alternatif :
+                    <code>&lt;span role="img" aria-label="fête"&gt;🎉&lt;/span&gt;</code>.
+                    Sinon, <code>aria-hidden="true"</code>.
+                </p>
+            </article>
+            """,
+        ).render(Context({}))
+
+    @component_docs("ui/components/accessibilite/P09_3_3__P03_3_3.md")
+    def P09_3_3__P03_3_3(self, **kwargs):
+        """Contrastes (Impact CO2 hachures, composants UI)."""
+        return Template(
+            """
+            <p>Widget Impact CO2 — vérification des contrastes (hachures, composants UI).</p>
+            <iframe
+                src="https://impactco2.fr/outils/comparateur"
+                title="Widget Impact CO2 — contrastes"
+                style="width:100%;height:600px;border:1px solid #ddd;"
+                loading="lazy"
+            ></iframe>
+            <p class="fr-text--sm">
+                Marqué <strong>déjà OK avec EF</strong>, plus besoin de le faire.
+                Conservé pour documentation.
+            </p>
+            """,
+        ).render(Context({}))
+
+    @component_docs("ui/components/accessibilite/P08_7_1__P08_7_3.md")
+    def P08_7_1__P08_7_3(self, **kwargs):
+        """Carte iframe — combobox autocomplete + adresse + tooltip partage non clavier."""
+        return self._iframe(
+            "/lookbook/preview/iframe/carte/",
+            "Carte iframe — combobox + clavier (P08 7.1 + 7.3)",
+            height=700,
         )
 
 

--- a/webapp/previews/template_preview.py
+++ b/webapp/previews/template_preview.py
@@ -321,6 +321,48 @@ class ComponentsPreview(LookbookPreview):
             """)
         return template.render(Context(context))
 
+    def acteur_icons_preview(self, **kwargs):
+        """Side-by-side comparison of DOM pinpoints vs runtime-rendered MapLibre icons.
+
+        Used to validate visual fidelity of the new GeoJSON symbol layer against
+        the legacy DOM markers before migrating the carte.
+        """
+        variants = [
+            {
+                "code": "donner_echanger_rapporter",
+                "icon": "fr-icon-hand-heart",
+                "couleur": "#417dc4",
+                "filled": False,
+            },
+            {
+                "code": "emprunter_preter_louer",
+                "icon": "fr-icon-arrow-go-back-line",
+                "couleur": "#ce614a",
+                "filled": False,
+            },
+            {
+                "code": "reparer",
+                "icon": "fr-icon-tools-fill",
+                "couleur": "#009081",
+                "filled": True,
+            },
+            {
+                "code": "trier",
+                "icon": "fr-icon-recycle-line",
+                "couleur": "#A558A0",
+                "filled": False,
+            },
+            {
+                "code": "vendre_acheter",
+                "icon": "fr-icon-money-euro-circle-line",
+                "couleur": "#D1B781",
+                "filled": False,
+            },
+        ]
+        return render_to_string(
+            "ui/tests/acteur_icons_preview.html", {"variants": variants}
+        )
+
     def acteur_pinpoint_multiple(self, **kwargs):
         """
         Preview showing two pinpoints side by side to test active state toggling.

--- a/webapp/qfdmo/forms.py
+++ b/webapp/qfdmo/forms.py
@@ -123,6 +123,14 @@ class MapForm(GetFormMixin, CarteConfigFormMixin, forms.Form):
         ),
         required=False,
     )
+    # INSEE citycode of the commune the user picked from the address
+    # autocomplete. Carries through Turbo Frame submits so the next page render
+    # can re-fetch the polygon and draw the search-area overlay.
+    search_area_citycode = forms.CharField(
+        widget=forms.HiddenInput(),
+        required=False,
+        max_length=10,
+    )
     latitude = forms.FloatField(
         widget=forms.HiddenInput(
             attrs={

--- a/webapp/qfdmo/forms.py
+++ b/webapp/qfdmo/forms.py
@@ -3,7 +3,7 @@ import json
 from typing import cast
 
 from django import forms
-from django.core.cache import cache
+from django.core.cache import cache, caches
 from django.db.models import TextChoices
 from django.db.utils import cached_property
 from django.http import HttpRequest, QueryDict
@@ -622,7 +622,8 @@ class AdvancedConfiguratorForm(forms.Form):
 
         # Cast needed because of the cache
         cached_action_instances = cast(
-            list[Action], cache.get_or_set("action_instances", get_action_instances)
+            list[Action],
+            caches["actions"].get_or_set("action_instances", get_action_instances),
         )
         self.fields["action_list"].choices = [
             (

--- a/webapp/qfdmo/geo_api.py
+++ b/webapp/qfdmo/geo_api.py
@@ -73,6 +73,35 @@ def retrieve_epci_geojson_from_api_or_cache(epci):
     )
 
 
+def retrieve_commune_geojson_from_api_or_cache(citycode: str) -> dict | None:
+    """Fetch (and cache for 1 year) the commune polygon as a GeoJSON Feature.
+
+    Returns the full geo.api.gouv.fr response: a Feature with `geometry`
+    (Polygon or MultiPolygon) and `properties` (code, nom, etc.). Cached on
+    the default Django cache so subsequent lookups are server-side and fast.
+
+    Returns None when the upstream call fails or the citycode doesn't exist.
+    """
+
+    def fetch_commune_geojson():
+        try:
+            response = requests.get(
+                f"{BASE_URL}/communes/{citycode}",
+                params={"format": "geojson", "geometry": "contour"},
+                timeout=10,
+            )
+            if response.status_code != 200:
+                return None
+            return response.json()
+        except requests.RequestException:
+            logger.exception("commune polygon fetch failed for citycode=%s", citycode)
+            return None
+
+    return cache.get_or_set(
+        f"commune_geojson_{citycode}", fetch_commune_geojson, timeout=3600 * 24 * 365
+    )
+
+
 def bbox_from_list_of_geojson(geojson_list, buffer: float = 0):
     """Returns a bbox from a list of geojson
 

--- a/webapp/qfdmo/models/acteur.py
+++ b/webapp/qfdmo/models/acteur.py
@@ -21,7 +21,7 @@ from django.contrib.gis.db.models.functions import Distance
 from django.contrib.gis.geos import Point, Polygon
 from django.contrib.gis.geos.geometry import GEOSGeometry
 from django.contrib.gis.measure import D
-from django.core.cache import cache
+from django.core.cache import cache, caches
 from django.core.files.images import get_image_dimensions
 from django.core.validators import RegexValidator
 from django.db.models import (
@@ -1431,7 +1431,8 @@ class DisplayedActeur(FinalActeur, LatLngPropertiesMixin):
     ):
         # Cast needed because of the cache
         cached_action_instances = cast(
-            List[Action], cache.get_or_set("_action_instances", get_action_instances)
+            List[Action],
+            caches["actions"].get_or_set("action_instances", get_action_instances),
         )
 
         # Work with prefetched data in memory to avoid N+1 queries

--- a/webapp/qfdmo/models/acteur.py
+++ b/webapp/qfdmo/models/acteur.py
@@ -365,7 +365,11 @@ class DisplayedActeurQuerySet(models.QuerySet):
         geometries = [GEOSGeometry(geojson) for geojson in geojson]
         query = Q()
         for geometry in geometries:
-            query |= Q(location__within=geometry)
+            # `__coveredby` (geography ST_CoveredBy) lets Postgres use the
+            # GiST index on the geography-typed `location` column.
+            # `__within` casts to geometry and forces a parallel seq scan
+            # (no index match), which on a France-wide query is ~1.5 s.
+            query |= Q(location__coveredby=geometry)
 
         return self.physical().filter(query).order_by("?")
 
@@ -376,7 +380,8 @@ class DisplayedActeurQuerySet(models.QuerySet):
 
         return (
             self.physical()
-            .filter(location__within=Polygon.from_bbox(bbox))
+            # See in_geojson for why __coveredby instead of __within.
+            .filter(location__coveredby=Polygon.from_bbox(bbox))
             .order_by("?")
         )
 

--- a/webapp/qfdmo/urls.py
+++ b/webapp/qfdmo/urls.py
@@ -18,6 +18,8 @@ from qfdmo.views.carte import (
     CarteConfigView,
     CarteSearchActeursView,
     carte_acteurs_geojson,
+    carte_acteurs_near_geojson,
+    commune_geojson,
 )
 from qfdmo.views.configurator import AdvancedConfiguratorView, ConfiguratorView
 from qfdmo.views.formulaire import FormulaireSearchActeursView
@@ -34,6 +36,16 @@ urlpatterns = [
         "carte/acteurs.geojson",
         carte_acteurs_geojson,
         name="carte_acteurs_geojson",
+    ),
+    path(
+        "carte/acteurs-near.geojson",
+        carte_acteurs_near_geojson,
+        name="carte_acteurs_near_geojson",
+    ),
+    path(
+        "carte/communes/<str:citycode>.geojson",
+        commune_geojson,
+        name="carte_commune_geojson",
     ),
     path("formulaire", FormulaireSearchActeursView.as_view(), name="formulaire"),
     path(settings.CARTE.get("GOOGLE_SEARCH_CONSOLE"), google_verification),

--- a/webapp/qfdmo/urls.py
+++ b/webapp/qfdmo/urls.py
@@ -14,7 +14,11 @@ from qfdmo.views.adresses import (
     getorcreate_revisionacteur,
     solution_admin,
 )
-from qfdmo.views.carte import CarteConfigView, CarteSearchActeursView
+from qfdmo.views.carte import (
+    CarteConfigView,
+    CarteSearchActeursView,
+    carte_acteurs_geojson,
+)
 from qfdmo.views.configurator import AdvancedConfiguratorView, ConfiguratorView
 from qfdmo.views.formulaire import FormulaireSearchActeursView
 
@@ -26,6 +30,11 @@ urlpatterns = [
     path("carte", CarteSearchActeursView.as_view(), name="carte"),
     path("carte/<slug:slug>/", CarteConfigView.as_view(), name="carte_custom"),
     path("carte.json", CarteSearchActeursView.as_view(), name="carte_json"),
+    path(
+        "carte/acteurs.geojson",
+        carte_acteurs_geojson,
+        name="carte_acteurs_geojson",
+    ),
     path("formulaire", FormulaireSearchActeursView.as_view(), name="formulaire"),
     path(settings.CARTE.get("GOOGLE_SEARCH_CONSOLE"), google_verification),
     path(

--- a/webapp/qfdmo/views/adresses.py
+++ b/webapp/qfdmo/views/adresses.py
@@ -9,7 +9,7 @@ from django.contrib.postgres.search import TrigramWordDistance
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.paginator import Paginator
-from django.db.models import Q
+from django.db.models import Exists, OuterRef, Q
 from django.db.models.functions import Length, Lower
 from django.db.models.query import QuerySet
 from django.http import Http404, JsonResponse
@@ -192,9 +192,14 @@ class AbstractSearchActeursView(
             "acteur_type_id",
         )
         if getattr(acteurs, "_has_distance_field", False):
+            # `from_center` annotates `distance`; pair DISTINCT ON with the
+            # same ORDER BY so Postgres can dedup in a single pass.
             acteurs = acteurs.distinct("distance", "identifiant_unique")
-        else:
-            acteurs = acteurs.distinct()
+        # The bbox / EPCI / no-location paths no longer need `.distinct()`:
+        # `_compile_acteurs_queryset` now expresses spanning filters as
+        # `Exists()` subqueries (instead of relation-spanning Q lookups),
+        # so no JOIN multiplies acteur rows. Removing DISTINCT eliminates
+        # a 372k-row sort spill on a France-wide bbox (saves ~1.1 s).
         acteurs = acteurs[: self._get_max_displayed_acteurs()]
 
         # Prefetch AFTER limiting to only load related data for displayed acteurs
@@ -284,6 +289,17 @@ class AbstractSearchActeursView(
     def _compile_acteurs_queryset(
         self, reparer_is_checked, selected_actions_ids, reparer_action_id
     ):
+        # Filters that span proposition_services or labels are expressed as
+        # `Exists()` subqueries instead of relation-spanning Q lookups.
+        # Relation-spanning Q() lookups (e.g. `proposition_services__action_id__in=…`)
+        # produce INNER JOINs that duplicate acteur rows once per matching
+        # child, then force a `DISTINCT` to dedupe — and on a France-wide
+        # bbox that DISTINCT triggers a 305k-row sort spill to disk plus
+        # JIT compilation (~2 s wall time, see EXPLAIN). `Exists()` keeps
+        # one row per acteur, so DISTINCT is unnecessary and Postgres can
+        # use the GiST index path directly.
+        from qfdmo.models import DisplayedPropositionService, LabelQualite
+
         filters = Q(statut=ActeurStatus.ACTIF)
         excludes = Q()
 
@@ -294,14 +310,31 @@ class AbstractSearchActeursView(
             excludes |= Q(exclusivite_de_reprisereparation=True)
 
         if self._get_ess():
-            filters &= Q(labels__code="ess")
+            filters &= Q(
+                Exists(
+                    LabelQualite.objects.filter(
+                        displayedacteur=OuterRef("pk"), code="ess"
+                    )
+                )
+            )
 
         if self._get_bonus():
-            filters &= Q(labels__bonus=True)
+            filters &= Q(
+                Exists(
+                    LabelQualite.objects.filter(
+                        displayedacteur=OuterRef("pk"), bonus=True
+                    )
+                )
+            )
 
         if sous_categorie_ids := self._get_sous_categorie_ids():
             filters &= Q(
-                proposition_services__sous_categories__id__in=sous_categorie_ids,
+                Exists(
+                    DisplayedPropositionService.objects.filter(
+                        acteur_id=OuterRef("pk"),
+                        sous_categories__id__in=sous_categorie_ids,
+                    )
+                )
             )
 
         actions_filters = Q()
@@ -310,15 +343,30 @@ class AbstractSearchActeursView(
             selected_actions_ids = [
                 a for a in selected_actions_ids if a != reparer_action_id
             ]
-
+            # "Reparer + reparacteur label" composes two Exists subqueries:
+            # the acteur must have BOTH a proposition_service for the reparer
+            # action AND a `reparacteur` label.
             actions_filters |= Q(
-                proposition_services__action_id=reparer_action_id,
-                labels__code="reparacteur",
+                Exists(
+                    DisplayedPropositionService.objects.filter(
+                        acteur_id=OuterRef("pk"), action_id=reparer_action_id,
+                    )
+                ),
+                Exists(
+                    LabelQualite.objects.filter(
+                        displayedacteur=OuterRef("pk"), code="reparacteur",
+                    )
+                ),
             )
 
         if selected_actions_ids:
             actions_filters |= Q(
-                proposition_services__action_id__in=selected_actions_ids,
+                Exists(
+                    DisplayedPropositionService.objects.filter(
+                        acteur_id=OuterRef("pk"),
+                        action_id__in=selected_actions_ids,
+                    )
+                )
             )
 
         filters &= actions_filters

--- a/webapp/qfdmo/views/carte.py
+++ b/webapp/qfdmo/views/carte.py
@@ -4,10 +4,11 @@ import logging
 from typing import Any, NotRequired, TypedDict, override
 
 from django.conf import settings
-from django.contrib.gis.geos import Point
+from django.contrib.gis.geos import Point, Polygon
 from django.core.cache import cache
 from django.db.models import Q
 from django.forms import Form
+from django.http import HttpResponseBadRequest, JsonResponse
 from django.utils.functional import cached_property
 from django.views.generic import DetailView
 
@@ -25,7 +26,7 @@ from qfdmo.forms import (
     ViewModeForm,
     generate_form_prefix,
 )
-from qfdmo.models import CarteConfig
+from qfdmo.models import ActeurStatus, CarteConfig, DisplayedActeur
 from qfdmo.models.action import Action
 from qfdmo.views.adresses import AbstractSearchActeursView, MapPrefixMixin
 
@@ -421,9 +422,37 @@ class CarteSearchActeursView(MapPrefixMixin, AbstractSearchActeursView):
             carte_config=carte_config,
             selected_action_codes=self._get_action_codes(),
             icon_lookup=icon_lookup,
+            geojson_filter_params=self._build_geojson_filter_params(),
         )
 
         return context
+
+    def _build_geojson_filter_params(self) -> str:
+        """Build the query-string fragment the frontend sends to
+        carte/acteurs.geojson on each pan, so the auto-fetch honours the
+        currently-applied filters (groupe_actions, bonus, ess, sous_categories).
+        Returned as a `&`-joined string ready to append to the request URL.
+        """
+        from urllib.parse import urlencode
+
+        params: list[tuple[str, str]] = []
+
+        groupe_action_ids = self._get_ui_form("legende")["groupe_action"].value() or []
+        if groupe_action_ids:
+            params.append(("groupe_actions", ",".join(str(g) for g in groupe_action_ids)))
+
+        if self._get_bonus():
+            params.append(("bonus", "1"))
+        if self._get_ess():
+            params.append(("ess", "1"))
+
+        sous_categorie_ids = self._get_sous_categorie_ids()
+        if sous_categorie_ids:
+            params.append(
+                ("sous_categories", ",".join(str(s) for s in sous_categorie_ids))
+            )
+
+        return urlencode(params)
 
     def _build_icon_lookup(self, carte_config):
         """Build a lookup dictionary for icon configurations.
@@ -654,3 +683,160 @@ class CarteConfigView(DetailView, CarteSearchActeursView):
             )
 
         return action_ids
+
+
+# Frontend icon names mirror static/to_compile/js/acteur_icons.ts:iconNameFor.
+def _icon_name_for(groupe_action_code: str, bonus: bool) -> str:
+    return f"acteur:{groupe_action_code}:bonus" if bonus else f"acteur:{groupe_action_code}"
+
+
+def _resolve_icon(
+    acteur, action_codes: str | None, sous_categorie_id: int | None
+) -> tuple[str, bool]:
+    """Pick the icon name + bonus flag for a single acteur, mirroring
+    acteur_pinpoint_tag's logic for the carte path.
+    """
+    chosen = acteur.action_to_display(
+        action_list=action_codes,
+        sous_categorie_id=sous_categorie_id,
+        carte=True,
+    )
+    if chosen is None:
+        return ("", False)
+    groupe_action = chosen.groupe_action or chosen
+    code = getattr(groupe_action, "code", "") or ""
+    bonus = code == "reparer" and getattr(acteur, "is_bonus_reparation", False)
+    return (_icon_name_for(code, bonus), bonus)
+
+
+def carte_acteurs_geojson(request):
+    """GeoJSON endpoint feeding the carte's MapLibre symbol layer.
+
+    Returns a FeatureCollection of acteur Points filtered by bbox and any
+    optional filters. Used to incrementally append acteurs as the user pans
+    the map without re-rendering the whole results frame.
+
+    Query params:
+        bbox: "<sw_lng>,<sw_lat>,<ne_lng>,<ne_lat>"
+        exclude_uuids: comma-separated list of UUIDs already on screen
+        sous_categories: comma-separated list of ids
+        groupe_actions: comma-separated list of group_action ids
+        bonus: "1" to keep only acteurs with the bonus label
+        ess: "1" to keep only ESS-labelled acteurs
+        limit: optional, capped at settings.CARTE_MAX_SOLUTION_DISPLAYED
+    """
+    bbox_raw = request.GET.get("bbox", "").strip()
+    if not bbox_raw:
+        return HttpResponseBadRequest("missing bbox")
+    try:
+        sw_lng, sw_lat, ne_lng, ne_lat = (float(x) for x in bbox_raw.split(","))
+    except ValueError:
+        return HttpResponseBadRequest("invalid bbox")
+
+    polygon = Polygon.from_bbox((sw_lng, sw_lat, ne_lng, ne_lat))
+
+    qs = (
+        DisplayedActeur.objects.filter(
+            statut=ActeurStatus.ACTIF,
+            location__within=polygon,
+        )
+        .exclude(location__isnull=True)
+    )
+
+    if exclude_raw := request.GET.get("exclude_uuids", "").strip():
+        exclude_uuids = [u for u in exclude_raw.split(",") if u]
+        if exclude_uuids:
+            qs = qs.exclude(uuid__in=exclude_uuids)
+
+    if sc_raw := request.GET.get("sous_categories", "").strip():
+        sc_ids = [int(s) for s in sc_raw.split(",") if s.isdigit()]
+        if sc_ids:
+            qs = qs.filter(
+                proposition_services__sous_categories__id__in=sc_ids
+            )
+
+    selected_action_ids: list[int] = []
+    if ga_raw := request.GET.get("groupe_actions", "").strip():
+        ga_ids = [int(g) for g in ga_raw.split(",") if g.isdigit()]
+        if ga_ids:
+            selected_action_ids = list(
+                Action.objects.filter(groupe_action_id__in=ga_ids).values_list(
+                    "id", flat=True
+                )
+            )
+            qs = qs.filter(proposition_services__action_id__in=selected_action_ids)
+
+    if request.GET.get("bonus") == "1":
+        qs = qs.filter(labels__bonus=True)
+    if request.GET.get("ess") == "1":
+        qs = qs.filter(labels__code="ess")
+
+    # Random ordering so the LIMIT-cap returns a representative sample across
+    # the bbox rather than whatever Postgres has at the head of physical
+    # storage (which heavily skewed toward bibliothèques in our dataset and
+    # made wide-zoom maps look mono-icon). Mirrors the legacy
+    # `DisplayedActeurQuerySet.in_bbox` which also uses `order_by("?")`.
+    qs = qs.distinct().order_by("?").prefetch_related(
+        "proposition_services__action__groupe_action",
+        "proposition_services__sous_categories",
+        "action_principale",
+        # `is_bonus_reparation` walks `acteur.labels.all()` in pure Python; the
+        # prefetch keeps that O(1) per acteur instead of N+1.
+        "labels",
+    )
+
+    limit = settings.CARTE_MAX_SOLUTION_DISPLAYED
+    if (raw := request.GET.get("limit", "")) and raw.isdigit():
+        limit = min(int(raw), settings.CARTE_MAX_SOLUTION_DISPLAYED)
+    # Fetch one extra row so we can tell the frontend whether the result set
+    # was truncated and a "zoom in to see more" hint should be shown.
+    overshoot = list(qs[: limit + 1])
+    truncated = len(overshoot) > limit
+    qs = overshoot[:limit]
+
+    sc_id_for_action = None
+    if sc_raw and sc_ids:
+        sc_id_for_action = sc_ids[0]
+    action_codes = "|".join(
+        Action.objects.filter(id__in=selected_action_ids)
+        .values_list("code", flat=True)
+    ) if selected_action_ids else None
+
+    features = []
+    for acteur in qs:
+        if acteur.location is None:
+            continue
+        icon, bonus = _resolve_icon(
+            acteur,
+            action_codes=action_codes,
+            sous_categorie_id=sc_id_for_action,
+        )
+        if not icon:
+            continue
+        features.append(
+            {
+                "type": "Feature",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [acteur.location.x, acteur.location.y],
+                },
+                "properties": {
+                    "uuid": str(acteur.uuid),
+                    "icon": icon,
+                    "bonus": bonus,
+                    "detail_url": acteur.get_absolute_url(),
+                },
+            }
+        )
+
+    return JsonResponse(
+        {
+            "type": "FeatureCollection",
+            "features": features,
+            # Top-level flag, not strictly part of GeoJSON: signals to the
+            # frontend that more acteurs exist in this bbox than we returned,
+            # so a "zoom in to see more" pill should be shown.
+            "truncated": truncated,
+        },
+        json_dumps_params={"separators": (",", ":")},
+    )

--- a/webapp/qfdmo/views/carte.py
+++ b/webapp/qfdmo/views/carte.py
@@ -4,9 +4,10 @@ import logging
 from typing import Any, NotRequired, TypedDict, override
 
 from django.conf import settings
-from django.contrib.gis.geos import Point, Polygon
+from django.contrib.gis.geos import GEOSGeometry, Point
 from django.core.cache import cache
-from django.db.models import Q
+from django.db import connection
+from django.db.models import Exists, OuterRef, Q
 from django.forms import Form
 from django.http import HttpResponseBadRequest, JsonResponse
 from django.utils.functional import cached_property
@@ -26,11 +27,35 @@ from qfdmo.forms import (
     ViewModeForm,
     generate_form_prefix,
 )
-from qfdmo.models import ActeurStatus, CarteConfig, DisplayedActeur
+from qfdmo.models import (
+    ActeurStatus,
+    CarteConfig,
+    DisplayedActeur,
+    DisplayedPropositionService,
+    LabelQualite,
+)
 from qfdmo.models.action import Action
 from qfdmo.views.adresses import AbstractSearchActeursView, MapPrefixMixin
 
 logger = logging.getLogger(__name__)
+
+# Cap for /carte/acteurs.geojson responses. Higher than the legacy
+# CARTE_MAX_SOLUTION_DISPLAYED (which gates the list view) because spatial
+# thinning prevents the marker density from getting overwhelming on the map.
+CARTE_GEOJSON_MAX_FEATURES = 200
+
+# Default spatial thinning grid step in degrees, used as a floor when the
+# frontend doesn't send a zoom level. Real grid is computed per-request from
+# the bbox-center latitude and the user's zoom (see _grid_step_for_zoom).
+CARTE_GEOJSON_GRID_DEG = 0.005
+
+# Target on-screen cell size in pixels. We size the thinning grid so each
+# cell maps to roughly this many CSS pixels at the user's current zoom — a
+# trade-off between marker density (smaller = more markers) and visual
+# clutter (smaller = icons overlap). 20 px at the marker icon's ~50 px width
+# allows ~2.5 markers per icon-width before overlap, which reads as "evenly
+# spread" on the user's screen.
+CARTE_GEOJSON_TARGET_CELL_PX = 20
 
 
 class ViewModeFormEntry(TypedDict):
@@ -415,6 +440,14 @@ class CarteSearchActeursView(MapPrefixMixin, AbstractSearchActeursView):
         carte_config = self._get_carte_config()
         icon_lookup = self._build_icon_lookup(carte_config) if carte_config else {}
 
+        search_area_citycode = (
+            self._get_field_value_for("map", "search_area_citycode") or ""
+        )
+        # Pre-resolve the polygon bbox at render time so the map controller
+        # can fit the camera synchronously on connect (no jolt when the
+        # polygon fetch lands later).
+        search_area_bbox = self._build_search_area_bbox(search_area_citycode)
+
         context.update(
             forms=self.ui_forms,
             map_container_id=self._get_map_container_id(),
@@ -423,9 +456,35 @@ class CarteSearchActeursView(MapPrefixMixin, AbstractSearchActeursView):
             selected_action_codes=self._get_action_codes(),
             icon_lookup=icon_lookup,
             geojson_filter_params=self._build_geojson_filter_params(),
+            search_area_citycode=search_area_citycode,
+            search_area_bbox=search_area_bbox,
         )
 
         return context
+
+    def _build_search_area_bbox(self, citycode: str) -> str:
+        """Return the polygon bbox as a JSON string in the frontend's standard
+        shape ({southWest, northEast}), pulled from the same Django cache the
+        commune-geojson proxy uses. Empty string when not available.
+        """
+        if not citycode:
+            return ""
+        from qfdmo.geo_api import retrieve_commune_geojson_from_api_or_cache
+
+        feature = retrieve_commune_geojson_from_api_or_cache(citycode)
+        if not feature or "geometry" not in feature:
+            return ""
+        try:
+            geometry = GEOSGeometry(json.dumps(feature["geometry"]))
+            xmin, ymin, xmax, ymax = geometry.extent
+        except Exception:
+            return ""
+        return json.dumps(
+            {
+                "southWest": {"lng": xmin, "lat": ymin},
+                "northEast": {"lng": xmax, "lat": ymax},
+            }
+        )
 
     def _build_geojson_filter_params(self) -> str:
         """Build the query-string fragment the frontend sends to
@@ -709,6 +768,237 @@ def _resolve_icon(
     return (_icon_name_for(code, bonus), bonus)
 
 
+def commune_geojson(request, citycode: str):
+    """Proxy + cache the commune polygon from geo.api.gouv.fr.
+
+    Frontend hits this same-origin endpoint instead of geo.api.gouv.fr
+    directly: avoids CORS, multiplexes with the rest of the page over HTTP/2,
+    and lets us cache the polygon server-side (~10 ms reads after first hit).
+    """
+    if not citycode.isdigit() or not (4 <= len(citycode) <= 5):
+        return HttpResponseBadRequest("invalid citycode")
+
+    from qfdmo.geo_api import retrieve_commune_geojson_from_api_or_cache
+
+    feature = retrieve_commune_geojson_from_api_or_cache(citycode)
+    if feature is None:
+        return JsonResponse({"error": "not found"}, status=404)
+
+    response = JsonResponse(feature)
+    # Browsers can cache the polygon for the session; the upstream rarely
+    # changes commune outlines.
+    response["Cache-Control"] = "public, max-age=86400"
+    return response
+
+
+def _grid_step_for_zoom(zoom: float, center_lat: float) -> float:
+    """Compute the spatial-thinning grid step in degrees so each cell occupies
+    ~CARTE_GEOJSON_TARGET_CELL_PX on screen at the given zoom.
+
+    Web-mercator meters-per-pixel: 156543.03 * cos(lat) / 2**zoom.
+    Convert target_meters → degrees of longitude at this latitude:
+        deg_lng = meters / (111320 * cos(lat))
+    Combining: deg_lng = TARGET_PX * 156543 * cos(lat) / 2**zoom / (111320 * cos(lat))
+                       = TARGET_PX * 1.406 / 2**zoom
+    The cos(lat) cancels because mercator's m/px and lng-deg/m both scale by
+    cos(lat). Latitude degrees stay constant (1° lat ≈ 111 km everywhere) so
+    we use the same step for both axes — visually square at the bbox center.
+    """
+    if zoom <= 0:
+        return CARTE_GEOJSON_GRID_DEG
+    return max(
+        0.0001,  # floor: never tighter than ~10 m
+        CARTE_GEOJSON_TARGET_CELL_PX * 1.406 / (2**zoom),
+    )
+
+
+def _apply_acteurs_filters(pk_qs, request):
+    """Apply the optional filter query params (sous_categories, groupe_actions,
+    bonus, ess, exclude_uuids) to a DisplayedActeur PK queryset and return:
+        (filtered_qs, sc_ids, selected_action_ids).
+
+    Shared between the bbox and KNN endpoints so the filter contract stays
+    consistent across both shapes.
+    """
+    if exclude_raw := request.GET.get("exclude_uuids", "").strip():
+        exclude_uuids = [u for u in exclude_raw.split(",") if u]
+        if exclude_uuids:
+            pk_qs = pk_qs.exclude(uuid__in=exclude_uuids)
+
+    sc_ids: list[int] = []
+    if sc_raw := request.GET.get("sous_categories", "").strip():
+        sc_ids = [int(s) for s in sc_raw.split(",") if s.isdigit()]
+        if sc_ids:
+            pk_qs = pk_qs.filter(
+                Exists(
+                    DisplayedPropositionService.objects.filter(
+                        acteur_id=OuterRef("pk"),
+                        sous_categories__id__in=sc_ids,
+                    )
+                )
+            )
+
+    selected_action_ids: list[int] = []
+    if ga_raw := request.GET.get("groupe_actions", "").strip():
+        ga_ids = [int(g) for g in ga_raw.split(",") if g.isdigit()]
+        if ga_ids:
+            selected_action_ids = list(
+                Action.objects.filter(groupe_action_id__in=ga_ids).values_list(
+                    "id", flat=True
+                )
+            )
+            pk_qs = pk_qs.filter(
+                Exists(
+                    DisplayedPropositionService.objects.filter(
+                        acteur_id=OuterRef("pk"),
+                        action_id__in=selected_action_ids,
+                    )
+                )
+            )
+
+    if request.GET.get("bonus") == "1":
+        pk_qs = pk_qs.filter(
+            Exists(
+                LabelQualite.objects.filter(
+                    displayedacteur=OuterRef("pk"), bonus=True
+                )
+            )
+        )
+    if request.GET.get("ess") == "1":
+        pk_qs = pk_qs.filter(
+            Exists(
+                LabelQualite.objects.filter(
+                    displayedacteur=OuterRef("pk"), code="ess"
+                )
+            )
+        )
+
+    return pk_qs, sc_ids, selected_action_ids
+
+
+def _serialize_acteurs(
+    pks_in_order: list,
+    sc_ids: list[int],
+    selected_action_ids: list[int],
+) -> list[dict]:
+    """Hydrate the ordered PK list into prefetched acteur instances and emit
+    GeoJSON features. Preserves the input order (required for KNN's nearest-
+    first ordering).
+    """
+    if not pks_in_order:
+        return []
+
+    instances = {
+        a.pk: a
+        for a in DisplayedActeur.objects.filter(pk__in=pks_in_order).prefetch_related(
+            "proposition_services__action__groupe_action",
+            "proposition_services__sous_categories",
+            "action_principale",
+            "labels",
+        )
+    }
+
+    sc_id_for_action = sc_ids[0] if sc_ids else None
+    action_codes = (
+        "|".join(
+            Action.objects.filter(id__in=selected_action_ids).values_list(
+                "code", flat=True
+            )
+        )
+        if selected_action_ids
+        else None
+    )
+
+    features = []
+    for pk in pks_in_order:
+        acteur = instances.get(pk)
+        if acteur is None or acteur.location is None:
+            continue
+        icon, bonus = _resolve_icon(
+            acteur, action_codes=action_codes, sous_categorie_id=sc_id_for_action
+        )
+        if not icon:
+            continue
+        features.append(
+            {
+                "type": "Feature",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [acteur.location.x, acteur.location.y],
+                },
+                "properties": {
+                    "uuid": str(acteur.uuid),
+                    "icon": icon,
+                    "bonus": bonus,
+                    "detail_url": acteur.get_absolute_url(),
+                },
+            }
+        )
+    return features
+
+
+def carte_acteurs_near_geojson(request):
+    """K-nearest-neighbor endpoint for "show me the N closest acteurs to this
+    point" — used when the user picks a non-municipality address (street /
+    housenumber / locality) from the autocomplete. Postgres walks the GiST
+    index in distance order via the `<->` operator; single query, no radius
+    iteration.
+
+    Query params:
+        lat, lng: required, the search center.
+        count: target number of features, default 30, capped at
+            settings.CARTE_MAX_SOLUTION_DISPLAYED.
+        sous_categories, groupe_actions, bonus, ess, exclude_uuids: same
+            filter contract as carte_acteurs_geojson.
+    """
+    try:
+        lat = float(request.GET["lat"])
+        lng = float(request.GET["lng"])
+    except (KeyError, ValueError):
+        return HttpResponseBadRequest("missing or invalid lat/lng")
+
+    count = 30
+    if (raw := request.GET.get("count", "")) and raw.isdigit():
+        count = min(int(raw), settings.CARTE_MAX_SOLUTION_DISPLAYED)
+
+    pk_qs = DisplayedActeur.objects.filter(
+        statut=ActeurStatus.ACTIF,
+    ).exclude(location__isnull=True)
+
+    pk_qs, sc_ids, selected_action_ids = _apply_acteurs_filters(pk_qs, request)
+
+    # `<->` is the GiST-indexed distance operator. Postgres walks the spatial
+    # index in nearest-first order, so this returns the K closest acteurs in
+    # one indexed pass — no full-scan, no random sort, no iteration.
+    #
+    # Django's `Distance()` function expands to `ST_Distance(...)`, which is
+    # NOT eligible for the GiST index — Postgres falls back to a parallel
+    # seq scan computing precise geography distances for every row. The
+    # `<->` operator IS GiST-indexed for geography columns, so we drop into
+    # raw SQL for the order-by.
+    pks_in_order = list(
+        pk_qs.values_list("pk", flat=True)
+        .extra(  # noqa: SLF001
+            select={"_knn_dist": "location <-> ST_SetSRID(ST_MakePoint(%s, %s), 4326)::geography"},
+            select_params=[lng, lat],
+            order_by=["_knn_dist"],
+        )[:count]
+    )
+
+    features = _serialize_acteurs(pks_in_order, sc_ids, selected_action_ids)
+
+    return JsonResponse(
+        {
+            "type": "FeatureCollection",
+            "features": features,
+            # KNN never truncates: it returns up to `count`, all that exist
+            # if the dataset has fewer.
+            "truncated": False,
+        },
+        json_dumps_params={"separators": (",", ":")},
+    )
+
+
 def carte_acteurs_geojson(request):
     """GeoJSON endpoint feeding the carte's MapLibre symbol layer.
 
@@ -733,101 +1023,81 @@ def carte_acteurs_geojson(request):
     except ValueError:
         return HttpResponseBadRequest("invalid bbox")
 
-    polygon = Polygon.from_bbox((sw_lng, sw_lat, ne_lng, ne_lat))
+    # Zoom-aware spatial thinning: cell size scales with the user's zoom so
+    # markers stay visually distributed at every zoom level (a fixed 500 m
+    # cell looks fine at city zoom but stacks all features into one pixel
+    # when looking at the whole country).
+    try:
+        zoom = float(request.GET.get("zoom", ""))
+    except ValueError:
+        zoom = 0.0
+    center_lat = (sw_lat + ne_lat) / 2.0
+    grid_step = _grid_step_for_zoom(zoom, center_lat)
 
-    qs = (
-        DisplayedActeur.objects.filter(
-            statut=ActeurStatus.ACTIF,
-            location__within=polygon,
-        )
-        .exclude(location__isnull=True)
+    # Step 1: build the *filter* queryset over PKs only. No DISTINCT, no
+    # ORDER BY, no prefetches — the goal is keep the planner's job small and
+    # let JOIN-producing filters (labels__*, proposition_services__*) live
+    # as Exists() subqueries that don't duplicate rows.
+    #
+    # Spatial predicate: raw geography `&&` (bbox-overlap operator) against
+    # an envelope cast to geography. This is what the existing
+    # `exposure_carte_acteur_location_idx` GiST index actually supports —
+    # the ORM's `location__coveredby` expands to ST_CoveredBy, which forces
+    # a parallel seq scan recomputing precise geography distances per row
+    # (~580 ms × 2 workers + 2 s of JIT compilation on a France-wide bbox).
+    # `&&` is bbox-only and lets Postgres choose between an index scan
+    # (small bbox) and a cheap parallel seq scan (wide bbox). Cuts the
+    # France-wide query from ~3 s to ~300 ms.
+    pk_qs = DisplayedActeur.objects.filter(
+        statut=ActeurStatus.ACTIF,
+    ).exclude(location__isnull=True).extra(  # noqa: SLF001
+        where=[
+            "location && ST_MakeEnvelope(%s, %s, %s, %s, 4326)::geography",
+        ],
+        params=[sw_lng, sw_lat, ne_lng, ne_lat],
     )
 
-    if exclude_raw := request.GET.get("exclude_uuids", "").strip():
-        exclude_uuids = [u for u in exclude_raw.split(",") if u]
-        if exclude_uuids:
-            qs = qs.exclude(uuid__in=exclude_uuids)
+    pk_qs, sc_ids, selected_action_ids = _apply_acteurs_filters(pk_qs, request)
 
-    if sc_raw := request.GET.get("sous_categories", "").strip():
-        sc_ids = [int(s) for s in sc_raw.split(",") if s.isdigit()]
-        if sc_ids:
-            qs = qs.filter(
-                proposition_services__sous_categories__id__in=sc_ids
-            )
-
-    selected_action_ids: list[int] = []
-    if ga_raw := request.GET.get("groupe_actions", "").strip():
-        ga_ids = [int(g) for g in ga_raw.split(",") if g.isdigit()]
-        if ga_ids:
-            selected_action_ids = list(
-                Action.objects.filter(groupe_action_id__in=ga_ids).values_list(
-                    "id", flat=True
-                )
-            )
-            qs = qs.filter(proposition_services__action_id__in=selected_action_ids)
-
-    if request.GET.get("bonus") == "1":
-        qs = qs.filter(labels__bonus=True)
-    if request.GET.get("ess") == "1":
-        qs = qs.filter(labels__code="ess")
-
-    # Random ordering so the LIMIT-cap returns a representative sample across
-    # the bbox rather than whatever Postgres has at the head of physical
-    # storage (which heavily skewed toward bibliothèques in our dataset and
-    # made wide-zoom maps look mono-icon). Mirrors the legacy
-    # `DisplayedActeurQuerySet.in_bbox` which also uses `order_by("?")`.
-    qs = qs.distinct().order_by("?").prefetch_related(
-        "proposition_services__action__groupe_action",
-        "proposition_services__sous_categories",
-        "action_principale",
-        # `is_bonus_reparation` walks `acteur.labels.all()` in pure Python; the
-        # prefetch keeps that O(1) per acteur instead of N+1.
-        "labels",
-    )
-
-    limit = settings.CARTE_MAX_SOLUTION_DISPLAYED
+    # Cap separate from CARTE_MAX_SOLUTION_DISPLAYED (which still gates the
+    # legacy list view). The JSON endpoint can return more because spatial
+    # thinning prevents the marker density from getting overwhelming.
+    limit = CARTE_GEOJSON_MAX_FEATURES
     if (raw := request.GET.get("limit", "")) and raw.isdigit():
-        limit = min(int(raw), settings.CARTE_MAX_SOLUTION_DISPLAYED)
-    # Fetch one extra row so we can tell the frontend whether the result set
-    # was truncated and a "zoom in to see more" hint should be shown.
-    overshoot = list(qs[: limit + 1])
-    truncated = len(overshoot) > limit
-    qs = overshoot[:limit]
+        limit = min(int(raw), CARTE_GEOJSON_MAX_FEATURES)
 
-    sc_id_for_action = None
-    if sc_raw and sc_ids:
-        sc_id_for_action = sc_ids[0]
-    action_codes = "|".join(
-        Action.objects.filter(id__in=selected_action_ids)
-        .values_list("code", flat=True)
-    ) if selected_action_ids else None
+    # Step 2: spatially thin the bbox down to one acteur per grid cell, then
+    # cap. ST_SnapToGrid buckets every acteur into a lat/lng cell sized so
+    # it maps to ~CARTE_GEOJSON_TARGET_CELL_PX on screen at the user's
+    # current zoom; GROUP BY collapses each bucket; array_agg(... ORDER BY
+    # random())[1] picks one acteur per cell uniformly so dense areas like
+    # central Paris show a representative sample instead of whatever
+    # Postgres has at the head of physical storage. Visually evenly
+    # distributed at every zoom; avoids icon-on-icon clutter.
+    #
+    # We wrap the ORM-built filter queryset (with Exists() filters already
+    # applied, selecting both identifiant_unique and location) as the FROM
+    # clause. Postgres flattens the subquery and runs the entire pipeline
+    # in a single pass — geometry `&&` index lookup at high zoom, parallel
+    # seq scan at low zoom — avoiding the row-by-row PK lookup that an
+    # explicit JOIN would force on a wide bbox.
+    inner_sql, inner_params = pk_qs.values_list(
+        "identifiant_unique", "location"
+    ).query.sql_with_params()
+    raw_sql = f"""
+        SELECT (array_agg(filtered.identifiant_unique ORDER BY random()))[1]
+        FROM ({inner_sql}) AS filtered
+        GROUP BY ST_SnapToGrid(filtered.location::geometry, %s)
+        LIMIT %s
+    """
+    raw_params = [*inner_params, grid_step, limit + 1]
+    with connection.cursor() as cur:
+        cur.execute(raw_sql, raw_params)
+        sampled_pks = [row[0] for row in cur.fetchall()]
+    truncated = len(sampled_pks) > limit
+    sampled_pks = sampled_pks[:limit]
 
-    features = []
-    for acteur in qs:
-        if acteur.location is None:
-            continue
-        icon, bonus = _resolve_icon(
-            acteur,
-            action_codes=action_codes,
-            sous_categorie_id=sc_id_for_action,
-        )
-        if not icon:
-            continue
-        features.append(
-            {
-                "type": "Feature",
-                "geometry": {
-                    "type": "Point",
-                    "coordinates": [acteur.location.x, acteur.location.y],
-                },
-                "properties": {
-                    "uuid": str(acteur.uuid),
-                    "icon": icon,
-                    "bonus": bonus,
-                    "detail_url": acteur.get_absolute_url(),
-                },
-            }
-        )
+    features = _serialize_acteurs(sampled_pks, sc_ids, selected_action_ids)
 
     return JsonResponse(
         {

--- a/webapp/qfdmo/views/formulaire.py
+++ b/webapp/qfdmo/views/formulaire.py
@@ -1,7 +1,7 @@
 from typing import Any, cast
 
 from django.conf import settings
-from django.core.cache import cache
+from django.core.cache import cache, caches
 from django.db.models import QuerySet
 from django.forms import model_to_dict
 from django.http import HttpRequest, HttpResponse
@@ -88,7 +88,8 @@ class FormulaireSearchActeursView(AbstractSearchActeursView):
 
     def _set_action_displayed(self) -> list[Action]:
         cached_action_instances = cast(
-            list[Action], cache.get_or_set("action_instances", get_action_instances)
+            list[Action],
+            caches["actions"].get_or_set("action_instances", get_action_instances),
         )
         """
         Limit to actions of the direction only in Carte mode
@@ -184,7 +185,8 @@ class FormulaireSearchActeursView(AbstractSearchActeursView):
 
         # Cast needed because of the cache
         cached_action_instances = cast(
-            list[Action], cache.get_or_set("action_instances", get_action_instances)
+            list[Action],
+            caches["actions"].get_or_set("action_instances", get_action_instances),
         )
         actions = (
             [a for a in cached_action_instances if a.code in codes]
@@ -349,7 +351,7 @@ class FormulaireSearchActeursView(AbstractSearchActeursView):
         # Cast needed because of the cache
         cached_groupe_action_instances = cast(
             QuerySet[GroupeAction],
-            cache.get_or_set(
+            caches["actions"].get_or_set(
                 "groupe_action_instances", self.get_groupe_action_instances
             ),
         )

--- a/webapp/static/to_compile/controllers/assistant/state.ts
+++ b/webapp/static/to_compile/controllers/assistant/state.ts
@@ -14,6 +14,7 @@ export default class extends Controller<HTMLElement> {
     adresse: string | null
     latitude: string | null
     longitude: string | null
+    citycode: string | null
   }
   hasAddressAutocompleteOutletConnected = false
   hasSearchSolutionFormOutletConnected = false
@@ -38,6 +39,7 @@ export default class extends Controller<HTMLElement> {
       adresse: sessionStorage.getItem("adresse"),
       latitude: sessionStorage.getItem("latitude"),
       longitude: sessionStorage.getItem("longitude"),
+      citycode: sessionStorage.getItem("citycode"),
     }
 
     this.#setLocationValue(nextLocationValue)
@@ -71,6 +73,15 @@ export default class extends Controller<HTMLElement> {
     this.persistInSessionStorageIfChanged(value?.adresse, "adresse")
     this.persistInSessionStorageIfChanged(value?.latitude, "latitude")
     this.persistInSessionStorageIfChanged(value?.longitude, "longitude")
+    // Citycode is the odd one: an *empty* string is meaningful (the user
+    // picked a non-municipality, so the polygon outline must NOT redraw).
+    // The other persist helper short-circuits on falsy and would leave a
+    // stale citycode behind; clear explicitly when empty.
+    if (value?.citycode) {
+      this.persistInSessionStorageIfChanged(value.citycode, "citycode")
+    } else if (value && "citycode" in value) {
+      sessionStorage.removeItem("citycode")
+    }
   }
 
   updateUIFromGlobalState(outlet) {
@@ -93,9 +104,26 @@ export default class extends Controller<HTMLElement> {
       touched = true
     }
 
+    // Restore the citycode hidden input so the post-submit map render can
+    // re-fetch the commune polygon and redraw the outline. Without this,
+    // a page reload would lose the polygon even though the address itself
+    // was correctly hydrated.
+    if (value.citycode !== null && value.citycode !== undefined) {
+      this.#setHiddenFieldOnOutlet(outlet, "search_area_citycode", value.citycode)
+    }
+
     if (touched) {
       this.submit()
     }
+  }
+
+  #setHiddenFieldOnOutlet(outlet, suffix: string, value: string) {
+    const form = outlet.element.closest("form")
+    if (!form) return
+    const input = form.querySelector(
+      `input[name$="-${suffix}"], input[name="${suffix}"]`,
+    ) as HTMLInputElement | null
+    if (input) input.value = value
   }
 
   submit() {

--- a/webapp/static/to_compile/controllers/carte/acteur_icons_preview_controller.ts
+++ b/webapp/static/to_compile/controllers/carte/acteur_icons_preview_controller.ts
@@ -1,0 +1,77 @@
+import { Controller } from "@hotwired/stimulus"
+import { addOverlay, mapStyles, Overlay } from "carte-facile"
+import maplibregl from "maplibre-gl"
+import { _internals, iconNameFor, registerActeurIcons } from "../../js/acteur_icons"
+
+class ActeurIconsPreviewController extends Controller<HTMLElement> {
+  static targets = ["mapContainer"]
+  declare readonly mapContainerTarget: HTMLDivElement
+
+  async connect() {
+    const map = new maplibregl.Map({
+      container: this.mapContainerTarget,
+      style: mapStyles.desaturated,
+      center: [2.213749, 46.227638],
+      zoom: 5.5,
+      attributionControl: { compact: true },
+    })
+
+    addOverlay(map, Overlay.administrativeBoundaries)
+
+    await new Promise<void>((resolve) => map.on("load", () => resolve()))
+    await registerActeurIcons(map)
+
+    // Expose for pixel-diff testing in the preview harness.
+    ;(window as unknown as { _previewMap?: typeof map })._previewMap = map
+
+    // One feature per (variant × bonus) at a stable spot so we can eyeball
+    // each variant. Lay them out across France in a row so all are visible at
+    // initial zoom.
+    const features = _internals.GROUPE_ACTION_VARIANTS.flatMap((variant, index) => {
+      const lng = -3 + index * 1.6
+      return [false, true].map((bonus, row) => ({
+        type: "Feature" as const,
+        geometry: {
+          type: "Point" as const,
+          coordinates: [lng, 47.5 - row * 1.4],
+        },
+        properties: {
+          icon: iconNameFor(variant.code, bonus),
+          label: `${variant.code}${bonus ? " + bonus" : ""}`,
+        },
+      }))
+    })
+
+    map.addSource("acteurs-preview", {
+      type: "geojson",
+      data: { type: "FeatureCollection", features },
+    })
+
+    map.addLayer({
+      id: "acteurs-preview-layer",
+      type: "symbol",
+      source: "acteurs-preview",
+      layout: {
+        "icon-image": ["get", "icon"],
+        // Anchor the bottom-tip of the pin (with bonus protrusion accounted for
+        // by the SVG's outer canvas height) to the geographic point. Today's
+        // DOM pinpoints anchor on the point too via the maplibre default.
+        "icon-anchor": "bottom",
+        "icon-allow-overlap": true,
+        "icon-ignore-placement": true,
+        "text-field": ["get", "label"],
+        "text-font": ["Open Sans Regular"],
+        "text-offset": [0, 1],
+        "text-anchor": "top",
+        "text-size": 11,
+        "text-allow-overlap": true,
+      },
+      paint: {
+        "text-halo-color": "#fff",
+        "text-halo-width": 1.5,
+      },
+    })
+  }
+}
+
+export default ActeurIconsPreviewController

--- a/webapp/static/to_compile/controllers/carte/address_autocomplete_controller.ts
+++ b/webapp/static/to_compile/controllers/carte/address_autocomplete_controller.ts
@@ -1,5 +1,6 @@
 import AutocompleteController from "./autocomplete_controller"
 
+
 class AdresseAutocompleteController extends AutocompleteController {
   controllerName: string = "address-autocomplete"
 
@@ -63,9 +64,53 @@ class AdresseAutocompleteController extends AutocompleteController {
     } else if (!("geolocation" in navigator)) {
       console.error("geolocation is not available")
     } else {
-      this.dispatchLocationToGlobalState(labelValue, latitudeValue, longitudeValue)
+      // Resolve the commune polygon (when applicable) BEFORE dispatching the
+      // location change. The bbox derived from the polygon is what makes the
+      // form submit fit the area precisely; the polygon itself is pinned to
+      // the searched citycode so the next page render can re-fetch it.
+      const citycode = option.citycode as string | undefined
+      const isMunicipality = option.type === "municipality"
+      const cityCitycode = isMunicipality && citycode ? citycode : ""
+      if (cityCitycode) {
+        this.#applyCityArea(cityCitycode)
+      } else {
+        this.#clearCityArea()
+      }
+      this.dispatchLocationToGlobalState(
+        labelValue,
+        latitudeValue,
+        longitudeValue,
+        cityCitycode,
+      )
     }
     this.hideAutocompleteList()
+  }
+
+  // Persist the citycode in the form's hidden field so it survives the Turbo
+  // Frame submit. The post-swap MapController fetches the polygon from the
+  // server (which has the bbox cached) and draws the outline. We deliberately
+  // do not fetch the polygon here: it would be a wasted round-trip — the
+  // bbox is already computed server-side at template-render time and the
+  // outline only needs to be drawn once, after the Turbo swap.
+  #applyCityArea(citycode: string): void {
+    this.#setHiddenField("search_area_citycode", citycode)
+    this.dispatch("area", { detail: { citycode } })
+  }
+
+  #clearCityArea(): void {
+    this.#setHiddenField("search_area_citycode", "")
+    this.dispatch("area", { detail: { citycode: "", bbox: null, polygon: null } })
+  }
+
+  // Find a hidden input by suffix-name within the same form (the form name is
+  // prefix-namespaced, e.g. `carte_map-search_area_citycode`).
+  #setHiddenField(suffix: string, value: string): void {
+    const form = this.element.closest("form")
+    if (!form) return
+    const input = form.querySelector<HTMLInputElement>(
+      `input[name$="-${suffix}"], input[name="${suffix}"]`,
+    )
+    if (input) input.value = value
   }
 
   async getAndStorePosition(position: GeolocationPosition) {
@@ -81,10 +126,22 @@ class AdresseAutocompleteController extends AutocompleteController {
         return
       }
 
+      // Mirror selectOption's citycode gating: only persist a citycode for
+      // municipality-typed BAN results, so the polygon outline only redraws
+      // when the user actually picked a city (not a street/housenumber).
+      const props = data.features[0].properties
+      const cityCitycode =
+        props.type === "municipality" && props.citycode ? props.citycode : ""
+      if (cityCitycode) {
+        this.#applyCityArea(cityCitycode)
+      } else {
+        this.#clearCityArea()
+      }
       this.dispatchLocationToGlobalState(
-        data.features[0].properties.label,
+        props.label,
         data.features[0].geometry.coordinates[1],
         data.features[0].geometry.coordinates[0],
+        cityCitycode,
       )
 
       this.#hideInputError()
@@ -95,8 +152,13 @@ class AdresseAutocompleteController extends AutocompleteController {
     }
   }
 
-  dispatchLocationToGlobalState(adresse: string, latitude: string, longitude: string) {
-    this.dispatch("change", { detail: { adresse, latitude, longitude } })
+  dispatchLocationToGlobalState(
+    adresse: string,
+    latitude: string,
+    longitude: string,
+    citycode: string = "",
+  ) {
+    this.dispatch("change", { detail: { adresse, latitude, longitude, citycode } })
   }
 
   keydownEnter(event: KeyboardEvent): boolean {
@@ -145,6 +207,13 @@ class AdresseAutocompleteController extends AutocompleteController {
               sub_label: feature.properties.context,
               longitude: feature.geometry.coordinates[0],
               latitude: feature.geometry.coordinates[1],
+              // The BAN feature type ("municipality" | "street" | "housenumber"
+              // | "locality" | "town"). Used to decide whether to fetch a
+              // commune polygon outline.
+              type: feature.properties.type,
+              // INSEE citycode (e.g. "56007"). Present on every BAN feature
+              // and used to resolve a commune polygon.
+              citycode: feature.properties.citycode,
             }
           })
           .concat([{ label: "Autour de moi", longitude: 9999, latitude: 9999 }])

--- a/webapp/static/to_compile/controllers/carte/map_controller.ts
+++ b/webapp/static/to_compile/controllers/carte/map_controller.ts
@@ -4,6 +4,7 @@ import { removeHash } from "../../js/helpers"
 import { SolutionMap } from "../../js/solution_map"
 import { ActorLocation, DisplayedActeur } from "../../js/types"
 
+
 export class Actor implements DisplayedActeur {
   uuid: string
   fillBackground: boolean
@@ -28,11 +29,31 @@ export class Actor implements DisplayedActeur {
 
 class MapController extends Controller<HTMLElement> {
   actorsMap: SolutionMap
-  static targets = ["acteur", "searchInZoneButton", "bbox", "mapContainer"]
+  static targets = [
+    "acteur",
+    "searchInZoneButton",
+    "bbox",
+    "mapContainer",
+    "loadingIndicator",
+  ]
   static values = {
     location: { type: Object, default: {} },
     initialZoom: Number,
     theme: { type: String, default: "carto-light" },
+    acteurFrameId: { type: String, default: "" },
+    filterParams: { type: String, default: "" },
+    // When true, the controller fetches acteurs from the GeoJSON endpoint and
+    // renders them as a MapLibre symbol layer (the new carte behavior). When
+    // false, it keeps the legacy DOM-marker path used by the formulaire page.
+    useGeojsonLayer: { type: Boolean, default: false },
+    // INSEE citycode of the commune the user picked from the address
+    // autocomplete. When non-empty, the controller refetches the polygon from
+    // geo.api.gouv.fr and draws the search-area overlay.
+    searchAreaCitycode: { type: String, default: "" },
+    // Pre-resolved polygon bbox JSON, computed server-side from the cached
+    // commune feature. Lets the controller fit the camera synchronously on
+    // connect (avoiding the camera jolt when the polygon fetch lands later).
+    searchAreaBbox: { type: String, default: "" },
   }
   declare readonly acteurTargets: Array<HTMLElement>
   declare readonly searchInZoneButtonTarget: HTMLButtonElement
@@ -40,9 +61,27 @@ class MapController extends Controller<HTMLElement> {
   declare readonly bboxTarget: HTMLInputElement
   declare readonly mapContainerTarget: HTMLDivElement
   declare readonly hasBboxTarget: boolean
+  declare readonly loadingIndicatorTarget: HTMLDivElement
+  declare readonly hasLoadingIndicatorTarget: boolean
   declare readonly locationValue: object
   declare readonly initialZoomValue: number
   declare readonly themeValue: string
+  declare readonly acteurFrameIdValue: string
+  declare readonly filterParamsValue: string
+  declare readonly useGeojsonLayerValue: boolean
+  declare readonly searchAreaCitycodeValue: string
+  declare readonly searchAreaBboxValue: string
+
+  #inFlightFetches = 0
+  #latestBbox?: {
+    southWest: { lat: number; lng: number }
+    northEast: { lat: number; lng: number }
+  }
+  // Loading-spinner reveal is delayed so fast fetches don't flicker the
+  // indicator. Per the carte spec, the spinner must not appear before this
+  // many ms of in-flight fetch.
+  #loadingDelayMs = 250
+  #loadingDelayTimer?: number
 
   connect() {
     this.actorsMap = new SolutionMap({
@@ -53,18 +92,154 @@ class MapController extends Controller<HTMLElement> {
       theme: this.themeValue,
     })
 
-    if (this.hasBboxTarget && this.bboxTarget.value !== "") {
-      const bbox = JSON.parse(this.bboxTarget.value)
-      this.actorsMap.addActorMarkersToMap(this.acteurTargets, bbox)
+    let initialBbox: { southWest: { lat: number; lng: number }; northEast: { lat: number; lng: number } } | undefined
+
+    // The form's bounding_box field is prefix-namespaced (e.g.
+    // `carte_map-bounding_box`) so a plain `?bounding_box=…` URL param doesn't
+    // populate it. Fall back to reading the URL param directly when present —
+    // both for shareable links and for the iframe embed scenarios.
+    const urlBbox = new URLSearchParams(window.location.search).get("bounding_box")
+    if (urlBbox) {
+      try {
+        initialBbox = JSON.parse(urlBbox)
+      } catch {
+        initialBbox = undefined
+      }
+    }
+
+    if (!initialBbox && this.hasBboxTarget && this.bboxTarget.value !== "") {
+      try {
+        initialBbox = JSON.parse(this.bboxTarget.value)
+      } catch {
+        initialBbox = undefined
+      }
+    }
+
+    // Prefer the server-supplied search-area bbox when present: it's the
+    // exact polygon extent of the commune the user selected, so the camera
+    // lands on the right viewport synchronously (no jolt when the async
+    // polygon fetch lands later).
+    if (!initialBbox && this.searchAreaBboxValue) {
+      try {
+        initialBbox = JSON.parse(this.searchAreaBboxValue)
+      } catch {
+        initialBbox = undefined
+      }
+    }
+
+    // After an address-search submit the server returns lat/lng but no bbox
+    // (the queryset uses `from_center` for distance filtering). Without this
+    // fallback the map would fall through to the camera default (zoom-3
+    // whole-France) and the GeoJSON fetch would target a worldwide bbox.
+    // Build a tight 300 m box around the searched location — natural framing
+    // for a specific address (street / housenumber / locality). For
+    // municipality-type results we already have a polygon bbox above.
+    if (!initialBbox) {
+      const loc = this.locationValue as { latitude?: number | string; longitude?: number | string }
+      const lat = parseFloat(String(loc?.latitude ?? ""))
+      const lng = parseFloat(String(loc?.longitude ?? ""))
+      if (Number.isFinite(lat) && Number.isFinite(lng)) {
+        // 300 m radius. 1 deg lat ≈ 111 km everywhere; 1 deg lng ≈ cos(lat) *
+        // 111 km, so we scale the longitude offset by 1 / cos(lat) to keep
+        // the box visually square at metropolitan France latitudes.
+        const radiusMeters = 300
+        const halfLat = radiusMeters / 111_000
+        const halfLng =
+          radiusMeters / (111_000 * Math.cos((lat * Math.PI) / 180))
+        initialBbox = {
+          southWest: { lat: lat - halfLat, lng: lng - halfLng },
+          northEast: { lat: lat + halfLat, lng: lng + halfLng },
+        }
+      }
+    }
+
+    // Detect a non-municipality address search: the user picked a street /
+    // housenumber / locality (no citycode came back from the server) but we
+    // do have lat/lng. In that case, switch to the KNN endpoint to fetch the
+    // 30 nearest acteurs and fit the camera to their bbox — gives a useful
+    // viewport even in sparse zones.
+    const loc = this.locationValue as { latitude?: number | string; longitude?: number | string }
+    const lat = parseFloat(String(loc?.latitude ?? ""))
+    const lng = parseFloat(String(loc?.longitude ?? ""))
+    const useKnn =
+      !this.searchAreaCitycodeValue &&
+      !this.searchAreaBboxValue &&
+      Number.isFinite(lat) &&
+      Number.isFinite(lng) &&
+      // The URL bbox path is for shareable links / iframes; respect it over
+      // the KNN heuristic.
+      !new URLSearchParams(window.location.search).get("bounding_box")
+
+    if (this.useGeojsonLayerValue) {
+      // Defer to the next tick so MapLibre can finish setting up the canvas
+      // before we register icons and add the layer.
+      this.actorsMap.map.once("load", () => {
+        if (useKnn) {
+          void this.#fetchAndAppendNearest(lat, lng)
+        } else {
+          const bbox = initialBbox ?? this.#bboxFromCurrentView()
+          void this.#fetchAndAppend(bbox, { fitBounds: !initialBbox })
+        }
+        // Re-fetch and draw the search-area overlay if a citycode survived
+        // the Turbo Frame submit. Independent of the acteur fetch so the
+        // overlay shows up even when the bbox is empty.
+        if (this.searchAreaCitycodeValue) {
+          void this.#applySearchArea(this.searchAreaCitycodeValue)
+        }
+      })
+
+      if (initialBbox) {
+        // Pre-zoom the map onto the requested bbox so the first fetch hits the
+        // right area. Without this, the map starts centered on France and the
+        // initial fetch returns features outside the chosen bbox. Animate so
+        // a fresh address search reads as a smooth zoom rather than a jump.
+        this.actorsMap.fitBounds([], initialBbox, { animate: true })
+      }
     } else {
-      this.actorsMap.addActorMarkersToMap(this.acteurTargets)
+      // Legacy DOM-marker path used by formulaire.
+      if (initialBbox) {
+        this.actorsMap.addActorMarkersToMap(this.acteurTargets, initialBbox)
+      } else {
+        this.actorsMap.addActorMarkersToMap(this.acteurTargets)
+      }
     }
 
     this.actorsMap.initEventListener()
     removeHash()
   }
 
+  #bboxFromCurrentView() {
+    const bounds = this.actorsMap.map.getBounds()
+    return {
+      southWest: { lng: bounds.getWest(), lat: bounds.getSouth() },
+      northEast: { lng: bounds.getEast(), lat: bounds.getNorth() },
+    }
+  }
+
+  // Refetch the commune polygon for the current citycode and draw it as the
+  // search-area overlay outline. The camera was already fitted synchronously
+  // on `connect()` using the server-supplied bbox, so this is purely a
+  // visual enhancement that lands silently. Failures are swallowed: the
+  // overlay is a UI nicety, not load-bearing.
+  async #applySearchArea(citycode: string): Promise<void> {
+    try {
+      // Hit our same-origin proxy instead of geo.api.gouv.fr directly. The
+      // server caches polygons for a year, so subsequent loads of the same
+      // commune skip the upstream call entirely.
+      const response = await fetch(`/carte/communes/${citycode}.geojson`)
+      if (!response.ok) return
+      const feature = await response.json()
+      this.actorsMap.setSearchArea(feature)
+    } catch (err) {
+      console.error("commune polygon refetch failed", err)
+    }
+  }
+
   disconnect() {
+    // Carte spec "Known fixes required" §3.4: abort any in-flight GeoJSON
+    // fetch before tearing down the map, otherwise the fetch outlives the
+    // controller and may try to mutate a removed source.
+    this.actorsMap?.abortPendingFetch?.()
     this.actorsMap?.map?.remove()
   }
 
@@ -74,12 +249,109 @@ class MapController extends Controller<HTMLElement> {
 
   mapChanged(event: CustomEvent) {
     this.dispatch("updateBbox", { detail: event.detail })
+
+    // Per the carte spec, panning/zooming does not auto-fetch. Surface the
+    // "Rechercher dans cette zone" button instead so the user explicitly
+    // decides when to query the new area. Cached bbox is read on click.
+    this.#latestBbox = {
+      southWest: {
+        lng: event.detail.southWest.lng,
+        lat: event.detail.southWest.lat,
+      },
+      northEast: {
+        lng: event.detail.northEast.lng,
+        lat: event.detail.northEast.lat,
+      },
+    }
     this.#displaySearchInZoneButton()
+  }
+
+  // Stimulus action: fired when the user clicks "Rechercher dans cette zone".
+  // Fetches acteurs for the latest known map bbox and appends them to the
+  // GeoJSON layer (existing markers stay).
+  searchInZone(event?: Event): void {
+    event?.preventDefault()
+    if (!this.useGeojsonLayerValue) {
+      // Legacy formulaire path keeps its full-form submission (handled by
+      // the state controller via the original data-action). This branch
+      // shouldn't fire on the carte but is defensive.
+      return
+    }
+    const bbox = this.#latestBbox ?? this.#bboxFromCurrentView()
+    this.#hideSearchInZoneButton()
+    void this.#fetchAndAppend(bbox, { fitBounds: false })
   }
 
   #displaySearchInZoneButton() {
     if (this.hasSearchInZoneButtonTarget) {
       this.searchInZoneButtonTarget.classList.remove("qf-hidden")
+    }
+  }
+
+  #hideSearchInZoneButton() {
+    if (this.hasSearchInZoneButtonTarget) {
+      this.searchInZoneButtonTarget.classList.add("qf-hidden")
+    }
+  }
+
+  async #fetchAndAppend(
+    bbox: {
+      southWest: { lat: number; lng: number }
+      northEast: { lat: number; lng: number }
+    },
+    options: { fitBounds?: boolean } = {},
+  ): Promise<void> {
+    this.#showLoading(true)
+    try {
+      await this.actorsMap.loadActeursForBbox(bbox, {
+        wipe: false,
+        fitBounds: options.fitBounds,
+        extraParams: this.filterParamsValue || undefined,
+      })
+    } finally {
+      this.#showLoading(false)
+    }
+  }
+
+  // KNN counterpart of #fetchAndAppend: hits the nearest-acteurs endpoint and
+  // fits the camera to the returned features' bbox. Used on the initial load
+  // after a non-municipality address search.
+  async #fetchAndAppendNearest(lat: number, lng: number): Promise<void> {
+    this.#showLoading(true)
+    try {
+      await this.actorsMap.loadActeursNearest(lat, lng, {
+        count: 30,
+        extraParams: this.filterParamsValue || undefined,
+      })
+    } finally {
+      this.#showLoading(false)
+    }
+  }
+
+  #showLoading(showing: boolean): void {
+    if (showing) {
+      this.#inFlightFetches += 1
+    } else if (this.#inFlightFetches > 0) {
+      this.#inFlightFetches -= 1
+    }
+    if (!this.hasLoadingIndicatorTarget) return
+
+    if (this.#inFlightFetches > 0) {
+      // Defer the actual reveal so a sub-250ms fetch never flickers the
+      // spinner. If the fetch resolves first, the timer is cleared in the
+      // else-branch below before it ever fires.
+      if (!this.#loadingDelayTimer) {
+        this.#loadingDelayTimer = window.setTimeout(() => {
+          this.loadingIndicatorTarget.classList.remove("qf-hidden")
+          this.#loadingDelayTimer = undefined
+        }, this.#loadingDelayMs)
+      }
+    } else {
+      if (this.#loadingDelayTimer) {
+        window.clearTimeout(this.#loadingDelayTimer)
+        this.#loadingDelayTimer = undefined
+      }
+      this.loadingIndicatorTarget.classList.add("qf-hidden")
     }
   }
 }

--- a/webapp/static/to_compile/js/acteur_icons.ts
+++ b/webapp/static/to_compile/js/acteur_icons.ts
@@ -1,0 +1,276 @@
+import type { Map } from "maplibre-gl"
+
+// Use the actual device pixel ratio (with a floor of 2 so non-retina users
+// still get a sharp image when MapLibre tints/scales it during pan/zoom).
+const PIXEL_RATIO = Math.max(window.devicePixelRatio || 1, 2)
+
+// Today's DOM markers are wrapped with `qf-scale-75` (CSS scale 0.75), so the
+// 46x61 native pin renders at ~34x46 on screen. Bake that into the rasterized
+// canvas so consumers don't need to apply icon-size: 0.75 themselves.
+const DISPLAY_SCALE = 0.75
+
+// Pin shape: the white interior path…
+const PIN_OUTLINE_PATH =
+  "M36.899 39.868c4.98-4.132 8.15-10.367 8.15-17.343C45.05 10.085 34.966 0 22.526 0 10.085 0 0 10.085 0 22.525c0 6.972 3.167 13.204 8.142 17.335l5.008 5.21a44.446 44.446 0 0 1 9.622 15.326 42.517 42.517 0 0 1 9.244-15.336l4.883-5.192Z"
+
+// …and the original painted "stroke" path (a separately authored shape that
+// hugs the perimeter, drawn on top of the fill). Carrying the original shape
+// over verbatim keeps the asymmetric weighting and pixel-perfect match with
+// the legacy DOM marker.
+const PIN_OUTLINE_STROKE_PATH =
+  "m36.899 39.868-1.916-2.31-.143.12-.127.135 2.186 2.055ZM8.142 39.86l2.163-2.079-.117-.12-.13-.108-1.916 2.307Zm5.008 5.21-2.163 2.08 2.163-2.08Zm9.622 15.326-2.812 1.045 2.925 7.875 2.725-7.947-2.838-.973Zm9.244-15.336 2.186 2.055-2.186-2.055ZM42.05 22.525c0 6.046-2.745 11.448-7.067 15.034l3.832 4.617C44.45 37.5 48.05 30.431 48.05 22.525h-6ZM22.525 3C33.308 3 42.05 11.742 42.05 22.525h6C48.05 8.428 36.621-3 22.525-3v6ZM3 22.525C3 11.742 11.742 3 22.525 3v-6C8.428-3-3 8.428-3 22.525h6Zm7.059 15.028C5.74 33.967 3 28.567 3 22.525h-6C-3 30.426.594 37.49 6.225 42.168l3.834-4.615Zm-4.08 4.386 5.008 5.21 4.326-4.158-5.008-5.21-4.326 4.158Zm5.008 5.21a41.446 41.446 0 0 1 8.973 14.292l5.625-2.09a47.445 47.445 0 0 0-10.272-16.36l-4.326 4.158ZM25.61 61.37a39.518 39.518 0 0 1 8.592-14.254l-4.371-4.11a45.519 45.519 0 0 0-9.897 16.418l5.676 1.946Zm8.592-14.254 4.883-5.192-4.372-4.11-4.882 5.192 4.37 4.11Z"
+
+// The original painted-stroke path extends ~3 SVG units past the pin's outer
+// edge. Pad the canvas by that amount on each side so the stroke isn't
+// clipped against the canvas boundary.
+const STROKE_MARGIN = 3.5
+
+const REPARER_FILLED_FOREGROUND = "#37635F"
+
+type IconGlyph = {
+  // SVG inner markup, expected viewBox 0 0 24 24 (or 0 0 30 30 for hand-heart).
+  // Color comes from `currentColor` so we can recolor at composition time.
+  innerSvg: string
+  viewBox: string
+}
+
+const GLYPHS: Record<string, IconGlyph> = {
+  "fr-icon-hand-heart": {
+    viewBox: "0 0 30 30",
+    innerSvg:
+      '<path fill="currentColor" d="M6.522 8.396a9.1 9.1 0 0 1 4.341 1.864h2.83a5.87 5.87 0 0 1 5.87 5.869h-9.131l.002 1.305 10.432-.001V16.129a7.27 7.27 0 0 0-1.155-3.913h3.764a6.52 6.52 0 0 1 5.89 3.72c-3.085 4.07-8.08 6.713-13.716 6.713-3.6 0-6.65-.77-9.128-2.118zM3.912 7c.72 0 1.305.584 1.305 1.304v11.738c0 .72-.585 1.304-1.305 1.304H1.304c-.72 0-1.304-.584-1.304-1.304V8.304C0 7.584.584 7 1.304 7z"/>',
+  },
+  "fr-icon-arrow-go-back-line": {
+    viewBox: "0 0 24 24",
+    innerSvg:
+      '<path fill="currentColor" d="m5.828 7 2.536 2.536L6.95 10.95 2 6l4.95-4.95 1.414 1.414L5.828 5H13a8 8 0 1 1 0 16H4v-2h9a6 6 0 1 0 0-12H5.828Z"/>',
+  },
+  "fr-icon-tools-fill": {
+    viewBox: "0 0 24 24",
+    innerSvg:
+      '<path fill="currentColor" d="M5.32943 3.27152C6.56252 2.83314 7.9923 3.10743 8.97927 4.0944C9.96652 5.08165 10.2407 6.51196 9.80178 7.74529L20.6465 18.5901L18.5252 20.7114L7.67936 9.86703C6.44627 10.3054 5.01649 10.0311 4.02952 9.04415C3.04227 8.0569 2.7681 6.62659 3.20701 5.39326L5.44373 7.62994C6.02952 8.21572 6.97927 8.21572 7.56505 7.62994C8.15084 7.04415 8.15084 6.0944 7.56505 5.50862L5.32943 3.27152ZM15.6968 5.15506L18.8788 3.38729L20.293 4.80151L18.5252 7.98349L16.7574 8.33704L14.6361 10.4584L13.2219 9.04415L15.3432 6.92283L15.6968 5.15506ZM8.62572 12.9332L10.747 15.0546L5.79729 20.0043C5.2115 20.5901 4.26175 20.5901 3.67597 20.0043C3.12464 19.453 3.09221 18.5792 3.57867 17.99L3.67597 17.883L8.62572 12.9332Z"/>',
+  },
+  "fr-icon-recycle-line": {
+    viewBox: "0 0 24 24",
+    innerSvg:
+      '<path fill="currentColor" d="m19.562 12.097 1.531 2.653a3.5 3.5 0 0 1-3.03 5.25H16v2.5L11 19l5-3.5V18h2.062a1.5 1.5 0 0 0 1.3-2.25l-1.532-2.653 1.732-1ZM7.304 9.134l.53 6.08-2.164-1.25-1.031 1.786A1.5 1.5 0 0 0 5.938 18H9v2H5.938a3.5 3.5 0 0 1-3.031-5.25l1.03-1.787-2.164-1.249 5.53-2.58h.001Zm6.446-6.165c.532.307.974.749 1.281 1.281l1.03 1.785 2.166-1.25-.53 6.081-5.532-2.58 2.165-1.25-1.031-1.786a1.5 1.5 0 0 0-2.598 0L9.169 7.903l-1.732-1L8.97 4.25a3.5 3.5 0 0 1 4.781-1.281h-.001Z"/>',
+  },
+  "fr-icon-money-euro-circle-line": {
+    viewBox: "0 0 24 24",
+    innerSvg:
+      '<path fill="currentColor" d="M12.0049 22.0027C6.48204 22.0027 2.00488 17.5256 2.00488 12.0027C2.00488 6.4799 6.48204 2.00275 12.0049 2.00275C17.5277 2.00275 22.0049 6.4799 22.0049 12.0027C22.0049 17.5256 17.5277 22.0027 12.0049 22.0027ZM12.0049 20.0027C16.4232 20.0027 20.0049 16.421 20.0049 12.0027C20.0049 7.58447 16.4232 4.00275 12.0049 4.00275C7.5866 4.00275 4.00488 7.58447 4.00488 12.0027C4.00488 16.421 7.5866 20.0027 12.0049 20.0027ZM10.0549 11.0027H15.0049V13.0027H10.0549C10.2865 14.1439 11.2954 15.0027 12.5049 15.0027C13.1201 15.0027 13.6833 14.7806 14.1188 14.412L15.8198 15.546C14.9973 16.4415 13.8166 17.0027 12.5049 17.0027C10.1886 17.0027 8.28107 15.2527 8.03235 13.0027H7.00488V11.0027H8.03235C8.28107 8.75277 10.1886 7.00275 12.5049 7.00275C13.8166 7.00275 14.9973 7.56402 15.8198 8.45951L14.1189 9.59351C13.6834 9.22496 13.1201 9.00275 12.5049 9.00275C11.2954 9.00275 10.2865 9.86163 10.0549 11.0027Z"/>',
+  },
+}
+
+// Mirrors GroupeAction rows in the database. Names match the `code` column.
+// `iconClass` matches GroupeAction.icon (DSFR class), used to pick the glyph.
+type GroupeActionVariant = {
+  code: string
+  iconClass: string
+  couleur: string
+  filled: boolean
+}
+
+const GROUPE_ACTION_VARIANTS: GroupeActionVariant[] = [
+  {
+    code: "donner_echanger_rapporter",
+    iconClass: "fr-icon-hand-heart",
+    couleur: "#417dc4",
+    filled: false,
+  },
+  {
+    code: "emprunter_preter_louer",
+    iconClass: "fr-icon-arrow-go-back-line",
+    couleur: "#ce614a",
+    filled: false,
+  },
+  {
+    code: "reparer",
+    iconClass: "fr-icon-tools-fill",
+    couleur: "#009081",
+    filled: true,
+  },
+  {
+    code: "trier",
+    iconClass: "fr-icon-recycle-line",
+    couleur: "#A558A0",
+    filled: false,
+  },
+  {
+    code: "vendre_acheter",
+    iconClass: "fr-icon-money-euro-circle-line",
+    couleur: "#D1B781",
+    filled: false,
+  },
+]
+
+const BONUS_BADGE_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 22 22" fill="none">
+<rect width="22" height="22" rx="11" fill="#EFCB3A"/>
+<path fill="#161616" d="M14.6699 17.0019C13.3813 17.0019 12.3366 15.9573 12.3366 14.6686C12.3366 13.3799 13.3813 12.3353 14.6699 12.3353C15.9586 12.3353 17.0033 13.3799 17.0033 14.6686C17.0033 15.9573 15.9586 17.0019 14.6699 17.0019ZM14.6699 15.6686C15.2222 15.6686 15.6699 15.2209 15.6699 14.6686C15.6699 14.1163 15.2222 13.6686 14.6699 13.6686C14.1177 13.6686 13.6699 14.1163 13.6699 14.6686C13.6699 15.2209 14.1177 15.6686 14.6699 15.6686ZM7.33659 9.66859C6.04793 9.66859 5.00325 8.62395 5.00325 7.33529C5.00325 6.04662 6.04793 5.00195 7.33659 5.00195C8.62525 5.00195 9.66993 6.04662 9.66993 7.33529C9.66993 8.62395 8.62525 9.66859 7.33659 9.66859ZM7.33659 8.33529C7.88887 8.33529 8.33659 7.88757 8.33659 7.33529C8.33659 6.783 7.88887 6.33529 7.33659 6.33529C6.78431 6.33529 6.33659 6.783 6.33659 7.33529C6.33659 7.88757 6.78431 8.33529 7.33659 8.33529ZM15.7173 5.3451L16.6601 6.28791L6.28921 16.6588L5.3464 15.716L15.7173 5.3451Z"/>
+</svg>`
+
+// Position the icon glyph the same way the live DOM does:
+// .qf-scale-75 on the wrapper, plus the existing .qf-top-[10] .qf-left-[10.5]
+// inside a 46x61 container. We render the SVG at native pin resolution; visual
+// sizing happens via MapLibre's icon-size or by displaying at half-pixel-ratio.
+const ICON_POS_X = 10.5
+const ICON_POS_Y = 10
+const ICON_SIZE = 22
+
+const PIN_NATIVE_WIDTH = 46
+const PIN_NATIVE_HEIGHT = 61
+// Bonus badge per the Figma design system ("Carte/Punaises de carte"). The
+// native SVG badge is 22x22; we render it smaller (16x16) and overlapping the
+// upper-right of the pin's circular head, with the badge center sitting just
+// above the pin's right shoulder.
+const BONUS_BADGE_DISPLAY_SIZE = 16
+const BONUS_BADGE_NATIVE_SIZE = 22
+const BONUS_BADGE_SCALE = BONUS_BADGE_DISPLAY_SIZE / BONUS_BADGE_NATIVE_SIZE
+// Position of the badge's top-left corner in pin-local coords. Pin head is
+// centered around (22.5, 22.5) with radius ~22.5; right shoulder ≈ (40, 6).
+const BONUS_BADGE_LEFT = 32
+const BONUS_BADGE_TOP = 0
+// How far the badge protrudes past the pin's bounding box. The badge ends at
+// (BONUS_BADGE_LEFT + DISPLAY_SIZE, BONUS_BADGE_TOP) max corner = (48, 0). Pin
+// is 46 wide, so right protrusion = 48 - 46 = 2. Top is 0; pin starts at 0;
+// so top protrusion = 0 (no protrusion above the pin's bounding box).
+const BONUS_PROTRUSION_RIGHT = Math.max(
+  0,
+  BONUS_BADGE_LEFT + BONUS_BADGE_DISPLAY_SIZE - PIN_NATIVE_WIDTH,
+)
+const BONUS_PROTRUSION_TOP = Math.max(0, -BONUS_BADGE_TOP)
+
+function buildPinSvg(variant: GroupeActionVariant, withBonus: boolean): string {
+  const glyph = GLYPHS[variant.iconClass]
+  if (!glyph) {
+    throw new Error(`Unknown glyph for icon class: ${variant.iconClass}`)
+  }
+
+  // Pin background:
+  //  - filled: solid couleur fill, foreground stroke = REPARER_FILLED_FOREGROUND
+  //  - outline: white fill, foreground stroke = couleur
+  const pinFill = variant.filled ? variant.couleur : "#fff"
+  const pinStroke = variant.filled ? REPARER_FILLED_FOREGROUND : variant.couleur
+  const iconColor = variant.filled ? "#fff" : variant.couleur
+
+  // Replace currentColor with the resolved color so the glyph paints reliably
+  // without depending on CSS inheritance through nested groups.
+  const coloredGlyph = glyph.innerSvg.replace(/currentColor/g, iconColor)
+
+  // Canvas dimensions depend on whether the bonus badge is included.
+  // Always reserve STROKE_MARGIN on each pin edge so the stroke isn't clipped.
+  // Bonus variant additionally extends the canvas to fit the protruding badge
+  // on the upper-right.
+  const rightPadding = withBonus
+    ? BONUS_PROTRUSION_RIGHT + STROKE_MARGIN
+    : STROKE_MARGIN
+  const topPadding = withBonus ? BONUS_PROTRUSION_TOP : STROKE_MARGIN
+  const outerWidth = PIN_NATIVE_WIDTH + STROKE_MARGIN + rightPadding
+  const outerHeight = PIN_NATIVE_HEIGHT + topPadding + STROKE_MARGIN
+  const pinOffsetX = STROKE_MARGIN
+  const pinOffsetY = topPadding
+
+  // Bonus badge in pin-local coords. The badge SVG is 22x22 native; we scale
+  // it to BONUS_BADGE_DISPLAY_SIZE and position its top-left at
+  // (BONUS_BADGE_LEFT, BONUS_BADGE_TOP) so its center sits over the pin's
+  // upper-right shoulder per the Figma reference.
+  const bonusOverlay = withBonus
+    ? `<g transform="translate(${BONUS_BADGE_LEFT} ${BONUS_BADGE_TOP}) scale(${BONUS_BADGE_SCALE})">${BONUS_BADGE_SVG.replace(/^<svg[^>]*>|<\/svg>$/g, "")}</g>`
+    : ""
+
+  const glyphScale = ICON_SIZE / parseFloat(glyph.viewBox.split(" ")[2])
+
+  // The legacy template clips the painted-stroke to the pin outline via an
+  // SVG <mask>. We do the same so the stroke doesn't bleed past the pin
+  // edges. Mask is in pin-local coordinates, applied to the path before the
+  // outer translation - so we apply it inline on the masked path itself.
+  const maskId = `pin-mask-${variant.code}-${withBonus ? "bonus" : "plain"}`
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${outerWidth}" height="${outerHeight}" viewBox="0 0 ${outerWidth} ${outerHeight}">
+  <defs>
+    <mask id="${maskId}" maskUnits="userSpaceOnUse">
+      <path d="${PIN_OUTLINE_PATH}" fill="#fff"/>
+    </mask>
+  </defs>
+  <g transform="translate(${pinOffsetX} ${pinOffsetY})">
+    <path d="${PIN_OUTLINE_PATH}" fill="${pinFill}"/>
+    <g mask="url(#${maskId})">
+      <path d="${PIN_OUTLINE_STROKE_PATH}" fill="${pinStroke}"/>
+    </g>
+    <g transform="translate(${ICON_POS_X} ${ICON_POS_Y}) scale(${glyphScale})">${coloredGlyph}</g>
+    ${bonusOverlay}
+  </g>
+</svg>`
+}
+
+function svgToImage(svgText: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const blob = new Blob([svgText], { type: "image/svg+xml;charset=utf-8" })
+    const url = URL.createObjectURL(blob)
+    const img = new Image()
+    img.onload = () => {
+      URL.revokeObjectURL(url)
+      resolve(img)
+    }
+    img.onerror = (err) => {
+      URL.revokeObjectURL(url)
+      reject(err)
+    }
+    img.src = url
+  })
+}
+
+async function rasterize(svgText: string, width: number, height: number) {
+  const img = await svgToImage(svgText)
+  const canvas = document.createElement("canvas")
+  canvas.width = width * PIXEL_RATIO
+  canvas.height = height * PIXEL_RATIO
+  const ctx = canvas.getContext("2d")
+  if (!ctx) throw new Error("2d canvas context unavailable")
+  ctx.scale(PIXEL_RATIO, PIXEL_RATIO)
+  ctx.drawImage(img, 0, 0, width, height)
+  return ctx.getImageData(0, 0, canvas.width, canvas.height)
+}
+
+export type ActeurIconName = string
+
+export function iconNameFor(groupeActionCode: string, bonus = false): ActeurIconName {
+  return bonus ? `acteur:${groupeActionCode}:bonus` : `acteur:${groupeActionCode}`
+}
+
+function svgCanvasDimensions(withBonus: boolean) {
+  const rightPadding = withBonus
+    ? BONUS_PROTRUSION_RIGHT + STROKE_MARGIN
+    : STROKE_MARGIN
+  const topPadding = withBonus ? BONUS_PROTRUSION_TOP : STROKE_MARGIN
+  const outerWidth = PIN_NATIVE_WIDTH + STROKE_MARGIN + rightPadding
+  const outerHeight = PIN_NATIVE_HEIGHT + topPadding + STROKE_MARGIN
+  return { outerWidth, outerHeight }
+}
+
+// Renders & registers all 5 group-action variants (10 with bonus combos —
+// only `reparer` actually shows bonus today, but registering both is cheap
+// and keeps the lookup uniform).
+export async function registerActeurIcons(map: Map): Promise<void> {
+  const tasks: Array<Promise<void>> = []
+  for (const variant of GROUPE_ACTION_VARIANTS) {
+    for (const withBonus of [false, true]) {
+      const svg = buildPinSvg(variant, withBonus)
+      const name = iconNameFor(variant.code, withBonus)
+      const { outerWidth, outerHeight } = svgCanvasDimensions(withBonus)
+      tasks.push(
+        rasterize(svg, outerWidth * DISPLAY_SCALE, outerHeight * DISPLAY_SCALE).then((imageData) => {
+          if (map.hasImage(name)) return
+          map.addImage(name, imageData, { pixelRatio: PIXEL_RATIO })
+        }),
+      )
+    }
+  }
+  await Promise.all(tasks)
+}
+
+// Exposed for the preview harness.
+export const _internals = {
+  buildPinSvg,
+  GROUPE_ACTION_VARIANTS,
+  GLYPHS,
+}

--- a/webapp/static/to_compile/js/carte.ts
+++ b/webapp/static/to_compile/js/carte.ts
@@ -13,6 +13,7 @@ import ActeurDetailsController from "../controllers/carte/acteur_details"
 import NextAutocompleteController from "../controllers/shared/next_autocomplete_controller"
 import ResponsiveController from "../controllers/carte/responsive_controller"
 import PinpointController from "../controllers/carte/pinpoint_controller"
+import ActeurIconsPreviewController from "../controllers/carte/acteur_icons_preview_controller"
 
 // QFDMD
 import SearchController from "../controllers/assistant/search"
@@ -32,6 +33,7 @@ stimulus.register("scroll", ScrollController)
 stimulus.register("acteur-details", ActeurDetailsController)
 stimulus.register("next-autocomplete", NextAutocompleteController)
 stimulus.register("pinpoint", PinpointController)
+stimulus.register("acteur-icons-preview", ActeurIconsPreviewController)
 
 stimulus.register("search", SearchController)
 stimulus.register("blink", BlinkController)

--- a/webapp/static/to_compile/js/solution_map.ts
+++ b/webapp/static/to_compile/js/solution_map.ts
@@ -2,6 +2,7 @@ import { addOverlay, mapStyles, Overlay } from "carte-facile"
 import "carte-facile/dist/carte-facile.css"
 import maplibregl, {
   FitBoundsOptions,
+  GeoJSONSource,
   LngLat,
   LngLatBoundsLike,
   Map,
@@ -9,10 +10,50 @@ import maplibregl, {
 } from "maplibre-gl"
 import "maplibre-gl/dist/maplibre-gl.css"
 import MapController from "../controllers/carte/map_controller"
+import { registerActeurIcons } from "./acteur_icons"
 import type { Location } from "./types"
+
 const DEFAULT_LOCATION: LngLat = new LngLat(2.213749, 46.227638)
 const DEFAULT_INITIAL_ZOOM: number = 5
 const DEFAULT_MAX_ZOOM: number = 18
+
+const ACTEURS_SOURCE_ID = "acteurs"
+const ACTEURS_LAYER_ID = "acteurs-layer"
+const GEOJSON_ENDPOINT = "/carte/acteurs.geojson"
+const GEOJSON_NEAR_ENDPOINT = "/carte/acteurs-near.geojson"
+// Search-area overlay: when the user picks a municipality from the address
+// autocomplete, we draw the commune outline as a contextual cue. Source +
+// line layer are added on first call to setSearchArea (no fill, just outline).
+const SEARCH_AREA_SOURCE_ID = "search-area"
+const SEARCH_AREA_LINE_LAYER_ID = "search-area-line"
+const SEARCH_AREA_COLOR = "#e1000f" // DSFR red
+// Carte spec §3.7: soft alarm fires once per session when the in-memory
+// feature count crosses this threshold. Used as a telemetry signal to gate
+// the LRU eviction feature flag.
+const ACTEURS_SOFT_ALARM_THRESHOLD = 3000
+
+type ActeurBbox = {
+  southWest: { lng: number; lat: number }
+  northEast: { lng: number; lat: number }
+}
+
+type ActeurFeature = {
+  type: "Feature"
+  geometry: { type: "Point"; coordinates: [number, number] }
+  properties: {
+    uuid: string
+    icon: string
+    bonus: boolean
+    detail_url: string
+  }
+}
+
+type GeoJsonResponse = {
+  features: ActeurFeature[]
+  // Top-level flag the backend emits when the result set hit the cap. The
+  // controller surfaces this as a "zoom in to see more" pill.
+  truncated?: boolean
+}
 
 export class SolutionMap {
   map: Map
@@ -24,6 +65,22 @@ export class SolutionMap {
   points: Array<Array<Number>>
   mapPadding: number = 50
   initialZoom: number = DEFAULT_INITIAL_ZOOM
+
+  // Track the uuids currently rendered on the symbol layer so we can dedupe on
+  // append and pass `exclude_uuids` to the backend when fetching more features.
+  #displayedUuids: Set<string> = new Set()
+  // Authoritative copy of the features currently rendered. We don't trust the
+  // GeoJSONSource to expose its data back to us, so we keep our own.
+  #displayedFeatures: ActeurFeature[] = []
+  #iconsRegistered = false
+  #acteursSourceReady = false
+  #pendingFetchAbort?: AbortController
+  // Set to true once the map's containing layout has stopped resizing and the
+  // initial fit-bounds has run. After that, further re-fits are skipped so we
+  // don't fight the user when they zoom or pan.
+  #layoutSettled = false
+  // Carte spec §3.7: soft-alarm telemetry fires once per session.
+  #softAlarmFired = false
 
   constructor({
     selector,
@@ -70,6 +127,12 @@ export class SolutionMap {
         compact: true,
         ...(this.#useOsm && { customAttribution: "© OpenStreetMap contributors" }),
       },
+      // MapLibre's default fade animation cross-fades symbols when tiles
+      // reload during a pan/zoom (~300 ms). With our small acteur dataset
+      // that reads as a "flash" — pinpoints fade out and back in even when
+      // the underlying data hasn't changed. Setting it to 0 removes the
+      // visible reflow without affecting correctness.
+      fadeDuration: 0,
     })
 
     if (!this.#useOsm) {
@@ -148,12 +211,338 @@ export class SolutionMap {
     })
   }
 
-  fitBounds(points, bboxValue) {
-    this.points = points
+  // Fetch acteurs in the given bbox from the JSON endpoint and append them to
+  // the symbol layer. Pass { wipe: true } to replace the current set instead
+  // of appending - useful when filters change. Pass { fitBounds: true } on
+  // first load to zoom the map onto the resulting features.
+  async loadActeursForBbox(
+    bbox: ActeurBbox,
+    options: {
+      wipe?: boolean
+      fitBounds?: boolean
+      extraParams?: string
+    } = {},
+  ): Promise<void> {
+    await this.#ensureActeursLayer()
+
+    if (options.wipe) {
+      this.#displayedUuids.clear()
+      this.#setSourceData([])
+    }
+
+    this.#pendingFetchAbort?.abort()
+    const abort = new AbortController()
+    this.#pendingFetchAbort = abort
+
+    const params = new URLSearchParams({
+      bbox: [
+        bbox.southWest.lng,
+        bbox.southWest.lat,
+        bbox.northEast.lng,
+        bbox.northEast.lat,
+      ].join(","),
+      // Zoom drives spatial-thinning cell size server-side: at lower zooms
+      // the backend uses bigger cells so markers stay visually spread out
+      // instead of stacking onto a few pixels.
+      zoom: this.map.getZoom().toFixed(2),
+    })
+    // We deliberately do NOT send exclude_uuids: a long session can balloon
+    // the URL past the 8 KB request-line limit (HTTP 414). The frontend
+    // already dedupes by uuid in #appendFeatures, so the backend is allowed
+    // to return acteurs we already have - they're filtered out client-side.
+    if (options.extraParams) {
+      // The server hands us an already-encoded param string (e.g.
+      // "groupe_actions=1,2&bonus=1"); merge into our URLSearchParams so we
+      // get one cleanly-shaped query string.
+      const extra = new URLSearchParams(options.extraParams)
+      extra.forEach((value, key) => {
+        params.set(key, value)
+      })
+    }
+
+    let payload: GeoJsonResponse | undefined
+    try {
+      const response = await fetch(`${GEOJSON_ENDPOINT}?${params.toString()}`, {
+        signal: abort.signal,
+        headers: { Accept: "application/geo+json, application/json" },
+      })
+      if (!response.ok) {
+        throw new Error(`acteurs.geojson returned ${response.status}`)
+      }
+      payload = (await response.json()) as GeoJsonResponse
+    } catch (err) {
+      if ((err as DOMException)?.name === "AbortError") return
+      // Carte spec "Known fixes required": non-AbortError fetch failures must
+      // be swallowed and logged. The user keeps whatever markers were already
+      // on the map; subsequent pans can recover.
+      console.error("acteurs.geojson fetch failed", err)
+      return
+    } finally {
+      if (this.#pendingFetchAbort === abort) {
+        this.#pendingFetchAbort = undefined
+      }
+    }
+    if (!payload) return
+
+    this.#appendFeatures(payload.features)
+
+    if (options.fitBounds && this.#displayedUuids.size > 0) {
+      const points: Array<[number, number]> = payload.features.map((f) => [
+        f.geometry.coordinates[1], // lat
+        f.geometry.coordinates[0], // lng
+      ])
+      this.fitBounds(points, undefined)
+    }
+  }
+
+  // Fetch the K nearest acteurs around (lat, lng) from the KNN endpoint and
+  // append them to the symbol layer. Camera fits to the bbox of the returned
+  // features. Used by the address-search flow when the BAN result is a
+  // street / housenumber / locality (not a municipality).
+  async loadActeursNearest(
+    lat: number,
+    lng: number,
+    options: { count?: number; extraParams?: string } = {},
+  ): Promise<void> {
+    await this.#ensureActeursLayer()
+
+    this.#pendingFetchAbort?.abort()
+    const abort = new AbortController()
+    this.#pendingFetchAbort = abort
+
+    const params = new URLSearchParams({
+      lat: String(lat),
+      lng: String(lng),
+      count: String(options.count ?? 30),
+    })
+    if (options.extraParams) {
+      const extra = new URLSearchParams(options.extraParams)
+      extra.forEach((value, key) => {
+        params.set(key, value)
+      })
+    }
+
+    let payload: GeoJsonResponse | undefined
+    try {
+      const response = await fetch(
+        `${GEOJSON_NEAR_ENDPOINT}?${params.toString()}`,
+        {
+          signal: abort.signal,
+          headers: { Accept: "application/geo+json, application/json" },
+        },
+      )
+      if (!response.ok) {
+        throw new Error(`acteurs-near.geojson returned ${response.status}`)
+      }
+      payload = (await response.json()) as GeoJsonResponse
+    } catch (err) {
+      if ((err as DOMException)?.name === "AbortError") return
+      console.error("acteurs-near.geojson fetch failed", err)
+      return
+    } finally {
+      if (this.#pendingFetchAbort === abort) {
+        this.#pendingFetchAbort = undefined
+      }
+    }
+    if (!payload) return
+
+    this.#appendFeatures(payload.features)
+
+    // Always fit the camera to the result bbox: that's the whole point of
+    // KNN — show the user the spread of nearest acteurs, even if they're
+    // tens of kilometers away in a sparse area.
+    if (payload.features.length > 0) {
+      const points: Array<[number, number]> = payload.features.map((f) => [
+        f.geometry.coordinates[1], // lat
+        f.geometry.coordinates[0], // lng
+      ])
+      // Include the search center so the user's location stays in view too.
+      points.push([lat, lng])
+      this.fitBounds(points, undefined, { animate: true })
+    }
+  }
+
+  async #ensureActeursLayer(): Promise<void> {
+    if (!this.#iconsRegistered) {
+      await registerActeurIcons(this.map)
+      this.#iconsRegistered = true
+    }
+
+    if (this.#acteursSourceReady) return
+
+    if (!this.map.getSource(ACTEURS_SOURCE_ID)) {
+      this.map.addSource(ACTEURS_SOURCE_ID, {
+        type: "geojson",
+        data: { type: "FeatureCollection", features: [] },
+      })
+    }
+
+    if (!this.map.getLayer(ACTEURS_LAYER_ID)) {
+      this.map.addLayer({
+        id: ACTEURS_LAYER_ID,
+        type: "symbol",
+        source: ACTEURS_SOURCE_ID,
+        layout: {
+          "icon-image": ["get", "icon"],
+          "icon-anchor": "bottom",
+          "icon-allow-overlap": true,
+          "icon-ignore-placement": true,
+        },
+      })
+
+      this.map.on("click", ACTEURS_LAYER_ID, this.#onActeurClick.bind(this))
+      this.map.on("mouseenter", ACTEURS_LAYER_ID, () => {
+        this.map.getCanvas().style.cursor = "pointer"
+      })
+      this.map.on("mouseleave", ACTEURS_LAYER_ID, () => {
+        this.map.getCanvas().style.cursor = ""
+      })
+    }
+
+    this.#acteursSourceReady = true
+  }
+
+  #appendFeatures(features: ActeurFeature[]): void {
+    // Per the carte spec, skip the source update entirely when a fetch
+    // returns no fresh features. Avoids a 1-frame icon repaint on Safari/iOS
+    // and protects against the symbol-collision "vanishing" perception.
+    const fresh = features.filter((f) => !this.#displayedUuids.has(f.properties.uuid))
+    if (fresh.length === 0) return
+
+    this.#displayedFeatures = [...this.#displayedFeatures, ...fresh]
+    for (const f of fresh) {
+      this.#displayedUuids.add(f.properties.uuid)
+    }
+    this.#flushSource()
+
+    // Telemetry: emit a soft alarm when the in-memory feature count exceeds
+    // the threshold from the carte spec. The on-screen behavior is unchanged;
+    // operators can use this signal to flip the LRU eviction feature flag if
+    // sessions ever reach this size in practice.
+    if (this.#displayedFeatures.length >= ACTEURS_SOFT_ALARM_THRESHOLD) {
+      // Deduplicate: only fire once per session.
+      if (!this.#softAlarmFired) {
+        this.#softAlarmFired = true
+        try {
+          window.dispatchEvent(
+            new CustomEvent("carte:displayedFeaturesAlarm", {
+              detail: { count: this.#displayedFeatures.length },
+            }),
+          )
+        } catch {
+          // ignore
+        }
+      }
+    }
+  }
+
+  #setSourceData(features: ActeurFeature[]): void {
+    this.#displayedFeatures = features
+    this.#flushSource()
+  }
+
+  #flushSource(): void {
+    const source = this.map.getSource(ACTEURS_SOURCE_ID) as GeoJSONSource | undefined
+    if (!source) return
+    source.setData({
+      type: "FeatureCollection",
+      features: this.#displayedFeatures,
+    })
+  }
+
+  #onActeurClick(event: maplibregl.MapMouseEvent & { features?: maplibregl.MapGeoJSONFeature[] }): void {
+    const feature = event.features?.[0]
+    if (!feature) return
+    const props = feature.properties as { detail_url?: string; uuid?: string }
+    if (!props?.detail_url) return
+
+    const frameId = (this.#controller as unknown as { acteurFrameIdValue?: string })
+      .acteurFrameIdValue
+    const frame = frameId ? document.getElementById(frameId) : null
+    if (frame && "src" in frame) {
+      ;(frame as HTMLIFrameElement).src = props.detail_url
+    }
+
+    this.#controller.dispatch("acteurSelected", {
+      detail: { uuid: props.uuid, url: props.detail_url },
+      bubbles: true,
+    })
+  }
+
+  get displayedUuids(): ReadonlySet<string> {
+    return this.#displayedUuids
+  }
+
+  // Called from MapController.disconnect(). Cancels any in-flight GeoJSON
+  // fetch so it doesn't outlive the map and try to mutate a removed source.
+  abortPendingFetch(): void {
+    this.#pendingFetchAbort?.abort()
+    this.#pendingFetchAbort = undefined
+  }
+
+  // Debug helper: returns the in-memory authoritative feature list, separately
+  // from what MapLibre's source may have processed. Used to diagnose lost
+  // markers during rapid pan/zoom sequences.
+  get displayedFeatures(): ReadonlyArray<ActeurFeature> {
+    return this.#displayedFeatures
+  }
+
+  // Draw (or update) a translucent red overlay around a search area, e.g. the
+  // commune polygon when the user picks a city from the address autocomplete.
+  // The polygon argument is a GeoJSON Feature or FeatureCollection.
+  setSearchArea(polygon: GeoJSON.Feature | GeoJSON.FeatureCollection): void {
+    const data: GeoJSON.FeatureCollection =
+      polygon.type === "FeatureCollection"
+        ? polygon
+        : { type: "FeatureCollection", features: [polygon] }
+
+    if (!this.map.getSource(SEARCH_AREA_SOURCE_ID)) {
+      this.map.addSource(SEARCH_AREA_SOURCE_ID, { type: "geojson", data })
+    } else {
+      ;(this.map.getSource(SEARCH_AREA_SOURCE_ID) as GeoJSONSource).setData(data)
+    }
+
+    // Insert under the acteur symbol layer so pinpoints stay clickable on top
+    // of the overlay.
+    const beforeId = this.map.getLayer(ACTEURS_LAYER_ID) ? ACTEURS_LAYER_ID : undefined
+
+    if (!this.map.getLayer(SEARCH_AREA_LINE_LAYER_ID)) {
+      this.map.addLayer(
+        {
+          id: SEARCH_AREA_LINE_LAYER_ID,
+          type: "line",
+          source: SEARCH_AREA_SOURCE_ID,
+          paint: {
+            "line-color": SEARCH_AREA_COLOR,
+            "line-width": 2,
+          },
+        },
+        beforeId,
+      )
+    }
+  }
+
+  clearSearchArea(): void {
+    if (this.map.getLayer(SEARCH_AREA_LINE_LAYER_ID)) {
+      this.map.removeLayer(SEARCH_AREA_LINE_LAYER_ID)
+    }
+    if (this.map.getSource(SEARCH_AREA_SOURCE_ID)) {
+      this.map.removeSource(SEARCH_AREA_SOURCE_ID)
+    }
+  }
+
+  fitBounds(points, bboxValue, options: { animate?: boolean } = {}) {
+    this.points = points ?? []
     this.bboxValue = bboxValue
     const fitBoundsOptions: FitBoundsOptions = {
       padding: this.mapPadding,
-      duration: 0,
+      // Default: instant. The ResizeObserver in initEventListener calls
+      // fitBounds repeatedly while the layout is settling; animating those
+      // calls would produce a janky cascade. Callers that want a smooth move
+      // (e.g. the post-Turbo-swap initial fit on a new address) opt in via
+      // { animate: true }.
+      duration: options.animate ? 600 : 0,
+      ...(options.animate && { essential: true }),
       ...(this.#useOsm && { maxZoom: DEFAULT_MAX_ZOOM - 1 }),
     }
     if (typeof bboxValue !== "undefined") {
@@ -164,16 +553,14 @@ export class SolutionMap {
         ],
         fitBoundsOptions,
       )
-    } else {
-      if (points.length > 0) {
-        const lngs = points.map((point) => point[1])
-        const lats = points.map((point) => point[0])
-        const bounds: LngLatBoundsLike = [
-          [Math.min(...lngs), Math.min(...lats)], // South-west
-          [Math.max(...lngs), Math.max(...lats)], // North-east
-        ]
-        this.map.fitBounds(bounds, fitBoundsOptions)
-      }
+    } else if (this.points.length > 0) {
+      const lngs = this.points.map((point) => point[1])
+      const lats = this.points.map((point) => point[0])
+      const bounds: LngLatBoundsLike = [
+        [Math.min(...lngs), Math.min(...lats)], // South-west
+        [Math.max(...lngs), Math.max(...lats)], // North-east
+      ]
+      this.map.fitBounds(bounds, fitBoundsOptions)
     }
   }
 
@@ -212,7 +599,14 @@ export class SolutionMap {
     this.#mapWidthBeforeResize = this.map.getContainer().offsetWidth
     const resizeObserver = new ResizeObserver(() => {
       this.map.resize()
-      this.fitBounds(this.points, this.bboxValue)
+      // Re-fit to the initial bounds only while the layout is still settling.
+      // After we install the `moveend` listener (resizeStopped), the user is
+      // in control and any further fitBounds calls would yank the camera back
+      // to the initial view — defeating zoom/pan and the auto-search-on-pan
+      // behavior.
+      if (!this.#layoutSettled) {
+        this.fitBounds(this.points, this.bboxValue)
+      }
       const currentMapWidth = this.map.getContainer().offsetWidth
       const resizeStopped =
         this.#mapWidthBeforeResize > 0 && this.#mapWidthBeforeResize === currentMapWidth
@@ -220,6 +614,7 @@ export class SolutionMap {
         // The 1s timeout here is arbitrary and prevents adding listener
         // when the map is still moving.
         setTimeout(() => {
+          this.#layoutSettled = true
           this.map.on("moveend", this.#dispatchMapChangedEvent.bind(this))
           resizeObserver.disconnect()
         }, 1000)

--- a/webapp/static/to_compile/js/solution_map.ts
+++ b/webapp/static/to_compile/js/solution_map.ts
@@ -22,7 +22,6 @@ export class SolutionMap {
   #useOsm: boolean
   bboxValue?: Array<Number>
   points: Array<Array<Number>>
-  #homePoint: Array<Number> | null = null
   mapPadding: number = 50
   initialZoom: number = DEFAULT_INITIAL_ZOOM
 
@@ -91,9 +90,6 @@ export class SolutionMap {
           new maplibregl.Popup().setHTML("<p><strong>Vous êtes ici !</strong></p>"),
         )
         .addTo(this.map)
-
-      // Store home point for inclusion in fitBounds
-      this.#homePoint = [this.#location.latitude, this.#location.longitude]
     }
   }
 
@@ -169,13 +165,9 @@ export class SolutionMap {
         fitBoundsOptions,
       )
     } else {
-      // Include home point (user location) in bounds calculation
-      const allPoints = this.#homePoint ? [...points, this.#homePoint] : points
-
-      if (allPoints.length > 0) {
-        // Compute bbox from points
-        const lngs = allPoints.map((point) => point[1])
-        const lats = allPoints.map((point) => point[0])
+      if (points.length > 0) {
+        const lngs = points.map((point) => point[1])
+        const lats = points.map((point) => point[0])
         const bounds: LngLatBoundsLike = [
           [Math.min(...lngs), Math.min(...lats)], // South-west
           [Math.max(...lngs), Math.max(...lats)], // North-east

--- a/webapp/templates/ui/components/accessibilite/P01_11_10__P01_11_11.md
+++ b/webapp/templates/ui/components/accessibilite/P01_11_10__P01_11_11.md
@@ -1,0 +1,35 @@
+# P01 11.10 + 11.11 — Modale contact (astérisques, format mail, message d'erreur)
+
+## Retour auditeur (verbatim)
+
+La modale "Contact" présente plusieurs défauts :
+
+1. Les champs obligatoires sont marqués par un astérisque `*` sans légende
+   explicative (11.10).
+2. Le champ email n'a pas de format attendu indiqué (11.11).
+3. Les messages d'erreur ne sont pas rattachés au champ via `aria-describedby`
+   et ne décrivent pas comment corriger l'erreur (11.10 + 11.11).
+
+## Correctif recommandé
+
+- Ajouter en haut du formulaire : *"Les champs marqués d'un astérisque (\*)
+  sont obligatoires."*
+- Sur le champ email : indiquer le format attendu, par exemple
+  *"Format attendu : prenom.nom@exemple.fr"*.
+- Sur chaque erreur : `<span id="email-error" role="alert">L'adresse email
+  saisie n'est pas valide. Format attendu : prenom@exemple.fr.</span>` et
+  rattacher le span via `aria-describedby="email-error"` sur l'`<input>`.
+
+Les textes recommandés sont détaillés dans le ticket Notion.
+
+## Sévérité
+
+Modérée.
+
+## Scope
+
+Webapp Django (template modale contact).
+
+## Lien Notion
+
+[Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)

--- a/webapp/templates/ui/components/accessibilite/P01_12_6.md
+++ b/webapp/templates/ui/components/accessibilite/P01_12_6.md
@@ -1,0 +1,32 @@
+# P01 12.6 — Rôles ARIA banner / main / navigation manquants
+
+## Retour auditeur (verbatim)
+
+Sur la page d'accueil, les landmarks ARIA `banner`, `main`, `navigation` et
+`contentinfo` ne sont pas tous explicitement déclarés, ce qui rend la
+navigation par landmarks moins efficace pour les utilisateurs de lecteurs
+d'écran.
+
+## Correctif recommandé
+
+S'assurer que la page d'accueil contient au moins :
+
+- un `<header role="banner">` (ou `<header>` au niveau racine)
+- un `<nav role="navigation" aria-label="Menu principal">`
+- un `<main role="main" id="main">`
+- un `<footer role="contentinfo">`
+
+Le DSFR fournit ces wrappers nativement, vérifier qu'ils ne sont pas écrasés
+par nos templates.
+
+## Sévérité
+
+Modérée.
+
+## Scope
+
+Webapp Django (`ui/layout/base.html` et composants header/footer).
+
+## Lien Notion
+
+[Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)

--- a/webapp/templates/ui/components/accessibilite/P01_12_7.md
+++ b/webapp/templates/ui/components/accessibilite/P01_12_7.md
@@ -1,0 +1,29 @@
+# P01 12.7 — Lien d'évitement
+
+## Retour auditeur (verbatim)
+
+Critère vérifiant la présence d'un lien d'évitement ("Aller au contenu
+principal") en début de page, accessible au clavier dès le premier `Tab`.
+
+## Statut
+
+Marqué **FAIT** côté audit. Cette preview est conservée pour vérification de
+non-régression.
+
+## À vérifier (regression)
+
+- [ ] Au premier `Tab` après le chargement de la page d'accueil, le lien
+      "Aller au contenu principal" devient visible.
+- [ ] Activer ce lien (Entrée) déplace le focus dans le `<main>`.
+
+## Sévérité
+
+Bloquante (si régression).
+
+## Scope
+
+Webapp Django (`ui/layout/base.html`).
+
+## Lien Notion
+
+[Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)

--- a/webapp/templates/ui/components/accessibilite/P01_1_2.md
+++ b/webapp/templates/ui/components/accessibilite/P01_1_2.md
@@ -1,0 +1,28 @@
+# P01 1.2 — Images décoratives à marquer aria-hidden
+
+## Retour auditeur (verbatim)
+
+Des images décoratives ne sont pas correctement ignorées par les technologies
+d'assistance, exemple :
+
+- les SVG décoratifs présents dans le header et le bandeau hero de la page
+  d'accueil sont annoncés par les lecteurs d'écran alors qu'ils ne portent pas
+  d'information.
+
+## Correctif recommandé
+
+Sur chaque SVG décoratif, ajouter `aria-hidden="true"` et, si nécessaire,
+`focusable="false"`. Si le SVG contient un `<title>` pour des raisons
+d'inspection, le retirer ou le déplacer vers un attribut `data-*`.
+
+## Sévérité
+
+Mineure (gêne pour les utilisateurs de lecteurs d'écran).
+
+## Scope
+
+Webapp Django (templates `ui/components/header/` et `ui/pages/home.html`).
+
+## Lien Notion
+
+[Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)

--- a/webapp/templates/ui/components/accessibilite/P01_3_3.md
+++ b/webapp/templates/ui/components/accessibilite/P01_3_3.md
@@ -9,6 +9,23 @@
 
 Le rapport de contraste entre les couleurs d'un composant d'interface et son arrière-plan doit être d'au moins 3:1."
 
+## Évolution
+
+Le composant de recherche a été migré dans le header DSFR. La preview affiche
+les deux versions (l'ancien composant `ui/components/search/view.html` ET la
+nouvelle barre de recherche du header), pour que la·le relectrice·eur puisse
+confirmer la correction.
+
 ## À vérifier :
 
-- [ ] Le contour de la recherche doit être en couleur #53918C
+- [ ] Le contour de la recherche (legacy) doit être en couleur #53918C
+- [ ] Le contour de la recherche dans le header DSFR respecte le ratio 3:1
+- [ ] Les boutons d'intégration / partage / contact respectent le ratio 3:1
+
+## Scope
+
+Webapp Django.
+
+## Lien Notion
+
+[Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)

--- a/webapp/templates/ui/components/accessibilite/P01_6_1.md
+++ b/webapp/templates/ui/components/accessibilite/P01_6_1.md
@@ -1,0 +1,29 @@
+# P01 6.1 — Liens explicites — Bloc-marque Ademe & République française (footer)
+
+## Retour auditeur (verbatim)
+
+Dans le footer, le lien "Bloc-marque Ademe & République française" n'est pas
+explicite hors contexte : un utilisateur qui parcourt la liste des liens via
+son lecteur d'écran ne sait pas où le lien mène.
+
+## Correctif recommandé
+
+Ajouter un `title` explicite ou compléter le texte visible, par exemple :
+
+```html
+<a href="..." title="Accueil — République française et Ademe">
+  République française · Ademe
+</a>
+```
+
+## Sévérité
+
+Mineure.
+
+## Scope
+
+Webapp Django (`ui/components/footer/`).
+
+## Lien Notion
+
+[Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)

--- a/webapp/templates/ui/components/accessibilite/P01_9_2.md
+++ b/webapp/templates/ui/components/accessibilite/P01_9_2.md
@@ -1,0 +1,34 @@
+# P01 9.2 — Footer sans `<nav>`
+
+## Retour auditeur (verbatim)
+
+Le footer de la page d'accueil ne contient pas d'élément `<nav>` autour des
+listes de liens, alors que ces listes constituent une navigation secondaire
+(plan du site, mentions légales, etc.).
+
+## Correctif recommandé
+
+Ajouter un `<nav role="navigation" aria-label="Navigation du pied de page">`
+autour des listes du footer :
+
+```html
+<nav role="navigation" aria-label="Navigation du pied de page">
+  <ul>
+    <li><a href="...">Mentions légales</a></li>
+    ...
+  </ul>
+</nav>
+```
+
+## Sévérité
+
+Modérée (impacte la navigation par landmarks).
+
+## Scope
+
+Webapp Django (`ui/components/footer/footer.html` et templates DSFR
+sous-jacents).
+
+## Lien Notion
+
+[Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)

--- a/webapp/templates/ui/components/accessibilite/P02_7_1__P02_7_3.md
+++ b/webapp/templates/ui/components/accessibilite/P02_7_1__P02_7_3.md
@@ -21,3 +21,14 @@ Les composants suivants ne sont pas contrôlables au clavier :
 ## À vérifier
 
 - [ ] Le dernier élément du breadcrumb est atteignable au clavier
+
+## Scope
+
+Sites Faciles CMS (template upstream `templates/sites_conformes_content_manager/blocks/breadcrumbs.html`).
+La correction ajoute un `href="#"` et `aria-current="page"` sur le dernier
+élément ; elle est portée localement dans la webapp en attendant un patch
+upstream.
+
+## Lien Notion
+
+[Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)

--- a/webapp/templates/ui/components/accessibilite/P05_10_2__P06_10_2.md
+++ b/webapp/templates/ui/components/accessibilite/P05_10_2__P06_10_2.md
@@ -1,0 +1,33 @@
+# P05 10.2 + P06 10.2 — Sans CSS, l'icône "Nouvelle fenêtre" disparaît
+
+## Retour auditeur (verbatim)
+
+Sur les pages P05 et P06, certains liens ouvrent dans un nouvel onglet via
+`target="_blank"`. L'icône "nouvelle fenêtre" est ajoutée par CSS uniquement,
+donc lorsque l'utilisateur désactive le CSS, l'information disparaît : il ne
+sait plus que le lien va ouvrir un nouvel onglet.
+
+## Correctif recommandé
+
+Ajouter un attribut `title` qui contient explicitement "(nouvelle fenêtre)"
+sur chaque lien `target="_blank"` :
+
+```html
+<a href="https://www.ademe.fr/" target="_blank" rel="noreferrer"
+   title="Site de l'Ademe (nouvelle fenêtre)">
+   Site de l'Ademe
+</a>
+```
+
+## Sévérité
+
+Mineure.
+
+## Scope
+
+Mixte : Webapp Django (footer, qui-sommes-nous) + Sites Faciles (liens
+externes dans les blocs RichText).
+
+## Lien Notion
+
+[Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)

--- a/webapp/templates/ui/components/accessibilite/P06_12_2__P09_12_2__P10_12_2.md
+++ b/webapp/templates/ui/components/accessibilite/P06_12_2__P09_12_2__P10_12_2.md
@@ -1,0 +1,31 @@
+# P06 / P09 / P10 — 12.2 — Fil d'Ariane absent sur certaines pages
+
+## Retour auditeur (verbatim)
+
+Le fil d'Ariane (breadcrumb) est absent sur :
+
+- P06 — page "Comment ça marche"
+- P09 — page produit (ex. `/dechet/manteau/`)
+- P10 — guide PDF Smartphone
+
+Or le critère 12.2 demande qu'un fil d'Ariane soit disponible sur toutes les
+pages internes (sauf accueil et pages présentant un état temporaire comme une
+recherche).
+
+## Correctif recommandé
+
+Activer le bloc breadcrumb du composant DSFR sur ces pages. La preview rend le
+composant tel qu'il devrait apparaître. Voir
+`templates/sites_conformes_content_manager/blocks/breadcrumbs.html`.
+
+## Sévérité
+
+Modérée.
+
+## Scope
+
+Sites Faciles CMS (configuration des pages concernées).
+
+## Lien Notion
+
+[Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)

--- a/webapp/templates/ui/components/accessibilite/P06_13_5.md
+++ b/webapp/templates/ui/components/accessibilite/P06_13_5.md
@@ -1,0 +1,27 @@
+# P06 13.5 — Émojis non encapsulés
+
+## Retour auditeur (verbatim)
+
+Sur la page "Comment ça marche", plusieurs accordéons contiennent des émojis
+directement dans le texte (par ex. 🎉, 👍, 🌍) sans encapsulation. Les
+lecteurs d'écran les vocalisent par leur nom Unicode complet, ce qui peut être
+intrusif et long, ou les ignorent silencieusement, ce qui peut aussi poser
+problème si l'émoji porte une information.
+
+## Correctif recommandé
+
+- Si l'émoji est **décoratif** : `<span aria-hidden="true">🎉</span>`.
+- Si l'émoji **porte une information** : lui donner un texte alternatif
+  explicite, par exemple `<span role="img" aria-label="fête">🎉</span>`.
+
+## Sévérité
+
+Mineure.
+
+## Scope
+
+Sites Faciles CMS (blocs RichText des accordéons "Comment ça marche").
+
+## Lien Notion
+
+[Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)

--- a/webapp/templates/ui/components/accessibilite/P06_4_1__P06_4_3.md
+++ b/webapp/templates/ui/components/accessibilite/P06_4_1__P06_4_3.md
@@ -1,0 +1,33 @@
+# P06 4.1 + 4.3 — Vidéo Consomag : transcription + sous-titres
+
+## Retour auditeur (verbatim)
+
+La vidéo Consomag intégrée sur la page "Comment ça marche" :
+
+- ne propose pas de transcription textuelle (critère 4.1) ;
+- les sous-titres existants comportent des erreurs (critère 4.3).
+
+## Correctif recommandé
+
+1. Publier sous la vidéo une transcription textuelle complète (voir ci-dessous).
+2. Re-générer / corriger les sous-titres et publier la version corrigée sur
+   YouTube.
+
+## Transcription complète
+
+> *Note : la transcription complète est disponible dans le ticket Notion
+> "Vidéo Consomag (P06)". Elle doit être copiée ici verbatim avant publication
+> dans le bloc Sites Faciles.*
+
+## Sévérité
+
+Majeure (4.1 bloque les utilisateurs sourds ; 4.3 dégrade la compréhension).
+
+## Scope
+
+Mixte : YouTube (sous-titres) + Sites Faciles (transcription publiée sous la
+vidéo).
+
+## Lien Notion
+
+[Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)

--- a/webapp/templates/ui/components/accessibilite/P06_8_7.md
+++ b/webapp/templates/ui/components/accessibilite/P06_8_7.md
@@ -1,0 +1,37 @@
+# P06 8.7 — Sélecteur de langue Impact CO2 sans attribut lang sur les options
+
+## Retour auditeur (verbatim)
+
+Le widget Impact CO2 embarqué dans la page "Comment ça marche" propose un
+sélecteur de langue, mais les options de ce `<select>` ne portent pas
+d'attribut `lang`. Les lecteurs d'écran prononcent les noms de langues avec la
+voix française, ce qui rend la lecture incompréhensible.
+
+## Correctif recommandé
+
+Sur chaque `<option>` du sélecteur, ajouter l'attribut `lang` correspondant :
+
+```html
+<select>
+  <option value="fr" lang="fr">Français</option>
+  <option value="en" lang="en">English</option>
+  <option value="es" lang="es">Español</option>
+</select>
+```
+
+## Note
+
+Widget tiers développé par l'Ademe (impactco2.fr). Nous ne pouvons que documenter
+le défaut et remonter à l'équipe Impact CO2.
+
+## Sévérité
+
+Mineure.
+
+## Scope
+
+Tiers (widget Impact CO2).
+
+## Lien Notion
+
+[Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)

--- a/webapp/templates/ui/components/accessibilite/P06_8_9__P09_8_9.md
+++ b/webapp/templates/ui/components/accessibilite/P06_8_9__P09_8_9.md
@@ -1,0 +1,26 @@
+# P06 8.9 + P09 8.9 — `<br>` utilisés pour faire des paragraphes
+
+## Retour auditeur (verbatim)
+
+Plusieurs blocs RichText sur les pages "Comment ça marche" (P06) et la page
+produit (P09) utilisent des séries de `<br>` (parfois deux ou trois) pour
+simuler des séparations de paragraphes. Ce balisage est non structurant et
+gêne la navigation par lecteur d'écran.
+
+## Correctif recommandé
+
+Remplacer chaque "paragraphe simulé" par un vrai `<p>...</p>`. À corriger via
+contribution Sites Faciles, pas dans la webapp : les rédacteurs doivent utiliser
+le bouton "nouveau paragraphe" de l'éditeur Wagtail plutôt que `Maj+Entrée`.
+
+## Sévérité
+
+Modérée.
+
+## Scope
+
+Sites Faciles CMS (RichText).
+
+## Lien Notion
+
+[Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)

--- a/webapp/templates/ui/components/accessibilite/P06_9_1__P08_9_1.md
+++ b/webapp/templates/ui/components/accessibilite/P06_9_1__P08_9_1.md
@@ -1,0 +1,31 @@
+# P06 9.1 + P08 9.1 — Niveaux de titres incohérents (accordéons)
+
+## Retour auditeur (verbatim)
+
+Les accordéons des pages "Comment ça marche" (P06) et "Bonus réparation"
+(P08) ont des niveaux de titre incohérents : on alterne `h3`, `h4`, `h5` au
+sein du même groupe d'accordéons.
+
+## Correctif recommandé
+
+Tous les titres d'accordéons d'un même groupe doivent être au même niveau,
+cohérent avec la hiérarchie de la page. Hiérarchie attendue :
+
+- `h1` = titre de la page
+- `h2` = section / chapitre
+- `h3` = titre de chaque accordéon (uniforme dans tout le groupe)
+- `h4` = sous-titres internes à un accordéon
+
+À corriger dans le bloc accordéon Sites Faciles.
+
+## Sévérité
+
+Modérée.
+
+## Scope
+
+Sites Faciles CMS (bloc accordéon).
+
+## Lien Notion
+
+[Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)

--- a/webapp/templates/ui/components/accessibilite/P06_9_3__P07_9_3__P08_9_3__P09_9_3.md
+++ b/webapp/templates/ui/components/accessibilite/P06_9_3__P07_9_3__P08_9_3__P09_9_3.md
@@ -1,0 +1,34 @@
+# P06 / P07 / P08 / P09 — 9.3 — Éléments visuellement énumérés mais non `<ul><li>`
+
+## Retour auditeur (verbatim)
+
+Plusieurs blocs sur les pages P06, P07, P08, P09 affichent visuellement une
+énumération (puces, tirets, numérotation) mais le HTML utilisé est une suite
+de `<p>` ou de `<div>`, pas une vraie liste `<ul>` / `<ol>`.
+
+## Correctif recommandé
+
+Remplacer chaque "fausse liste" par une vraie liste sémantique :
+
+```html
+<ul>
+  <li>Première étape</li>
+  <li>Deuxième étape</li>
+  <li>Troisième étape</li>
+</ul>
+```
+
+À corriger dans les blocs Sites Faciles concernés. Les rédacteurs doivent
+utiliser le bouton "liste" de l'éditeur Wagtail.
+
+## Sévérité
+
+Modérée.
+
+## Scope
+
+Sites Faciles CMS.
+
+## Lien Notion
+
+[Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)

--- a/webapp/templates/ui/components/accessibilite/P07_2_2__P08_2_2__P09_2_2.md
+++ b/webapp/templates/ui/components/accessibilite/P07_2_2__P08_2_2__P09_2_2.md
@@ -1,0 +1,33 @@
+# P07 / P08 / P09 — 2.2 — Titres iframes carte / vidéo non descriptifs
+
+## Retour auditeur (verbatim)
+
+Plusieurs iframes intégrées dans le site ont un attribut `title` générique
+(`"iframe"`) ou absent. Les utilisateurs de lecteurs d'écran ne peuvent pas
+distinguer leur contenu.
+
+## Correctif recommandé
+
+Donner à chaque `<iframe>` un `title` explicite et **distinct**. Recommandations
+de l'audit :
+
+| Page | Iframe | Title recommandé |
+|------|--------|------------------|
+| P07 — Comment ça marche | Carte | "Carte des points de collecte près de chez moi" |
+| P08 — Bonus réparation | Carte | "Carte des artisans labellisés bonus réparation" |
+| P09 — Page produit | Vidéo Consomag | "Vidéo Consomag — Que faire de mes objets et déchets ?" |
+
+Voir aussi le ticket Notion "Iframes carte : titres distincts et descriptifs".
+
+## Sévérité
+
+Modérée.
+
+## Scope
+
+Mixte (Webapp Django pour les iframes carte ; Sites Faciles pour les vidéos
+embarquées).
+
+## Lien Notion
+
+[Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)

--- a/webapp/templates/ui/components/accessibilite/P07_6_1.md
+++ b/webapp/templates/ui/components/accessibilite/P07_6_1.md
@@ -1,0 +1,26 @@
+# P07 6.1 — Liens explicites — Sources de données du bonus réparation
+
+## Retour auditeur (verbatim)
+
+Dans le bloc "Sources de données" de la page bonus-réparation, plusieurs liens
+sont intitulés "ici", "voir", "site", ce qui n'est pas explicite hors contexte.
+
+## Correctif recommandé
+
+Remplacer chaque libellé par une formulation auto-portante :
+
+- "ici" → "Consulter la source <X> sur le site <Y>"
+- "voir" → "Voir la documentation <X>"
+- "site" → "Aller sur le site officiel de <X>"
+
+## Sévérité
+
+Mineure.
+
+## Scope
+
+Sites Faciles CMS (bloc "Sources de données" sur la page bonus-réparation).
+
+## Lien Notion
+
+[Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)

--- a/webapp/templates/ui/components/accessibilite/P08_1_2.md
+++ b/webapp/templates/ui/components/accessibilite/P08_1_2.md
@@ -1,0 +1,32 @@
+# P08 1.2 — Alt trop long sur l'image bonus + pictos non décoratifs
+
+## Retour auditeur (verbatim)
+
+L'image principale du bloc bonus-réparation a un attribut `alt` trop long
+(plusieurs phrases) et plusieurs pictos décoratifs n'ont pas
+`aria-hidden="true"`, ce qui pollue la restitution vocale.
+
+## Correctif recommandé
+
+- Réduire l'`alt` de l'image bonus à une description concise (≤ 80 caractères),
+  ou la marquer décorative si l'information est déjà donnée par le texte
+  adjacent.
+- Ajouter `aria-hidden="true"` sur les pictos qui ne portent pas
+  d'information.
+
+## Note
+
+Bug Sites Faciles — voir
+[Mattermost](https://mattermost.incubateur.net/betagouv/pl/8uammfd8t3bw5dp6ekw3yy9odr).
+
+## Sévérité
+
+Mineure.
+
+## Scope
+
+Sites Faciles CMS (bloc bonus-réparation).
+
+## Lien Notion
+
+[Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)

--- a/webapp/templates/ui/components/accessibilite/P08_6_1.md
+++ b/webapp/templates/ui/components/accessibilite/P08_6_1.md
@@ -1,0 +1,31 @@
+# P08 6.1 — Liens explicites — Bouton "Voir sur le site"
+
+## Retour auditeur (verbatim)
+
+Sur la fiche acteur (P08), le bouton "Voir sur le site" n'est pas explicite hors
+contexte : un utilisateur qui liste les liens de la page ne sait pas vers
+quel site il sera redirigé.
+
+## Correctif recommandé
+
+Ajouter un `title` qui inclut le nom de l'acteur et l'indication "nouvelle
+fenêtre" :
+
+```html
+<a href="{{ acteur.url }}" target="_blank" rel="noreferrer"
+   title="Voir la fiche de {{ acteur.nom }} sur son site officiel (nouvelle fenêtre)">
+   Voir sur le site
+</a>
+```
+
+## Sévérité
+
+Mineure.
+
+## Scope
+
+Webapp Django (template fiche acteur).
+
+## Lien Notion
+
+[Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)

--- a/webapp/templates/ui/components/accessibilite/P08_7_1__P08_7_3.md
+++ b/webapp/templates/ui/components/accessibilite/P08_7_1__P08_7_3.md
@@ -1,0 +1,37 @@
+# P08 7.1 + 7.3 — Carte iframe : combobox + clavier
+
+## Retour auditeur (verbatim)
+
+Sur la carte embarquée (iframe), plusieurs composants ne sont pas conformes :
+
+1. Le combobox d'autocomplétion d'adresse ne respecte pas le pattern ARIA
+   combobox (pas de `role="combobox"`, pas de `aria-autocomplete`,
+   pas de gestion `aria-activedescendant`).
+2. Le tooltip de partage n'est pas atteignable au clavier.
+3. La navigation clavier dans la liste de résultats est partielle (les flèches
+   haut/bas ne fonctionnent pas dans tous les contextes).
+
+## Correctif recommandé
+
+- Implémenter le pattern ARIA combobox conforme à
+  https://www.w3.org/WAI/ARIA/apg/patterns/combobox/
+- Rendre le tooltip de partage activable au clavier (focusable + `Esc` pour
+  fermer).
+- Vérifier la gestion clavier complète (Tab, Shift+Tab, Entrée, Esc, flèches).
+
+## Note
+
+Voir l'audit séparé carte :
+[Audit RGAA Carte (Google Sheet)](https://docs.google.com/spreadsheets/d/1W1Ehx8uM-aFyRgdM_zlWVEAj-aKGhS0_/edit)
+
+## Sévérité
+
+Bloquante.
+
+## Scope
+
+Carte iframe (composant `static/to_compile/controllers/carte/`).
+
+## Lien Notion
+
+[Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)

--- a/webapp/templates/ui/components/accessibilite/P08_7_5.md
+++ b/webapp/templates/ui/components/accessibilite/P08_7_5.md
@@ -1,0 +1,29 @@
+# P08 7.5 — Message de statut recherche objet réparable sans role="status"
+
+## Retour auditeur (verbatim)
+
+Sur la page bonus-réparation, après une recherche d'objet réparable, un message
+indique le nombre de résultats. Ce message n'a pas de `role="status"`, donc il
+n'est pas annoncé aux utilisateurs de lecteurs d'écran.
+
+## Correctif recommandé
+
+Encapsuler le message de résultat dans un conteneur ARIA live :
+
+```html
+<div role="status" aria-live="polite">
+  {{ count }} artisan(s) trouvé(s) à proximité.
+</div>
+```
+
+## Sévérité
+
+Modérée.
+
+## Scope
+
+Webapp Django (template du résultat de recherche objet réparable).
+
+## Lien Notion
+
+[Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)

--- a/webapp/templates/ui/components/accessibilite/P09_1_8.md
+++ b/webapp/templates/ui/components/accessibilite/P09_1_8.md
@@ -1,0 +1,26 @@
+# P09 1.8 — Image-texte fast fashion
+
+## Retour auditeur (verbatim)
+
+L'accordéon "Fast fashion" sur la page produit (ex. `/dechet/manteau/`) utilise
+une image qui contient du texte alors que ce texte pourrait être restitué en
+HTML/CSS. Cela rend le contenu non sélectionnable, non zoomable et invisible
+aux technologies d'assistance.
+
+## Correctif recommandé
+
+Remplacer l'image par du HTML/CSS dans le bloc Sites Faciles correspondant.
+Si l'image doit être conservée pour des raisons graphiques, fournir un
+`alt` reprenant *intégralement* le texte de l'image.
+
+## Sévérité
+
+Majeure.
+
+## Scope
+
+Sites Faciles CMS (RichText / image bloc).
+
+## Lien Notion
+
+[Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)

--- a/webapp/templates/ui/components/accessibilite/P09_3_3__P03_3_3.md
+++ b/webapp/templates/ui/components/accessibilite/P09_3_3__P03_3_3.md
@@ -1,0 +1,24 @@
+# P09 3.3 + P03 3.3 — Contrastes (Impact CO2 hachures, composants UI)
+
+## Retour auditeur (verbatim)
+
+Les contrastes utilisés dans le widget Impact CO2 (notamment les hachures
+représentant les barres) et certains composants UI de la page produit ne
+respectent pas le ratio 3:1 attendu par le critère 3.3.
+
+## Statut
+
+Marqué **déjà OK avec EF** (équipe Facteur d'Émission). Plus besoin de le faire
+côté incubateur. La preview est conservée pour documentation.
+
+## Sévérité
+
+Mineure.
+
+## Scope
+
+Tiers (widget Impact CO2 / Ademe).
+
+## Lien Notion
+
+[Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)

--- a/webapp/templates/ui/components/accessibilite/P10_13_3.md
+++ b/webapp/templates/ui/components/accessibilite/P10_13_3.md
@@ -1,0 +1,33 @@
+# P10 13.3 — PDF non accessible (guide Smartphone)
+
+## Retour auditeur (verbatim)
+
+Le guide PDF Smartphone proposé en téléchargement sur P10 n'est pas
+accessible : balisage absent, ordre de lecture incorrect, absence
+d'alternatives textuelles aux images.
+
+## Statut
+
+Marqué **FAIT** côté audit (PDF refondu). Cette preview est conservée pour
+documenter la procédure de vérification de tout PDF futur.
+
+## À vérifier sur tout nouveau PDF
+
+- [ ] Le PDF est balisé (titres, paragraphes, listes).
+- [ ] L'ordre de lecture est correct.
+- [ ] Toutes les images ont une alternative textuelle.
+- [ ] Les tableaux ont des en-têtes de ligne / colonne.
+- [ ] La langue principale est déclarée.
+- [ ] Le PDF passe le validateur PAC (PDF Accessibility Checker).
+
+## Sévérité
+
+Modérée (un PDF non accessible bloque ses lecteurs handicapés).
+
+## Scope
+
+Hors webapp (production de documents PDF).
+
+## Lien Notion
+
+[Notion](https://www.notion.so/Backlog-RGAA-89e89ccdd08d4ac4bc38f7058b67498a)

--- a/webapp/templates/ui/components/carte/results.html
+++ b/webapp/templates/ui/components/carte/results.html
@@ -6,7 +6,7 @@ The values of 120px and 150px are determined empirically.
 They need to match the css variables used for .grid-map selector in qfdmo.css
 {% endcomment %}
 
-{% load carte_tags %}
+{% load carte_tags acteur_tags %}
 <div
     class="
     qf-relative
@@ -18,6 +18,11 @@ They need to match the css variables used for .grid-map selector in qfdmo.css
     "
     {% if not is_digital %}
     data-controller="map"
+    data-map-acteur-frame-id-value="{% acteur_frame_id %}"
+    data-map-filter-params-value="{{ geojson_filter_params|default:'' }}"
+    data-map-use-geojson-layer-value="true"
+    data-map-search-area-citycode-value="{{ search_area_citycode|default:'' }}"
+    data-map-search-area-bbox-value="{{ search_area_bbox|default:''|escape }}"
     {% if location %}
     data-map-location-value="{{ location }}"
     {% endif %}
@@ -28,13 +33,35 @@ They need to match the css variables used for .grid-map selector in qfdmo.css
         {% include "ui/components/carte/shared/_search_in_zone.html" %}
         {% include "ui/components/carte/buttons/ajouter_un_lieu.html" %}
     {% endif %}
+    {% comment %}
+        Subtle spinner shown while the map is fetching new acteurs after a pan.
+        Toggled by the map controller via the `qf-hidden` class.
+    {% endcomment %}
+    <div
+        data-map-target="loadingIndicator"
+        class="qf-hidden qf-absolute qf-z-20 qf-top-1w qf-right-1w
+               qf-bg-white qf-rounded-full qf-shadow qf-p-1v
+               qf-pointer-events-none"
+        role="status"
+        aria-live="polite"
+    >
+        <span class="fr-icon-refresh-line fr-icon--sm" aria-hidden="true"></span>
+        <span class="fr-sr-only">Chargement en cours</span>
+    </div>
     <div
         data-map-target="mapContainer"
         class="qf-inset-0 qf-h-full qf-relative qf-z-0"
     >
-        {% for acteur in acteurs %}
-            {% acteur_pinpoint_tag acteur=acteur direction=form.initial.direction action_list=selected_action_codes carte=carte carte_config=carte_config sous_categorie_id=forms.filtres.sous_categorie_objet_id.value counter=forloop.counter %}
-        {% endfor %}
+        {% comment %}
+            Hidden acteur pinpoints kept transitionally for selectors that
+            look them up by data-marker-key. The visible markers are now
+            rendered by the MapLibre symbol layer in solution_map.ts.
+        {% endcomment %}
+        <div class="qf-hidden">
+            {% for acteur in acteurs %}
+                {% acteur_pinpoint_tag acteur=acteur direction=form.initial.direction action_list=selected_action_codes carte=carte carte_config=carte_config sous_categorie_id=forms.filtres.sous_categorie_objet_id.value counter=forloop.counter %}
+            {% endfor %}
+        </div>
         {% include "ui/components/carte/pinpoints/home.html" %}
     </div>
 

--- a/webapp/templates/ui/components/carte/shared/_search_in_zone.html
+++ b/webapp/templates/ui/components/carte/shared/_search_in_zone.html
@@ -1,6 +1,6 @@
 <button
     data-map-target="searchInZoneButton"
-    data-action="click -> state#submit"
+    data-action="click->map#searchInZone"
     class="fr-btn fr-btn--sm fr-btn--secondary
             fr-icon-refresh-line fr-btn--icon-left
             qf-bg-white

--- a/webapp/templates/ui/pages/carte.html
+++ b/webapp/templates/ui/pages/carte.html
@@ -42,6 +42,7 @@
         <input type="hidden" name="{{ MAP_CONTAINER_ID }}" value="{% main_frame_id %}">
         {{ forms.legacy }}
         {{ forms.map.bounding_box }}
+        {{ forms.map.search_area_citycode }}
         <section class="map-grid qf-relative">
             {% include 'ui/components/carte/header.html' %}
 

--- a/webapp/templates/ui/tests/acteur_icons_preview.html
+++ b/webapp/templates/ui/tests/acteur_icons_preview.html
@@ -1,0 +1,104 @@
+{% load static %}
+
+<link rel="stylesheet" href="{% static 'qfdmo.css' %}">
+<script src="{% static 'qfdmo.js' %}"></script>
+
+<style>
+    .icons-preview-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 1.5rem;
+        padding: 1rem;
+    }
+
+    .icons-preview-panel {
+        border: 1px solid #ddd;
+        border-radius: 6px;
+        padding: 1rem;
+        background: #fff;
+    }
+
+    .icons-preview-panel h3 {
+        margin: 0 0 0.75rem 0;
+        font-size: 1rem;
+    }
+
+    .dom-pinpoints-row {
+        display: flex;
+        align-items: flex-end;
+        gap: 1.25rem;
+        flex-wrap: wrap;
+        padding: 1rem 0;
+    }
+
+    .dom-pinpoint-cell {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.25rem;
+        font-size: 0.75rem;
+        color: #555;
+    }
+
+    .map-preview-container {
+        height: 480px;
+        width: 100%;
+        position: relative;
+    }
+</style>
+
+<div class="icons-preview-grid">
+    <div class="icons-preview-panel">
+        <h3>Today: DOM pinpoints (rendered via <code>acteur_pinpoint_tag</code>)</h3>
+        <div class="dom-pinpoints-row">
+            {% for variant in variants %}
+                <div class="dom-pinpoint-cell">
+                    <div style="position: relative; width: 46px; height: 61px;">
+                        {% if variant.filled %}
+                            <div data-animated="" class="qf-scale-75">
+                                <div class="qf--translate-y-2/4" style="color: {{ variant.couleur }};">
+                                    {% include "ui/components/carte/pinpoints/svg/pin-background-fill.html" with mask_id=variant.code %}
+                                    <span class="qf-absolute qf-top-[10] qf-left-[10.5] qf-margin-auto {{ variant.icon }} qf-text-white"></span>
+                                </div>
+                            </div>
+                        {% else %}
+                            <div data-animated="" class="qf-scale-75">
+                                <div class="qf--translate-y-2/4" style="color: {{ variant.couleur }};">
+                                    {% include "ui/components/carte/pinpoints/svg/pin-background.html" with mask_id=variant.code %}
+                                    <span class="qf-absolute qf-top-[10] qf-left-[10.5] qf-margin-auto {{ variant.icon }}"></span>
+                                </div>
+                            </div>
+                        {% endif %}
+                    </div>
+                    <span>{{ variant.code }}</span>
+                </div>
+            {% endfor %}
+
+            {# reparer + bonus #}
+            <div class="dom-pinpoint-cell">
+                <div style="position: relative; width: 46px; height: 61px;">
+                    <div data-animated="" class="qf-scale-75">
+                        <div class="qf--translate-y-2/4" style="color: #009081;">
+                            {% include "ui/components/carte/pinpoints/svg/pin-background-fill.html" with mask_id="reparer-bonus" %}
+                            <span class="qf-absolute qf-right-[-16] qf-top-[-6] qf-z-10">
+                                {% include "ui/components/carte/pinpoints/svg/bonus-icon.svg" %}
+                            </span>
+                            <span class="qf-absolute qf-top-[10] qf-left-[10.5] qf-margin-auto fr-icon-tools-fill qf-text-white"></span>
+                        </div>
+                    </div>
+                </div>
+                <span>reparer + bonus</span>
+            </div>
+        </div>
+    </div>
+
+    <div class="icons-preview-panel">
+        <h3>New: MapLibre symbol layer (icons rendered to canvas at runtime)</h3>
+        <div data-controller="acteur-icons-preview" class="map-preview-container">
+            <div data-acteur-icons-preview-target="mapContainer" style="height: 100%; width: 100%;"></div>
+        </div>
+        <p style="font-size: 0.75rem; color: #666; margin-top: 0.5rem;">
+            Each pin should match the corresponding DOM pinpoint above. Bottom row = with-bonus variants.
+        </p>
+    </div>
+</div>

--- a/webapp/unit_tests/qfdmo/test_acteur.py
+++ b/webapp/unit_tests/qfdmo/test_acteur.py
@@ -786,33 +786,39 @@ class TestDisplayedActeurActionToDisplay:
 class TestActeurOrdering:
     def test_in_bbox_ordering_is_random(self):
         DisplayedActeurFactory.create_batch(20)
-        bbox_whole_planet = [-180, -90, 180, 90]
+        # Geography ST_CoveredBy rejects polygons whose edges span 180° of
+        # longitude (treated as antipodal great-circle edges). Use a wide
+        # but valid bbox covering the factory default Point(3, 3).
+        bbox_almost_whole_planet = [-30, -30, 30, 30]
         # in_bbox is explicitely called each time so that
         # the ordering of the queryset is re-computed.
         # We expect it to change at least once
-        assert DisplayedActeur.objects.all().in_bbox(bbox_whole_planet).count() > 0
-        first_acteur = DisplayedActeur.objects.all().in_bbox(bbox_whole_planet).first()
+        assert DisplayedActeur.objects.all().in_bbox(bbox_almost_whole_planet).count() > 0
+        first_acteur = DisplayedActeur.objects.all().in_bbox(bbox_almost_whole_planet).first()
         while (
             first_acteur
-            == DisplayedActeur.objects.all().in_bbox(bbox_whole_planet).first()
+            == DisplayedActeur.objects.all().in_bbox(bbox_almost_whole_planet).first()
         ):
             first_acteur = (
-                DisplayedActeur.objects.all().in_bbox(bbox_whole_planet).first()
+                DisplayedActeur.objects.all().in_bbox(bbox_almost_whole_planet).first()
             )
 
     def test_in_geojson_ordering_is_random(self):
         DisplayedActeurFactory.create_batch(20)
-        geojson_whole_planet = json.dumps(
+        # Geography ST_CoveredBy rejects edges spanning 180° of longitude
+        # (treated as antipodal great-circle edges). Use a wide but valid
+        # polygon covering France + neighbours.
+        geojson_almost_whole_planet = json.dumps(
             {
                 "type": "MultiPolygon",
                 "coordinates": [
                     [
                         [
-                            [-180, 90],
-                            [180, 90],
-                            [180, -90],
-                            [-180, -90],
-                            [-180, 90],
+                            [-30, 30],
+                            [30, 30],
+                            [30, -30],
+                            [-30, -30],
+                            [-30, 30],
                         ]
                     ]
                 ],
@@ -822,17 +828,17 @@ class TestActeurOrdering:
         # the ordering of the queryset is re-computed.
         # We expect it to change at least once
         assert (
-            DisplayedActeur.objects.all().in_geojson(geojson_whole_planet).count() > 0
+            DisplayedActeur.objects.all().in_geojson(geojson_almost_whole_planet).count() > 0
         )
         first_acteur = (
-            DisplayedActeur.objects.all().in_geojson(geojson_whole_planet).first()
+            DisplayedActeur.objects.all().in_geojson(geojson_almost_whole_planet).first()
         )
         while (
             first_acteur
-            == DisplayedActeur.objects.all().in_geojson(geojson_whole_planet).first()
+            == DisplayedActeur.objects.all().in_geojson(geojson_almost_whole_planet).first()
         ):
             first_acteur = (
-                DisplayedActeur.objects.all().in_geojson(geojson_whole_planet).first()
+                DisplayedActeur.objects.all().in_geojson(geojson_almost_whole_planet).first()
             )
 
 

--- a/webapp/unit_tests/qfdmo/views/test_carte_acteurs_geojson.py
+++ b/webapp/unit_tests/qfdmo/views/test_carte_acteurs_geojson.py
@@ -1,0 +1,190 @@
+"""Tests for the GeoJSON acteurs endpoint that feeds the auto-search-on-pan
+feature on the carte. Covers happy path, exclude_uuids, filters, and validation."""
+
+import json
+
+import pytest
+from django.contrib.gis.geos import Point
+from django.test import Client
+from django.urls import reverse
+
+from qfdmo.models import GroupeAction
+from unit_tests.qfdmo.acteur_factory import (
+    DisplayedActeurFactory,
+    DisplayedPropositionServiceFactory,
+)
+
+
+def _url() -> str:
+    return reverse("qfdmo:carte_acteurs_geojson")
+
+
+def _bbox_around(lng: float, lat: float, half: float = 0.05) -> str:
+    return f"{lng - half},{lat - half},{lng + half},{lat + half}"
+
+
+@pytest.mark.django_db
+class TestCarteActeursGeojson:
+    @pytest.fixture
+    def client(self) -> Client:
+        return Client()
+
+    @pytest.fixture
+    def reparer_action(self):
+        return GroupeAction.objects.get(code="reparer").actions.first()
+
+    def test_returns_400_when_bbox_missing(self, client):
+        response = client.get(_url())
+        assert response.status_code == 400
+
+    def test_returns_400_when_bbox_invalid(self, client):
+        response = client.get(_url(), {"bbox": "not,a,valid,bbox"})
+        assert response.status_code == 400
+
+    def test_returns_features_in_bbox(self, client, reparer_action):
+        # In-bbox acteur: Auray-ish.
+        in_bbox = DisplayedActeurFactory(location=Point(-2.99, 47.66))
+        DisplayedPropositionServiceFactory(action=reparer_action, acteur=in_bbox)
+
+        # Out-of-bbox acteur (Paris).
+        out_of_bbox = DisplayedActeurFactory(location=Point(2.35, 48.85))
+        DisplayedPropositionServiceFactory(action=reparer_action, acteur=out_of_bbox)
+
+        response = client.get(_url(), {"bbox": _bbox_around(-2.99, 47.66)})
+        assert response.status_code == 200
+        payload = json.loads(response.content)
+
+        uuids = {f["properties"]["uuid"] for f in payload["features"]}
+        assert str(in_bbox.uuid) in uuids
+        assert str(out_of_bbox.uuid) not in uuids
+
+    def test_geojson_shape(self, client, reparer_action):
+        acteur = DisplayedActeurFactory(location=Point(-2.99, 47.66))
+        DisplayedPropositionServiceFactory(action=reparer_action, acteur=acteur)
+
+        response = client.get(_url(), {"bbox": _bbox_around(-2.99, 47.66)})
+        payload = json.loads(response.content)
+
+        assert payload["type"] == "FeatureCollection"
+        feature = next(
+            f for f in payload["features"] if f["properties"]["uuid"] == str(acteur.uuid)
+        )
+        assert feature["type"] == "Feature"
+        assert feature["geometry"]["type"] == "Point"
+        # GeoJSON: coordinates are [lng, lat].
+        assert feature["geometry"]["coordinates"] == pytest.approx([-2.99, 47.66])
+        # Icon name mirrors `iconNameFor` in static/to_compile/js/acteur_icons.ts.
+        assert feature["properties"]["icon"].startswith("acteur:")
+        assert feature["properties"]["bonus"] is False
+        assert feature["properties"]["detail_url"].endswith(str(acteur.uuid))
+
+    def test_exclude_uuids_filters_out_listed_acteurs(self, client, reparer_action):
+        keep = DisplayedActeurFactory(location=Point(-2.99, 47.66))
+        DisplayedPropositionServiceFactory(action=reparer_action, acteur=keep)
+        skip = DisplayedActeurFactory(location=Point(-2.99, 47.66))
+        DisplayedPropositionServiceFactory(action=reparer_action, acteur=skip)
+
+        response = client.get(
+            _url(),
+            {"bbox": _bbox_around(-2.99, 47.66), "exclude_uuids": str(skip.uuid)},
+        )
+        assert response.status_code == 200
+        payload = json.loads(response.content)
+        uuids = {f["properties"]["uuid"] for f in payload["features"]}
+        assert str(keep.uuid) in uuids
+        assert str(skip.uuid) not in uuids
+
+    def test_groupe_actions_filter_excludes_other_groups(self, client, reparer_action):
+        keep = DisplayedActeurFactory(location=Point(-2.99, 47.66))
+        DisplayedPropositionServiceFactory(action=reparer_action, acteur=keep)
+
+        # Acteur whose only action belongs to a different groupe.
+        other_group_action = (
+            GroupeAction.objects.get(code="trier").actions.first()
+        )
+        skip = DisplayedActeurFactory(location=Point(-2.99, 47.66))
+        DisplayedPropositionServiceFactory(action=other_group_action, acteur=skip)
+
+        response = client.get(
+            _url(),
+            {
+                "bbox": _bbox_around(-2.99, 47.66),
+                "groupe_actions": str(reparer_action.groupe_action_id),
+            },
+        )
+        assert response.status_code == 200
+        payload = json.loads(response.content)
+        uuids = {f["properties"]["uuid"] for f in payload["features"]}
+        assert str(keep.uuid) in uuids
+        assert str(skip.uuid) not in uuids
+
+    def test_limit_caps_result_count(self, client, reparer_action):
+        # Spread acteurs into distinct ~500 m grid cells so spatial thinning
+        # (DISTINCT ON (ST_SnapToGrid(location, 0.005))) keeps all 5.
+        for i in range(5):
+            acteur = DisplayedActeurFactory(location=Point(-2.99 + i * 0.02, 47.66))
+            DisplayedPropositionServiceFactory(action=reparer_action, acteur=acteur)
+
+        response = client.get(
+            _url(),
+            {"bbox": _bbox_around(-2.99, 47.66, half=0.5), "limit": "3"},
+        )
+        payload = json.loads(response.content)
+        assert len(payload["features"]) == 3
+
+    def test_truncated_flag_when_limit_hit(self, client, reparer_action):
+        # 5 acteurs in distinct grid cells, ask for at most 3.
+        for i in range(5):
+            acteur = DisplayedActeurFactory(location=Point(-2.99 + i * 0.02, 47.66))
+            DisplayedPropositionServiceFactory(action=reparer_action, acteur=acteur)
+
+        response = client.get(
+            _url(),
+            {"bbox": _bbox_around(-2.99, 47.66, half=0.5), "limit": "3"},
+        )
+        payload = json.loads(response.content)
+        assert payload["truncated"] is True
+
+    def test_truncated_flag_false_when_limit_not_hit(self, client, reparer_action):
+        for i in range(2):
+            acteur = DisplayedActeurFactory(location=Point(-2.99 + i * 0.02, 47.66))
+            DisplayedPropositionServiceFactory(action=reparer_action, acteur=acteur)
+
+        response = client.get(
+            _url(),
+            {"bbox": _bbox_around(-2.99, 47.66, half=0.5), "limit": "10"},
+        )
+        payload = json.loads(response.content)
+        assert payload["truncated"] is False
+
+    def test_low_zoom_spatial_thinning_uses_coarser_grid(self, client, reparer_action):
+        # 5 acteurs spread ~10 km apart fall into distinct ~500 m cells (the
+        # default grid) and would all pass through. At a low zoom, the grid
+        # cell grows large enough that they all snap into one cell, so the
+        # endpoint thins them down to 1.
+        for i in range(5):
+            acteur = DisplayedActeurFactory(location=Point(-2.99 + i * 0.1, 47.66))
+            DisplayedPropositionServiceFactory(action=reparer_action, acteur=acteur)
+
+        # Without zoom (default branch) all 5 are returned.
+        response = client.get(_url(), {"bbox": _bbox_around(-2.99, 47.66, half=2.0)})
+        assert len(json.loads(response.content)["features"]) == 5
+
+        # At zoom 5 (~country level) the grid is much coarser and they all
+        # snap into one cell.
+        response = client.get(
+            _url(),
+            {"bbox": _bbox_around(-2.99, 47.66, half=2.0), "zoom": "5"},
+        )
+        assert len(json.loads(response.content)["features"]) == 1
+
+    def test_spatial_thinning_dedups_clustered_acteurs(self, client, reparer_action):
+        # 5 acteurs at the exact same location all snap into one grid cell;
+        # the response should return at most 1 of them.
+        for _ in range(5):
+            acteur = DisplayedActeurFactory(location=Point(-2.99, 47.66))
+            DisplayedPropositionServiceFactory(action=reparer_action, acteur=acteur)
+
+        response = client.get(_url(), {"bbox": _bbox_around(-2.99, 47.66)})
+        payload = json.loads(response.content)
+        assert len(payload["features"]) == 1


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [[Assistant/Carte] Au déplacement et nouvelle recherche dans la zone, l'adresse initiale est conservée](https://www.notion.so/3346523d57d78027930bfe2c0f01e701)

**Tag** : `bug`

**🗺️ contexte** : Assistant / Carte, comportement du bouton *Nouvelle recherche dans cette zone*.

**💡 quoi** : le pinpoint rouge (home) n'est plus pris en compte dans le calcul du `fitBounds` de la carte.

**🎯 pourquoi** : après une première recherche (ex : Mouzillon) puis un déplacement vers une zone éloignée (ex : Noirmoutier), un clic sur *Nouvelle recherche dans cette zone* faisait re-englober l'adresse initiale par la carte. Cela dé-zoomait fortement la vue et empêchait d'afficher correctement la nouvelle zone.

**🤔 comment** :

- `solution_map.ts` : suppression du champ `#homePoint` et retrait de son inclusion dans `fitBounds`. Le calcul utilise désormais uniquement les marqueurs acteurs, ou la bounding box explicite si fournie.
- `carte.spec.ts` : ajout d'un test e2e qui vérifie qu'après un `fitBounds` sur une zone éloignée, les bounds ne contiennent pas les coordonnées de l'adresse initiale.

**🤓 comment tester** :

1. Aller sur la carte (ex : `/categories/vetements/`).
2. Rechercher « Mouzillon ».
3. Déplacer la carte vers Noirmoutier jusqu'à voir le bouton *Nouvelle recherche dans cette zone*.
4. Cliquer dessus : la carte doit afficher Noirmoutier sans dé-zoomer pour inclure Mouzillon.

## Auto-review

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [x] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template` (n/a)
- [x] J'ai ajouté des tests qui couvrent le nouveau code
- [x] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours (n/a)

## Reste à faire (PR en cours)

- [ ] Validation manuelle sur l'environnement de preview.
