### PR TITLE
Affiche la mini carte sur mobile dans la fiche détaillée

### DIFF
--- a/webapp/e2e_tests/carte.spec.ts
+++ b/webapp/e2e_tests/carte.spec.ts
@@ -564,6 +564,134 @@ test.describe("🗺️ Mini Carte - Affichage des Pinpoints", () => {
     const homePinpoint = page.locator("#pinpoint-home")
     await expect(homePinpoint).toBeVisible({ timeout: TIMEOUT.DEFAULT })
   })
+
+  test(
+    "La fiche acteur affiche une mini carte sur mobile (mode liste)",
+    { tag: ["@mobile", "@regression"] },
+    async ({ page }) => {
+      test.slow()
+      await navigateTo(page, "/carte")
+      await mockApiAdresse(page)
+      await searchForAuray(page)
+
+      await expect(
+        page.locator('#addressesPanel [data-controller="pinpoint"]').first(),
+      ).toBeVisible({ timeout: TIMEOUT.DEFAULT })
+
+      await switchToListeMode(page)
+
+      const voirLaFicheButtons = page.locator('[data-testid="voir-la-fiche"]')
+      await expect(voirLaFicheButtons.first()).toBeVisible({
+        timeout: TIMEOUT.DEFAULT,
+      })
+
+      const fifthVoirLaFiche = voirLaFicheButtons.nth(4)
+      const href = await fifthVoirLaFiche.getAttribute("href")
+      expect(href).toBeTruthy()
+
+      // List mode: with_map=1 is set, mini map must be visible on mobile
+      await navigateTo(page, `${href}&with_map=1`)
+
+      await expect(
+        page.locator('[data-testid="acteur-detail-about-panel"]'),
+      ).toBeVisible({ timeout: TIMEOUT.DEFAULT })
+
+      const miniMapContainer = page.locator('[data-map-target="mapContainer"]')
+      await expect(miniMapContainer).toBeVisible({ timeout: TIMEOUT.DEFAULT })
+
+      const acteurPinpoint = page.locator(
+        '.maplibregl-marker[data-controller="pinpoint"]:not(#pinpoint-home)',
+      )
+      await expect(acteurPinpoint.first()).toBeVisible({ timeout: TIMEOUT.DEFAULT })
+
+      const homePinpoint = page.locator("#pinpoint-home")
+      await expect(homePinpoint).toBeVisible({ timeout: TIMEOUT.DEFAULT })
+    },
+  )
+
+  test(
+    "La fiche acteur affiche une mini carte sur mobile (mode carte, sans with_map)",
+    { tag: ["@mobile", "@regression"] },
+    async ({ page }) => {
+      test.slow()
+      await navigateTo(page, "/carte")
+      await mockApiAdresse(page)
+      await searchForAuray(page)
+
+      await expect(
+        page.locator('#addressesPanel [data-controller="pinpoint"]').first(),
+      ).toBeVisible({ timeout: TIMEOUT.DEFAULT })
+
+      await switchToListeMode(page)
+
+      const voirLaFicheButtons = page.locator('[data-testid="voir-la-fiche"]')
+      await expect(voirLaFicheButtons.first()).toBeVisible({
+        timeout: TIMEOUT.DEFAULT,
+      })
+
+      const fifthVoirLaFiche = voirLaFicheButtons.nth(4)
+      const href = await fifthVoirLaFiche.getAttribute("href")
+      expect(href).toBeTruthy()
+
+      // Map mode: simulate a pinpoint click (no with_map param).
+      // Mini map must still be visible on mobile because the full-screen
+      // detail sheet hides the big map behind.
+      const hrefWithoutMap = href!.replace(/[?&]with_map=1/g, "")
+      await navigateTo(page, hrefWithoutMap)
+
+      await expect(
+        page.locator('[data-testid="acteur-detail-about-panel"]'),
+      ).toBeVisible({ timeout: TIMEOUT.DEFAULT })
+
+      const miniMapContainer = page.locator('[data-map-target="mapContainer"]')
+      await expect(miniMapContainer).toBeVisible({ timeout: TIMEOUT.DEFAULT })
+
+      const acteurPinpoint = page.locator(
+        '.maplibregl-marker[data-controller="pinpoint"]:not(#pinpoint-home)',
+      )
+      await expect(acteurPinpoint.first()).toBeVisible({ timeout: TIMEOUT.DEFAULT })
+
+      const homePinpoint = page.locator("#pinpoint-home")
+      await expect(homePinpoint).toBeVisible({ timeout: TIMEOUT.DEFAULT })
+    },
+  )
+
+  test("La fiche acteur n'affiche pas de mini carte sur desktop (mode carte, sans with_map)", async ({
+    page,
+  }) => {
+    test.slow()
+    await navigateTo(page, "/carte")
+    await mockApiAdresse(page)
+    await searchForAuray(page)
+
+    await expect(
+      page.locator('#addressesPanel [data-controller="pinpoint"]').first(),
+    ).toBeVisible({ timeout: TIMEOUT.DEFAULT })
+
+    await switchToListeMode(page)
+
+    const voirLaFicheButtons = page.locator('[data-testid="voir-la-fiche"]')
+    await expect(voirLaFicheButtons.first()).toBeVisible({ timeout: TIMEOUT.DEFAULT })
+
+    const fifthVoirLaFiche = voirLaFicheButtons.nth(4)
+    const href = await fifthVoirLaFiche.getAttribute("href")
+    expect(href).toBeTruthy()
+
+    // Desktop map mode: simulate a pinpoint click (no with_map param).
+    // Mini map must stay hidden because the big map remains visible
+    // alongside the detail panel.
+    const hrefWithoutMap = href!.replace(/[?&]with_map=1/g, "")
+    await navigateTo(page, hrefWithoutMap)
+
+    await expect(page.locator('[data-testid="acteur-detail-about-panel"]')).toBeVisible(
+      {
+        timeout: TIMEOUT.DEFAULT,
+      },
+    )
+
+    const miniMapContainer = page.locator('[data-map-target="mapContainer"]')
+    await expect(miniMapContainer).toBeHidden()
+  })
 })
 
 test.describe("🗺️ Absence du Pinpoint Home sans Adresse", () => {

--- a/webapp/templates/ui/components/acteur/tabs/sections/adresse.html
+++ b/webapp/templates/ui/components/acteur/tabs/sections/adresse.html
@@ -6,8 +6,8 @@ Adresse
 
 {% block content %}
 
-{% if request.GET.with_map %}
-<div class="max-md:qf-hidden">
+{% if is_carte and latitude and longitude %}
+<div class="{% if not request.GET.with_map %}md:qf-hidden{% endif %}">
     {% include "ui/components/mini_carte/mini_carte.html" with search_latitude=latitude search_longitude=longitude acteur=object %}
 </div>
 {% endif %}


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [[MOBILE] Dans la fiche détaillée en mode liste, il n'y a pas de carte, alors que c'est le cas en desktop/tablette](https://www.notion.so/3306523d57d7800289f9fce4b5f63f64)

**🗺️ contexte** : sur mobile, la fiche détaillée s'ouvre en plein écran et masque la grande carte. La mini carte de la fiche doit donc s'afficher pour conserver le repère géographique.

**💡 quoi** : afficher la mini carte dans la fiche détaillée sur mobile, en mode liste comme en mode carte. Comportement inchangé sur tablette et desktop.

**🎯 pourquoi** : le repère visuel de la localisation disparaissait sur mobile depuis le passage de la fiche en plein écran.

**🤔 comment** :

- Adaptation du wrapper conditionnel dans `adresse.html` : suppression de `max-md:qf-hidden` et ajout d'un `md:qf-hidden` appliqué uniquement quand `with_map` est absent.
- Matrice d'affichage attendue :

| Device    | Mode carte | Mode liste |
|-----------|------------|------------|
| Mobile    | Affichée   | Affichée   |
| Tablette  | Masquée    | Affichée   |
| Desktop   | Masquée    | Affichée   |

**🤓 comment tester** :

1. Aller sur `/carte` en mobile (viewport < 768px).
2. Rechercher une adresse, cliquer sur un pinpoint : la mini carte doit apparaître.
3. Basculer en mode liste, ouvrir une fiche : la mini carte doit également apparaître.
4. Refaire en desktop : mini carte masquée en mode carte, visible en mode liste.

## Auto-review

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [x] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template` (n/a)
- [x] J'ai ajouté des tests qui couvrent le nouveau code (3 tests e2e)
- [x] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours (n/a)
