### PR TITLE
Fiabilise la résolution du Frame iframe dans les tests analytics

### DIFF
--- a/webapp/e2e_tests/analytics.spec.ts
+++ b/webapp/e2e_tests/analytics.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, Page, Frame } from "@playwright/test"
+import { test, expect, Page, Frame, Locator, ElementHandle } from "@playwright/test"
 import {
   navigateTo,
   TIMEOUT,
@@ -70,6 +70,25 @@ async function waitForEvent(frame: Frame, eventName: string) {
     eventName,
     { timeout: TIMEOUT.DEFAULT },
   )
+}
+
+// Resolve the Frame object from an iframe Locator via its DOM handle.
+// Using contentFrame() is redirect-safe: for iframes whose server redirects
+// (e.g. /dechet -> /, /carte/<slug> -> /carte/<slug>/), URL-based matching
+// on f.url() vs. the iframe src attribute would never match.
+async function resolveIframeFrame(iframeEl: Locator): Promise<Frame> {
+  let frame: Frame | null = null
+  await expect
+    .poll(
+      async () => {
+        const handle: ElementHandle | null = await iframeEl.elementHandle()
+        frame = (await handle?.contentFrame()) ?? null
+        return frame !== null && frame.url() !== "about:blank"
+      },
+      { timeout: TIMEOUT.LONG },
+    )
+    .toBe(true)
+  return frame!
 }
 
 test.describe("📊 Analytics & Tracking", () => {
@@ -162,24 +181,8 @@ test.describe("📊 Analytics & Tracking", () => {
         const iframeEl = page.locator(`[data-testid="${testId}"] iframe`).first()
         await expect(iframeEl).toBeAttached({ timeout: TIMEOUT.LONG })
 
-        // Resolve Frame from src — poll until attached (iframes load lazily via script tag)
-        const iframeSrc = await iframeEl.getAttribute("src")
-        if (!iframeSrc) throw new Error(`No src on iframe for ${testId}`)
-
-        let frame: Frame | undefined
-        await expect
-          .poll(
-            () => {
-              frame = page
-                .frames()
-                .find((f) => f.url().split("?")[0] === iframeSrc.split("?")[0])
-              return !!frame
-            },
-            { timeout: TIMEOUT.LONG },
-          )
-          .toBe(true)
-
-        const resolvedFrame = frame!
+        // Resolve Frame via DOM handle (redirect-safe; iframe src may differ from final URL)
+        const resolvedFrame = await resolveIframeFrame(iframeEl)
         await resolvedFrame.waitForLoadState("domcontentloaded", {
           timeout: TIMEOUT.LONG,
         })
@@ -254,23 +257,7 @@ test.describe("📊 Analytics & Tracking", () => {
         const iframeEl = page.locator(`[data-testid="${testId}"] iframe`).first()
         await expect(iframeEl).toBeAttached({ timeout: TIMEOUT.LONG })
 
-        const iframeSrc = await iframeEl.getAttribute("src")
-        if (!iframeSrc) throw new Error(`No src on iframe for ${testId}`)
-
-        let frame: Frame | undefined
-        await expect
-          .poll(
-            () => {
-              frame = page
-                .frames()
-                .find((f) => f.url().split("?")[0] === iframeSrc.split("?")[0])
-              return !!frame
-            },
-            { timeout: TIMEOUT.LONG },
-          )
-          .toBe(true)
-
-        const resolvedFrame = frame!
+        const resolvedFrame = await resolveIframeFrame(iframeEl)
         await resolvedFrame.waitForLoadState("domcontentloaded", {
           timeout: TIMEOUT.LONG,
         })


### PR DESCRIPTION
# Description succincte du problème résolu


**🗺️ contexte** : suite à l'ajout des tests t_18 (iframe_page_properties), trois tests analytics étaient en échec sur main 

**💡 quoi** : résolution du Frame Playwright via l'`ElementHandle` de l'iframe (`contentFrame()`) au lieu d'une comparaison d'URL entre `iframe.src` et `frame.url()`.

**🎯 pourquoi** : la comparaison strict prefix sur `?` échouait quand Django renvoyait une redirection (la `src` de l'iframe diffère du `frame.url()` final, ex : `/dechet` vs `/`, `/carte/<slug>` vs `/carte/<slug>/`). Le poll ne trouvait jamais le Frame correspondant et timeoutait après 30s.

**🤔 comment** :

- Remplacement de la logique de poll URL-based par une résolution via `iframeEl.elementHandle().contentFrame()`, insensible aux redirections.
- Factorisation dans un helper `resolveIframeFrame(iframeEl)` réutilisé dans les deux tests (pageType et UTM).

**🤓 comment tester** :

1. `npm run build` dans `webapp/`.
2. `npx playwright test e2e_tests/analytics.spec.ts --project=chromium` doit renvoyer 11/11 passed.

## Auto-review

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [x] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template` (n/a)
- [x] J'ai ajouté des tests qui couvrent le nouveau code (refactor de tests existants)
- [x] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours (n/a)
