### PR TITLE
Utilisation du nouvel autocomplete pour le champ adresse de la carte

### DIFF
--- a/webapp/e2e_tests/carte_address_combobox.spec.ts
+++ b/webapp/e2e_tests/carte_address_combobox.spec.ts
@@ -1,0 +1,163 @@
+import { expect, Page } from "@playwright/test"
+import { test } from "./fixtures"
+import { mockCarteAutocompleteAddress, navigateTo, TIMEOUT } from "./helpers"
+
+/**
+ * Covers the next-autocomplete carte combobox:
+ *
+ *   1. typing fires a Turbo Frame fetch and renders BAN suggestions
+ *   2. picking a suggestion populates lat/lng, dispatches change, submits form
+ *   3. reloading after a pick does NOT enter a resubmit loop
+ *   4. the form serializes exactly one `adresse` field (regression: the
+ *      visible search input used to share its `name` with a hidden sibling,
+ *      sending `adresse=""` and triggering the loop above)
+ */
+
+const CARTE_INPUT = '[data-testid="carte-adresse-input"]'
+const CARTE_OPTION = '[role="option"][data-next-autocomplete-target="option"]'
+const ADRESSE_FIELD_NAME = "carte_map-adresse"
+
+/**
+ * Type a query into the carte combobox and click the first matching suggestion.
+ * Waits for the Turbo Frame response to settle before clicking.
+ */
+async function pickFirstAddress(page: Page, query: string): Promise<void> {
+  const input = page.locator(CARTE_INPUT)
+  await input.click()
+  await input.fill(query)
+
+  // Wait for our mocked Turbo Frame response before reaching for the option.
+  await page.waitForResponse(
+    (response) =>
+      response.url().includes("/qfdmo/autocomplete/address") &&
+      response.url().includes(`q=${query}`) &&
+      response.status() === 200,
+    { timeout: TIMEOUT.DEFAULT },
+  )
+
+  const firstOption = page.locator(CARTE_OPTION).filter({ hasText: query }).first()
+  await expect(firstOption).toBeVisible({ timeout: TIMEOUT.DEFAULT })
+  await firstOption.click()
+}
+
+test.describe("🗺️ Carte address combobox", () => {
+  test.beforeEach(async ({ page }) => {
+    // Always intercept the Turbo Frame autocomplete endpoint with deterministic
+    // results so the test never depends on data.geopf.fr being available.
+    await mockCarteAutocompleteAddress(page)
+  })
+
+  test("typing renders BAN suggestions with role=option", async ({ page }) => {
+    await navigateTo(page, "/carte")
+    await page.locator(CARTE_INPUT).fill("Auray")
+
+    const options = page.locator(CARTE_OPTION)
+    await expect(options.first()).toBeVisible({ timeout: TIMEOUT.DEFAULT })
+    await expect(options.first()).toHaveText(/Auray/)
+    await expect(options.first()).toHaveAttribute("data-lat", "47.668099")
+    await expect(options.first()).toHaveAttribute("data-lon", "-2.990838")
+  })
+
+  test("picking a suggestion populates lat/lng and submits the form", async ({
+    page,
+  }) => {
+    await navigateTo(page, "/carte")
+    await pickFirstAddress(page, "Auray")
+
+    // Selected label lands in the visible input.
+    await expect(page.locator(CARTE_INPUT)).toHaveValue("Auray")
+
+    // The carte controller wrote the coordinates onto the hidden fields.
+    const latitude = page.locator('[data-carte-address-autocomplete-target="latitude"]')
+    const longitude = page.locator(
+      '[data-carte-address-autocomplete-target="longitude"]',
+    )
+    await expect(latitude).toHaveValue("47.668099")
+    await expect(longitude).toHaveValue("-2.990838")
+
+    // state.ts mirrors the chosen location into sessionStorage.
+    const persisted = await page.evaluate(() => ({
+      adresse: sessionStorage.getItem("adresse"),
+      latitude: sessionStorage.getItem("latitude"),
+      longitude: sessionStorage.getItem("longitude"),
+    }))
+    expect(persisted).toEqual({
+      adresse: "Auray",
+      latitude: "47.668099",
+      longitude: "-2.990838",
+    })
+  })
+
+  test("the address field is serialized exactly once when the form submits", async ({
+    page,
+  }) => {
+    // Regression: when display_value=True, the widget used to emit both a
+    // visible search input and a hidden sibling with the same `name`. The
+    // browser submitted both, and the hidden's empty value won. The form
+    // received `adresse=""` and the page never recovered the picked label.
+    await navigateTo(page, "/carte")
+
+    const named = page.locator(`input[name="${ADRESSE_FIELD_NAME}"]`)
+    await expect(named).toHaveCount(1)
+    await expect(named).toHaveAttribute("type", "search")
+  })
+
+  test("submitting the form sends carte_map-adresse populated with the picked label", async ({
+    page,
+  }) => {
+    await navigateTo(page, "/carte")
+
+    // Capture the next form submission triggered by the address pick.
+    const submitRequest = page.waitForRequest(
+      (request) =>
+        request.method() === "GET" &&
+        request.url().includes("/carte?") &&
+        request.url().includes(`${ADRESSE_FIELD_NAME}=`),
+      { timeout: TIMEOUT.DEFAULT },
+    )
+
+    await pickFirstAddress(page, "Auray")
+
+    const request = await submitRequest
+    const url = new URL(request.url())
+    expect(url.searchParams.get(ADRESSE_FIELD_NAME)).toBe("Auray")
+    expect(url.searchParams.get("carte_map-latitude")).toBe("47.668099")
+    expect(url.searchParams.get("carte_map-longitude")).toBe("-2.990838")
+  })
+
+  test("reloading after picking an address does not re-submit in a loop", async ({
+    page,
+  }) => {
+    // Repro of the original loop: pick an address, reload, observe that the
+    // page settles and does NOT keep firing GET /carte requests.
+    await navigateTo(page, "/carte")
+    await pickFirstAddress(page, "Auray")
+
+    // Reload and count submits to /carte over a short observation window.
+    // Filter to actual form submissions (carry the adresse param) so the
+    // initial page-load request and unrelated traffic don't pollute the count.
+    const submitsAfterReload: string[] = []
+    page.on("request", (request) => {
+      const url = request.url()
+      if (
+        request.method() === "GET" &&
+        url.includes("/carte?") &&
+        url.includes(`${ADRESSE_FIELD_NAME}=`)
+      ) {
+        submitsAfterReload.push(url)
+      }
+    })
+
+    await page.reload()
+    // Give state.ts and the form's data-action plenty of time to misfire.
+    // The original bug submitted dozens of times within this window.
+    await page.waitForTimeout(3000)
+
+    expect(submitsAfterReload.length).toBeLessThanOrEqual(2)
+    // Every submit must carry the picked address — proves the field is no
+    // longer serializing as empty (which used to trigger the loop).
+    for (const url of submitsAfterReload) {
+      expect(url).toMatch(new RegExp(`${ADRESSE_FIELD_NAME}=Auray`))
+    }
+  })
+})

--- a/webapp/e2e_tests/carte_address_combobox.spec.ts
+++ b/webapp/e2e_tests/carte_address_combobox.spec.ts
@@ -216,3 +216,186 @@ test.describe("🗺️ Carte address combobox", () => {
     }
   })
 })
+
+/**
+ * APG combobox-autocomplete-list keyboard contract:
+ *   https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list/
+ *
+ * These tests pin the keyboard model against the spec — drift here breaks
+ * RGAA 7.1 / 7.3 conformance and confuses assistive-tech users.
+ *
+ * Conventions:
+ *   - DOM focus stays on the textbox at all times; the "focused" option is
+ *     conveyed only via aria-activedescendant + aria-selected.
+ *   - Down/Up on a closed listbox open it WITHOUT advancing into options.
+ *   - Arrow navigation does not wrap.
+ *   - Home/End act on the textbox (caret), not on the listbox.
+ */
+test.describe("⌨️ Carte combobox — APG keyboard contract", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockCarteAutocompleteAddress(page)
+  })
+
+  // Type "rue" to land on the multi-option fixture in mockCarteAutocompleteAddress.
+  async function openListboxWithMultipleOptions(page: Page) {
+    await navigateTo(page, "/carte")
+    const input = page.locator(CARTE_INPUT)
+    await input.click()
+    await input.fill("rue")
+    await page.waitForResponse(
+      (response) =>
+        response.url().includes("/qfdmo/autocomplete/address") &&
+        response.url().includes("q=rue") &&
+        response.status() === 200,
+      { timeout: TIMEOUT.DEFAULT },
+    )
+    // Wait for at least 2 options to materialize so navigation tests have
+    // somewhere to move.
+    await expect(page.locator(CARTE_OPTION)).toHaveCount(3, {
+      timeout: TIMEOUT.DEFAULT,
+    })
+    return input
+  }
+
+  test("ArrowDown on a closed listbox opens it without focusing an option", async ({
+    page,
+  }) => {
+    await navigateTo(page, "/carte")
+    const input = page.locator(CARTE_INPUT)
+    await input.click()
+    await input.fill("rue")
+    // First wait for results to be available, then close the listbox to
+    // get a clean "closed" starting state.
+    await page.waitForResponse(
+      (response) =>
+        response.url().includes("/qfdmo/autocomplete/address") &&
+        response.status() === 200,
+    )
+    await input.press("Escape")
+    await expect(input).toHaveAttribute("aria-expanded", "false")
+
+    // Re-open via ArrowDown — must not advance into the listbox.
+    await input.press("ArrowDown")
+    await expect(input).toHaveAttribute("aria-expanded", "true")
+    // No active option yet: aria-activedescendant absent or empty.
+    const ad = await input.getAttribute("aria-activedescendant")
+    expect(ad === null || ad === "").toBe(true)
+    // No option carries aria-selected.
+    await expect(page.locator(`${CARTE_OPTION}[aria-selected="true"]`)).toHaveCount(0)
+  })
+
+  test("second ArrowDown advances to the first option, third to the second", async ({
+    page,
+  }) => {
+    const input = await openListboxWithMultipleOptions(page)
+    // Listbox is already open (it opens on input). One Down to land on first.
+    await input.press("ArrowDown")
+    await expect(input).toHaveAttribute("aria-activedescendant", "option-1")
+    await expect(page.locator(`${CARTE_OPTION}#option-1`)).toHaveAttribute(
+      "aria-selected",
+      "true",
+    )
+
+    await input.press("ArrowDown")
+    await expect(input).toHaveAttribute("aria-activedescendant", "option-2")
+    await expect(page.locator(`${CARTE_OPTION}#option-1`)).not.toHaveAttribute(
+      "aria-selected",
+      /.*/,
+    )
+    await expect(page.locator(`${CARTE_OPTION}#option-2`)).toHaveAttribute(
+      "aria-selected",
+      "true",
+    )
+  })
+
+  test("ArrowDown does not wrap past the last option", async ({ page }) => {
+    const input = await openListboxWithMultipleOptions(page)
+    // Three options total — press Down four times. Stay on the last.
+    for (let i = 0; i < 4; i += 1) {
+      await input.press("ArrowDown")
+    }
+    await expect(input).toHaveAttribute("aria-activedescendant", "option-3")
+  })
+
+  test("ArrowUp does not wrap past the first option", async ({ page }) => {
+    const input = await openListboxWithMultipleOptions(page)
+    await input.press("ArrowDown")
+    await expect(input).toHaveAttribute("aria-activedescendant", "option-1")
+    // Up from the first option must stay on the first.
+    await input.press("ArrowUp")
+    await expect(input).toHaveAttribute("aria-activedescendant", "option-1")
+  })
+
+  test("DOM focus stays on the textbox while navigating the listbox", async ({
+    page,
+  }) => {
+    const input = await openListboxWithMultipleOptions(page)
+    await input.press("ArrowDown")
+    await input.press("ArrowDown")
+    // No matter how far we navigate, the active element on the page is the
+    // textbox itself. The option is only "visually focused" via ARIA.
+    const activeId = await page.evaluate(() => document.activeElement?.id)
+    expect(activeId).toBe("id_carte_map-adresse")
+  })
+
+  test("Alt + ArrowUp closes the listbox without committing a value", async ({
+    page,
+  }) => {
+    const input = await openListboxWithMultipleOptions(page)
+    await input.press("ArrowDown") // focus option-1
+    const beforeValue = await input.inputValue()
+
+    await input.press("Alt+ArrowUp")
+
+    await expect(input).toHaveAttribute("aria-expanded", "false")
+    // No commit happened: value unchanged.
+    await expect(input).toHaveValue(beforeValue)
+  })
+
+  test("Escape on an open listbox closes it without clearing the value", async ({
+    page,
+  }) => {
+    const input = await openListboxWithMultipleOptions(page)
+    await input.press("Escape")
+    await expect(input).toHaveAttribute("aria-expanded", "false")
+    // The textbox value is preserved.
+    await expect(input).toHaveValue("rue")
+  })
+
+  test("Escape on a closed listbox clears the textbox", async ({ page }) => {
+    const input = await openListboxWithMultipleOptions(page)
+    await input.press("Escape") // first Escape closes
+    await expect(input).toHaveAttribute("aria-expanded", "false")
+    await input.press("Escape") // second Escape clears
+    await expect(input).toHaveValue("")
+  })
+
+  test("Home moves the caret to the start of the textbox (not into the listbox)", async ({
+    page,
+  }) => {
+    const input = await openListboxWithMultipleOptions(page)
+    // Move caret to the end of "rue" first.
+    await input.press("End")
+
+    await input.press("Home")
+
+    // After Home, the caret is at position 0. No option should be aria-selected
+    // and aria-activedescendant should not point at an option (still empty/absent).
+    const caretAtStart = await input.evaluate(
+      (el: HTMLInputElement) => el.selectionStart,
+    )
+    expect(caretAtStart).toBe(0)
+    await expect(page.locator(`${CARTE_OPTION}[aria-selected="true"]`)).toHaveCount(0)
+  })
+
+  test("Enter commits the active option and closes the listbox", async ({ page }) => {
+    const input = await openListboxWithMultipleOptions(page)
+    await input.press("ArrowDown")
+    await input.press("ArrowDown") // option-2 — "Rue de Rivoli 75001 Paris"
+
+    await input.press("Enter")
+
+    await expect(input).toHaveAttribute("aria-expanded", "false")
+    await expect(input).toHaveValue("Rue de Rivoli 75001 Paris")
+  })
+})

--- a/webapp/e2e_tests/carte_address_combobox.spec.ts
+++ b/webapp/e2e_tests/carte_address_combobox.spec.ts
@@ -125,6 +125,61 @@ test.describe("🗺️ Carte address combobox", () => {
     expect(url.searchParams.get("carte_map-longitude")).toBe("-2.990838")
   })
 
+  test("picking a new address clears a stale bbox left by the map controller", async ({
+    page,
+  }) => {
+    // Regression: after the user pans the map, the search-solution-form's
+    // bounding_box hidden field carries the new map view. Picking a fresh
+    // address must clear that bbox before submitting — otherwise the server
+    // gives precedence to bbox over lat/lon and returns acteurs scoped to
+    // the previous map view (the original "Auray markers stay after picking
+    // Montbéliard" bug). state#setLocation owns the reset; the form's own
+    // listener was removed to avoid a race that submitted before bbox was
+    // cleared.
+    await navigateTo(page, "/carte")
+    await pickFirstAddress(page, "Auray")
+
+    // Simulate the map controller having written a bbox after a pan.
+    await page.evaluate(() => {
+      const bbox = document.querySelector<HTMLInputElement>(
+        '[data-search-solution-form-target="bbox"]',
+      )
+      if (!bbox) throw new Error("no bbox target")
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )?.set
+      setter?.call(
+        bbox,
+        JSON.stringify({
+          southWest: { lat: 47.4, lng: 6.6 },
+          northEast: { lat: 47.6, lng: 7.0 },
+        }),
+      )
+      bbox.dispatchEvent(new Event("input", { bubbles: true }))
+    })
+
+    // Capture the GET that fires when the user picks a new address.
+    const submitRequest = page.waitForRequest(
+      (request) =>
+        request.method() === "GET" &&
+        request.url().includes("/carte?") &&
+        request.url().includes(`${ADRESSE_FIELD_NAME}=Auray`),
+      { timeout: TIMEOUT.DEFAULT },
+    )
+
+    // Re-pick (same address — also exercises the case where the visible
+    // input value already matches the new pick).
+    const input = page.locator(CARTE_INPUT)
+    await input.click()
+    await input.fill("Auray")
+    await page.locator(CARTE_OPTION).filter({ hasText: "Auray" }).first().click()
+
+    const url = new URL((await submitRequest).url())
+    expect(url.searchParams.get("carte_map-bounding_box")).toBe("")
+    expect(url.searchParams.get(ADRESSE_FIELD_NAME)).toBe("Auray")
+  })
+
   test("reloading after picking an address does not re-submit in a loop", async ({
     page,
   }) => {

--- a/webapp/e2e_tests/carte_address_combobox.spec.ts
+++ b/webapp/e2e_tests/carte_address_combobox.spec.ts
@@ -398,4 +398,54 @@ test.describe("⌨️ Carte combobox — APG keyboard contract", () => {
     await expect(input).toHaveAttribute("aria-expanded", "false")
     await expect(input).toHaveValue("Rue de Rivoli 75001 Paris")
   })
+
+  test('focusing the empty address input shows "Autour de moi"', async ({ page }) => {
+    // Regression for kolok's 2026-05-18 review observation: focusing the
+    // address input on first visit must surface the synthetic "Autour de moi"
+    // geolocation option, not wait for the user to type something first.
+    await navigateTo(page, "/carte")
+    const input = page.locator(CARTE_INPUT)
+    await input.click()
+
+    await page.waitForResponse(
+      (response) =>
+        response.url().includes("/qfdmo/autocomplete/address") &&
+        response.status() === 200,
+      { timeout: TIMEOUT.DEFAULT },
+    )
+
+    await expect(input).toHaveAttribute("aria-expanded", "true")
+    await expect(page.locator(`${CARTE_OPTION}[data-geolocate="true"]`)).toBeVisible({
+      timeout: TIMEOUT.DEFAULT,
+    })
+  })
+
+  test("refocusing a committed value does not reopen the listbox", async ({ page }) => {
+    // Regression for kolok's 2026-05-18 review: after picking an address,
+    // clicking back into the input must not fire a new autocomplete request
+    // and must not re-open the listbox. The "already committed" guard in
+    // next_autocomplete_controller#focus must hold across the form submit /
+    // Turbo Frame reload that follows a pick.
+    await navigateTo(page, "/carte")
+    await pickFirstAddress(page, "Auray")
+    await expect(page.locator(CARTE_INPUT)).toHaveValue("Auray")
+
+    // Click outside to ensure the input is blurred, then count any
+    // autocomplete requests fired after we click back in.
+    const autocompleteRequests: string[] = []
+    page.on("request", (request) => {
+      if (request.url().includes("/qfdmo/autocomplete/address")) {
+        autocompleteRequests.push(request.url())
+      }
+    })
+
+    await page.locator("body").click({ position: { x: 5, y: 5 } })
+    await page.locator(CARTE_INPUT).click()
+
+    // Give focus and any potential request time to fire.
+    await page.waitForTimeout(500)
+
+    expect(autocompleteRequests).toHaveLength(0)
+    await expect(page.locator(CARTE_INPUT)).toHaveAttribute("aria-expanded", "false")
+  })
 })

--- a/webapp/e2e_tests/helpers.ts
+++ b/webapp/e2e_tests/helpers.ts
@@ -517,18 +517,46 @@ interface CarteAutocompleteOption {
 }
 
 function renderCarteAutocompleteFrame(turboFrameId: string, query: string): string {
-  const options: CarteAutocompleteOption[] =
-    query.length < 3
-      ? [{ label: "Autour de moi", geolocate: true }]
-      : [
-          {
-            label: "Auray",
-            sub_label: "56, Morbihan, Bretagne",
-            latitude: 47.668099,
-            longitude: -2.990838,
-            geolocate: false,
-          },
-        ]
+  let options: CarteAutocompleteOption[]
+  if (query.length < 3) {
+    options = [{ label: "Autour de moi", geolocate: true }]
+  } else if (query.startsWith("rue")) {
+    // Multi-option fixture for keyboard-navigation tests: three distinct
+    // suggestions so Down/Up arrows have somewhere to move.
+    options = [
+      {
+        label: "Rue de Paris 56400 Auray",
+        sub_label: "56, Morbihan",
+        latitude: 47.668099,
+        longitude: -2.990838,
+        geolocate: false,
+      },
+      {
+        label: "Rue de Rivoli 75001 Paris",
+        sub_label: "75, Paris",
+        latitude: 48.85661,
+        longitude: 2.3522,
+        geolocate: false,
+      },
+      {
+        label: "Rue de la République 69001 Lyon",
+        sub_label: "69, Rhône",
+        latitude: 45.764,
+        longitude: 4.8357,
+        geolocate: false,
+      },
+    ]
+  } else {
+    options = [
+      {
+        label: "Auray",
+        sub_label: "56, Morbihan, Bretagne",
+        latitude: 47.668099,
+        longitude: -2.990838,
+        geolocate: false,
+      },
+    ]
+  }
 
   const items = options
     .map((option, index) => {
@@ -543,9 +571,8 @@ function renderCarteAutocompleteFrame(turboFrameId: string, query: string): stri
         <li
           id="option-${counter}"
           role="option"
-          tabindex="-1"
           data-next-autocomplete-target="option"
-          data-action="keydown->next-autocomplete#navigate:prevent click->next-autocomplete#commitSelection"
+          data-action="click->next-autocomplete#commitSelection"
           data-value="${option.label}"
           data-selected-value="${option.label}"
           ${geoAttrs}

--- a/webapp/e2e_tests/helpers.ts
+++ b/webapp/e2e_tests/helpers.ts
@@ -465,6 +465,81 @@ export const mockApiAdresse = async (page: Page) =>
   )
 
 /**
+ * Mock the server-side BAN proxy endpoint (`/qfdmo/autocomplete/address`)
+ * that powers the carte combobox. The endpoint returns a Turbo Frame fragment
+ * (not JSON) — see `webapp/qfdmo/views/autocomplete.py`.
+ *
+ * We mock at this boundary rather than the upstream `data.geopf.fr` URL
+ * because the carte's Python view proxies BAN server-side; the browser only
+ * ever talks to `/qfdmo/autocomplete/address`.
+ */
+export const mockCarteAutocompleteAddress = async (page: Page) =>
+  await page.route(/\/qfdmo\/autocomplete\/address\?/, async (route) => {
+    const url = new URL(route.request().url())
+    const turboFrameId = url.searchParams.get("turbo_frame_id") ?? ""
+    const query = (url.searchParams.get("q") ?? "").toLowerCase()
+    const body = renderCarteAutocompleteFrame(turboFrameId, query)
+    await route.fulfill({
+      status: 200,
+      contentType: "text/html; charset=utf-8",
+      body,
+    })
+  })
+
+interface CarteAutocompleteOption {
+  label: string
+  sub_label?: string
+  latitude?: number
+  longitude?: number
+  geolocate: boolean
+}
+
+function renderCarteAutocompleteFrame(turboFrameId: string, query: string): string {
+  const options: CarteAutocompleteOption[] =
+    query.length < 3
+      ? [{ label: "Autour de moi", geolocate: true }]
+      : [
+          {
+            label: "Auray",
+            sub_label: "56, Morbihan, Bretagne",
+            latitude: 47.668099,
+            longitude: -2.990838,
+            geolocate: false,
+          },
+        ]
+
+  const items = options
+    .map((option, index) => {
+      const counter = index + 1
+      const geoAttrs = option.geolocate
+        ? `data-geolocate="true"`
+        : `data-lat="${option.latitude}" data-lon="${option.longitude}"`
+      const subLabel = option.sub_label
+        ? `<small class="fr-text--sm fr-m-0 qf-italic">${option.sub_label}</small>`
+        : ""
+      return `
+        <li
+          id="option-${counter}"
+          role="option"
+          tabindex="-1"
+          data-next-autocomplete-target="option"
+          data-action="keydown->next-autocomplete#navigate:prevent click->next-autocomplete#commitSelection"
+          data-value="${option.label}"
+          data-selected-value="${option.label}"
+          ${geoAttrs}
+        >
+          <span>${option.label}</span>
+          ${subLabel}
+        </li>`
+    })
+    .join("")
+
+  return `<turbo-frame data-next-autocomplete-target="results" id="${turboFrameId}">
+    <ul id="${turboFrameId}-listbox" role="listbox">${items}</ul>
+  </turbo-frame>`
+}
+
+/**
  * Modal/Dialog helpers
  */
 /**

--- a/webapp/e2e_tests/helpers.ts
+++ b/webapp/e2e_tests/helpers.ts
@@ -11,6 +11,14 @@ export const SEARCH_RESULTS_SELECTOR = "[data-next-autocomplete-target='option']
 export const SEARCH_RESULTS_DROPDOWN_SELECTOR =
   "[data-next-autocomplete-target='results']"
 
+// The carte address combobox uses the next-autocomplete pattern: each
+// suggestion is a <li role="option"> inside the Turbo Frame listbox.
+// The formulaire keeps the legacy AutoCompleteInput (client-side BAN) so
+// its options are still `.autocomplete-items div[data-action=...]`.
+const CARTE_OPTION_SELECTOR = '[role="option"][data-next-autocomplete-target="option"]'
+const LEGACY_OPTION_SELECTOR =
+  ".autocomplete-items div[data-action*='address-autocomplete#selectOption']"
+
 /**
  * Navigation helper
  */
@@ -35,7 +43,7 @@ export async function searchAndSelectAutocomplete(
   } = {},
 ) {
   const {
-    autocompleteSelector = ".autocomplete-items div[data-action*='address-autocomplete#selectOption']",
+    autocompleteSelector = CARTE_OPTION_SELECTOR,
     optionIndex = "first",
     timeout = TIMEOUT.DEFAULT,
     parentSelector,
@@ -98,6 +106,10 @@ export async function searchAddress(
       : '[data-testid="formulaire-adresse-input"]'
 
   await searchAndSelectAutocomplete(context, inputSelector, searchText, {
+    // The formulaire still uses the legacy client-side autocomplete; the
+    // carte combobox is the new next-autocomplete pattern (default).
+    autocompleteSelector:
+      formContext === "formulaire" ? LEGACY_OPTION_SELECTOR : CARTE_OPTION_SELECTOR,
     optionIndex: options.optionIndex ?? "first",
     parentSelector: options.parentSelector,
     parentLocator: options.parentLocator,
@@ -136,8 +148,7 @@ export async function searchCarteAndWaitForActeurs(
   } = {},
 ): Promise<void> {
   const inputSelector = '[data-testid="carte-adresse-input"]'
-  const autocompleteSelector =
-    ".autocomplete-items div[data-action*='address-autocomplete#selectOption']"
+  const autocompleteSelector = CARTE_OPTION_SELECTOR
 
   // Build the input locator, respecting optional parent scoping
   const inputLocator = options.parentLocator
@@ -233,8 +244,18 @@ export async function searchDummySousCategorieObjet(page: Page) {
 
 /**
  * API mocking helpers
+ *
+ * Two distinct flows ship suggestions to the address combobox:
+ *   - Legacy formulaire: browser → data.geopf.fr (mocked here directly)
+ *   - Carte combobox: browser → /qfdmo/autocomplete/address → BAN (server-side)
+ *
+ * `mockApiAdresse` sets up BOTH so existing carte tests that only call this
+ * helper keep working without depending on a live BAN endpoint.
  */
-export const mockApiAdresse = async (page: Page) =>
+export const mockApiAdresse = async (page: Page) => {
+  // The new carte combobox uses the server-proxied Turbo Frame endpoint.
+  await mockCarteAutocompleteAddress(page)
+  // The legacy flow (still used by the formulaire) hits data.geopf.fr directly.
   // Use glob pattern to match both with and without trailing slash, and case-insensitive query
   await page.route(
     /data\.geopf\.fr\/geocodage\/search\/?\?q=[aA]uray/i,
@@ -463,6 +484,7 @@ export const mockApiAdresse = async (page: Page) =>
       })
     },
   )
+}
 
 /**
  * Mock the server-side BAN proxy endpoint (`/qfdmo/autocomplete/address`)

--- a/webapp/qfdmo/forms.py
+++ b/webapp/qfdmo/forms.py
@@ -28,6 +28,7 @@ from qfdmo.models.action import (
 from qfdmo.models.config import CarteConfig
 from qfdmo.widgets import (
     AutoCompleteInput,
+    CarteAddressAutocompleteInput,
     DSFRCheckboxSelectMultiple,
     GenericAutoCompleteInput,
     RangeInput,
@@ -101,15 +102,17 @@ class MapForm(GetFormMixin, CarteConfigFormMixin, forms.Form):
             self.fields["bounding_box"].initial = json.dumps(bounding_box_json)
 
     adresse = forms.CharField(
-        widget=AutoCompleteInput(
+        widget=CarteAddressAutocompleteInput(
             attrs={
                 "class": "fr-input",
                 "placeholder": "Rechercher autour d'une adresse",
                 "autocomplete": "off",
                 "aria-label": "Saisir une adresse - obligatoire",
                 "data-testid": "carte-adresse-input",
+                # Outer `carte-address-autocomplete` controller reads/writes
+                # the visible input on commit + on error reset.
+                "data-carte-address-autocomplete-target": "input",
             },
-            data_controller="address-autocomplete",
         ),
         label="",
         required=False,
@@ -126,7 +129,7 @@ class MapForm(GetFormMixin, CarteConfigFormMixin, forms.Form):
     latitude = forms.FloatField(
         widget=forms.HiddenInput(
             attrs={
-                "data-address-autocomplete-target": "latitude",
+                "data-carte-address-autocomplete-target": "latitude",
                 "data-search-solution-form-target": "latitudeInput",
             }
         ),
@@ -136,7 +139,7 @@ class MapForm(GetFormMixin, CarteConfigFormMixin, forms.Form):
     longitude = forms.FloatField(
         widget=forms.HiddenInput(
             attrs={
-                "data-address-autocomplete-target": "longitude",
+                "data-carte-address-autocomplete-target": "longitude",
                 "data-search-solution-form-target": "longitudeInput",
             }
         ),

--- a/webapp/qfdmo/urls.py
+++ b/webapp/qfdmo/urls.py
@@ -14,6 +14,7 @@ from qfdmo.views.adresses import (
     getorcreate_revisionacteur,
     solution_admin,
 )
+from qfdmo.views.autocomplete import AutocompleteBanAddressView
 from qfdmo.views.carte import CarteConfigView, CarteSearchActeursView
 from qfdmo.views.configurator import AdvancedConfiguratorView, ConfiguratorView
 from qfdmo.views.formulaire import FormulaireSearchActeursView
@@ -65,6 +66,11 @@ urlpatterns = [
         "qfdmo/get_synonyme_list",
         get_synonyme_list,
         name="get_synonyme_list",
+    ),
+    path(
+        "qfdmo/autocomplete/address",
+        AutocompleteBanAddressView.as_view(),
+        name="autocomplete_address",
     ),
     path(
         "adresse/<str:identifiant_unique>",

--- a/webapp/qfdmo/urls.py
+++ b/webapp/qfdmo/urls.py
@@ -14,7 +14,10 @@ from qfdmo.views.adresses import (
     getorcreate_revisionacteur,
     solution_admin,
 )
-from qfdmo.views.autocomplete import AutocompleteBanAddressView
+from qfdmo.views.autocomplete import (
+    AutocompleteBanAddressView,
+    ReverseGeocodeBanView,
+)
 from qfdmo.views.carte import CarteConfigView, CarteSearchActeursView
 from qfdmo.views.configurator import AdvancedConfiguratorView, ConfiguratorView
 from qfdmo.views.formulaire import FormulaireSearchActeursView
@@ -71,6 +74,11 @@ urlpatterns = [
         "qfdmo/autocomplete/address",
         AutocompleteBanAddressView.as_view(),
         name="autocomplete_address",
+    ),
+    path(
+        "qfdmo/autocomplete/reverse",
+        ReverseGeocodeBanView.as_view(),
+        name="reverse_geocode_address",
     ),
     path(
         "adresse/<str:identifiant_unique>",

--- a/webapp/qfdmo/views/autocomplete.py
+++ b/webapp/qfdmo/views/autocomplete.py
@@ -2,13 +2,16 @@ import logging
 from typing import override
 
 import requests
+from django.http import HttpResponseBadRequest, JsonResponse
 from django.utils.decorators import method_decorator
+from django.views import View
 from django.views.decorators.cache import cache_control
 from django.views.generic import ListView
 
 logger = logging.getLogger(__name__)
 
 BAN_API_URL = "https://data.geopf.fr/geocodage/search/"
+BAN_REVERSE_API_URL = "https://data.geopf.fr/geocodage/reverse/"
 BAN_TIMEOUT_SECONDS = 3
 
 # Synthetic option always returned at the top of the listbox to let users
@@ -92,3 +95,66 @@ class AutocompleteBanAddressView(ListView):
         context["turbo_frame_id"] = self.request.GET.get("turbo_frame_id")
         context["results"] = self.object_list
         return context
+
+
+@method_decorator(
+    cache_control(public=True, max_age=60 * 60, stale_while_revalidate=60 * 5),
+    name="dispatch",
+)
+class ReverseGeocodeBanView(View):
+    """JSON proxy in front of BAN (data.geopf.fr) reverse-geocode.
+
+    Mirrors `AutocompleteBanAddressView` so the browser never talks to BAN
+    directly: avoids CORS / availability coupling and keeps a single
+    server-side timeout + cache policy. Used by the carte address combobox
+    when the user picks the synthetic "Autour de moi" geolocation option.
+
+    Returns the matched BAN feature as JSON:
+
+        {"adresse": "...", "latitude": <float>, "longitude": <float>}
+
+    On no match or upstream failure returns 404 / 502 with an empty body so
+    the client can surface a single user-facing error message.
+    """
+
+    def get(self, request, *args, **kwargs):
+        try:
+            lat = float(request.GET["lat"])
+            lon = float(request.GET["lon"])
+        except (KeyError, TypeError, ValueError):
+            return HttpResponseBadRequest()
+
+        # Guard against absurd values; BAN rejects them anyway but failing
+        # fast avoids logging junk through the proxy.
+        if not (-90 <= lat <= 90) or not (-180 <= lon <= 180):
+            return HttpResponseBadRequest()
+
+        try:
+            response = requests.get(
+                BAN_REVERSE_API_URL,
+                params={"lat": lat, "lon": lon},
+                timeout=BAN_TIMEOUT_SECONDS,
+            )
+            response.raise_for_status()
+            payload = response.json() or {}
+            features = payload.get("features", []) or []
+        except (requests.RequestException, ValueError) as exc:
+            logger.warning(
+                "BAN reverse-geocode proxy failed for (%s, %s): %s", lat, lon, exc
+            )
+            return JsonResponse({}, status=502)
+
+        if not features:
+            return JsonResponse({}, status=404)
+
+        try:
+            feature = features[0]
+            return JsonResponse(
+                {
+                    "adresse": feature["properties"]["label"],
+                    "latitude": feature["geometry"]["coordinates"][1],
+                    "longitude": feature["geometry"]["coordinates"][0],
+                }
+            )
+        except (KeyError, IndexError, TypeError):
+            return JsonResponse({}, status=502)

--- a/webapp/qfdmo/views/autocomplete.py
+++ b/webapp/qfdmo/views/autocomplete.py
@@ -1,0 +1,94 @@
+import logging
+from typing import override
+
+import requests
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_control
+from django.views.generic import ListView
+
+logger = logging.getLogger(__name__)
+
+BAN_API_URL = "https://data.geopf.fr/geocodage/search/"
+BAN_TIMEOUT_SECONDS = 3
+
+# Synthetic option always returned at the top of the listbox to let users
+# trigger `navigator.geolocation` from the same combobox.
+GEOLOCATE_OPTION = {
+    "label": "Autour de moi",
+    "sub_label": None,
+    "latitude": None,
+    "longitude": None,
+    "geolocate": True,
+}
+
+
+@method_decorator(
+    cache_control(public=True, max_age=60 * 60, stale_while_revalidate=60 * 5),
+    name="dispatch",
+)
+class AutocompleteBanAddressView(ListView):
+    """Server-rendered Turbo Frame listbox for the carte address combobox.
+
+    Proxies the BAN (data.geopf.fr) geocoding search API and returns a list of
+    `<li role="option">` entries. The first option is always the synthetic
+    « Autour de moi » entry; the others come from BAN.
+
+    Responses are public-cacheable for an hour so the proxy in front can serve
+    repeated queries without round-tripping to BAN. Address reference data is
+    shared across users and changes slowly.
+    """
+
+    template_name = "ui/forms/widgets/autocomplete/address_results.html"
+    DEFAULT_LIMIT = 5
+    MAX_LIMIT = 20
+    MIN_QUERY_LENGTH = 3
+    MAX_QUERY_LENGTH = 200
+
+    @override
+    def get_queryset(self):
+        query = (self.request.GET.get("q") or "").strip()[: self.MAX_QUERY_LENGTH]
+        try:
+            limit = int(self.request.GET.get("limit") or self.DEFAULT_LIMIT)
+        except ValueError:
+            limit = self.DEFAULT_LIMIT
+        limit = max(1, min(limit, self.MAX_LIMIT))
+
+        if len(query) < self.MIN_QUERY_LENGTH:
+            return [GEOLOCATE_OPTION]
+
+        try:
+            response = requests.get(
+                BAN_API_URL,
+                params={"q": query},
+                timeout=BAN_TIMEOUT_SECONDS,
+            )
+            response.raise_for_status()
+            payload = response.json() or {}
+            features = payload.get("features", []) or []
+        except (requests.RequestException, ValueError) as exc:
+            logger.warning("BAN proxy failed for query %r: %s", query, exc)
+            return []
+
+        options = []
+        for feature in features[:limit]:
+            try:
+                options.append(
+                    {
+                        "label": feature["properties"]["label"],
+                        "sub_label": feature["properties"].get("context"),
+                        "latitude": feature["geometry"]["coordinates"][1],
+                        "longitude": feature["geometry"]["coordinates"][0],
+                        "geolocate": False,
+                    }
+                )
+            except (KeyError, IndexError, TypeError):
+                continue
+
+        return options
+
+    @override
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["turbo_frame_id"] = self.request.GET.get("turbo_frame_id")
+        context["results"] = self.object_list
+        return context

--- a/webapp/qfdmo/widgets.py
+++ b/webapp/qfdmo/widgets.py
@@ -13,6 +13,23 @@ class SynonymeAutocompleteInput(NextAutocompleteInput):
     limit = 5
 
 
+class CarteAddressAutocompleteInput(NextAutocompleteInput):
+    """combobox-autocomplete-list for the carte address search field.
+
+    Proxies the BAN geocoding API server-side (see AutocompleteBanAddressView)
+    and renders results as a server-rendered Turbo Frame listbox.
+
+    Implements the W3C APG combobox-autocomplete-list pattern (RGAA 7.1, 7.3,
+    11.10): the visible input carries role=combobox + aria-controls, the
+    Turbo Frame's <ul> carries role=listbox, each result has role=option.
+    """
+
+    search_view = "qfdmo:autocomplete_address"
+    limit = 5
+    show_on_focus = True
+    display_value = True
+
+
 class RangeInput(widgets.NumberInput):
     template_name = "ui/forms/widgets/range_input.html"
     input_type = "range"

--- a/webapp/static/to_compile/controllers/assistant/state.ts
+++ b/webapp/static/to_compile/controllers/assistant/state.ts
@@ -68,9 +68,17 @@ export default class extends Controller<HTMLElement> {
   }
 
   setLocation(event) {
+    // The user explicitly picked a new address. Drop any stale bbox that the
+    // map controller left behind from a previous pan — otherwise the form
+    // submit below would still scope acteurs to the old map view.
     this.resetBboxInputs()
     const nextLocationValue = event.detail
     this.#setLocationValue(nextLocationValue)
+    // The carte controller already wrote the new lat/lon onto its targets
+    // before dispatching `change`, so #setLocationValue → updateUIFromGlobalState
+    // sees the DOM in sync and won't submit on its own. Submit explicitly here
+    // so the form re-fetches acteurs around the new address.
+    this.submit()
   }
 
   #setLocationValue(nextLocationValue) {

--- a/webapp/static/to_compile/controllers/assistant/state.ts
+++ b/webapp/static/to_compile/controllers/assistant/state.ts
@@ -1,14 +1,25 @@
 import { Controller } from "@hotwired/stimulus"
 import isEmpty from "lodash/isEmpty"
 import AdresseAutocompleteController from "../carte/address_autocomplete_controller"
+import CarteAddressAutocompleteController from "../carte/carte_address_autocomplete_controller"
 import SearchFormController from "../carte/search_solution_form_controller"
+
+// Both address autocomplete controllers expose the same target contract for
+// the state controller's purposes: an `input` for the visible address,
+// `latitude` and `longitude` for the hidden coordinate fields.
+type AddressOutlet = AdresseAutocompleteController | CarteAddressAutocompleteController
 
 export default class extends Controller<HTMLElement> {
   static values = {
     location: Object,
   }
-  static outlets = ["address-autocomplete", "search-solution-form"]
+  static outlets = [
+    "address-autocomplete",
+    "carte-address-autocomplete",
+    "search-solution-form",
+  ]
   declare addressAutocompleteOutlets: Array<AdresseAutocompleteController>
+  declare carteAddressAutocompleteOutlets: Array<CarteAddressAutocompleteController>
   declare searchSolutionFormOutlets: Array<SearchFormController>
   declare locationValue: {
     adresse: string | null
@@ -23,6 +34,13 @@ export default class extends Controller<HTMLElement> {
   }
 
   addressAutocompleteOutletConnected(outlet, element) {
+    if (outlet.inputTarget.value) {
+      return
+    }
+    this.updateUIFromGlobalState(outlet)
+  }
+
+  carteAddressAutocompleteOutletConnected(outlet) {
     if (outlet.inputTarget.value) {
       return
     }
@@ -60,7 +78,11 @@ export default class extends Controller<HTMLElement> {
     if (updatedLocationIsNotEmpty) {
       this.locationValue = nextLocationValue
 
-      for (const outlet of this.addressAutocompleteOutlets) {
+      const allOutlets: Array<AddressOutlet> = [
+        ...this.addressAutocompleteOutlets,
+        ...this.carteAddressAutocompleteOutlets,
+      ]
+      for (const outlet of allOutlets) {
         this.updateUIFromGlobalState(outlet)
       }
     }

--- a/webapp/static/to_compile/controllers/assistant/state.ts
+++ b/webapp/static/to_compile/controllers/assistant/state.ts
@@ -100,7 +100,7 @@ export default class extends Controller<HTMLElement> {
     // stored globally in the page
     const value = this.locationValue
     let touched = false
-    if (value.adresse) {
+    if (value.adresse && outlet.inputTarget.value !== value.adresse) {
       outlet.inputTarget.value = value.adresse
       touched = true
     }

--- a/webapp/static/to_compile/controllers/carte/carte_address_autocomplete_controller.ts
+++ b/webapp/static/to_compile/controllers/carte/carte_address_autocomplete_controller.ts
@@ -1,0 +1,129 @@
+import { Controller } from "@hotwired/stimulus"
+
+const REVERSE_GEOCODE_URL =
+  "https://data.geopf.fr/geocodage/reverse/?lon={lon}&lat={lat}"
+
+interface LocationDetail {
+  adresse: string
+  latitude: string
+  longitude: string
+}
+
+interface NextAutocompleteCommitDetail {
+  option: HTMLElement
+  value: string
+  selectedValue: string
+}
+
+/**
+ * Carte-specific listener that turns a `next-autocomplete:commit` event into
+ * lat/lon population on the surrounding form and dispatches the
+ * `carte-address-autocomplete:change` event that the global state controller
+ * listens to.
+ *
+ * Also handles the synthetic « Autour de moi » option by triggering
+ * `navigator.geolocation` + a reverse-geocode on data.geopf.fr.
+ *
+ * The combobox plumbing (search, listbox, keyboard nav, commit) belongs to the
+ * inner `next-autocomplete` controller mounted by the widget itself. This
+ * controller is mounted on the outer wrapper so it can reach the lat/lon
+ * sibling inputs as Stimulus targets.
+ */
+export default class CarteAddressAutocompleteController extends Controller<HTMLElement> {
+  static targets = ["input", "latitude", "longitude", "displayError"]
+
+  declare readonly inputTarget: HTMLInputElement
+  declare readonly latitudeTarget: HTMLInputElement
+  declare readonly longitudeTarget: HTMLInputElement
+  declare readonly displayErrorTarget: HTMLElement
+  declare readonly hasDisplayErrorTarget: boolean
+
+  commit(event: CustomEvent<NextAutocompleteCommitDetail>) {
+    const option = event.detail.option
+    if (!option) return
+
+    if (option.dataset.geolocate === "true") {
+      this.#triggerGeolocation()
+      return
+    }
+
+    this.#setLocation({
+      adresse: option.dataset.selectedValue?.trim() ?? "",
+      latitude: option.dataset.lat ?? "",
+      longitude: option.dataset.lon ?? "",
+    })
+  }
+
+  #triggerGeolocation() {
+    if (!("geolocation" in navigator)) {
+      this.#displayInputError("La géolocalisation est inaccessible sur votre appareil")
+      return
+    }
+    navigator.geolocation.getCurrentPosition(
+      (position) => this.#reverseGeocode(position),
+      () =>
+        this.#displayInputError(
+          "La géolocalisation est inaccessible sur votre appareil",
+        ),
+    )
+  }
+
+  async #reverseGeocode(position: GeolocationPosition) {
+    const url = REVERSE_GEOCODE_URL.replace(
+      "{lon}",
+      position.coords.longitude.toString(),
+    ).replace("{lat}", position.coords.latitude.toString())
+    try {
+      const response = await fetch(url)
+      const data = await response.json()
+      if (!data.features?.length) {
+        this.#displayInputError(
+          "Votre adresse n'a pas pu être déterminée. Vous pouvez ré-essayer ou saisir votre adresse manuellement",
+        )
+        return
+      }
+      const feature = data.features[0]
+      this.#setLocation({
+        adresse: feature.properties.label,
+        latitude: feature.geometry.coordinates[1].toString(),
+        longitude: feature.geometry.coordinates[0].toString(),
+      })
+    } catch (error) {
+      console.error("reverse geocoding failed:", error)
+      this.#displayInputError(
+        "Votre adresse n'a pas pu être déterminée. Vous pouvez ré-essayer ou saisir votre adresse manuellement",
+      )
+    }
+  }
+
+  #setLocation(detail: LocationDetail) {
+    this.inputTarget.value = detail.adresse
+    this.latitudeTarget.value = detail.latitude
+    this.longitudeTarget.value = detail.longitude
+    this.#hideInputError()
+    // `carte-address-autocomplete:change` is consumed by:
+    // - body `data-action` -> `state#setLocation` (global location sync)
+    // - the carte form `data-action` -> `search-solution-form#submitForm`
+    this.dispatch("change", { detail })
+  }
+
+  #displayInputError(message: string) {
+    this.inputTarget.classList.add("fr-input--error")
+    this.inputTarget.parentElement?.classList.add("fr-input-group--error")
+    if (this.hasDisplayErrorTarget) {
+      this.displayErrorTarget.textContent = message
+      this.displayErrorTarget.style.display = "block"
+    }
+    this.inputTarget.value = ""
+    this.latitudeTarget.value = ""
+    this.longitudeTarget.value = ""
+  }
+
+  #hideInputError() {
+    this.inputTarget.classList.remove("fr-input--error")
+    this.inputTarget.parentElement?.classList.remove("fr-input-group--error")
+    if (this.hasDisplayErrorTarget) {
+      this.displayErrorTarget.style.display = "none"
+    }
+  }
+}

--- a/webapp/static/to_compile/controllers/carte/carte_address_autocomplete_controller.ts
+++ b/webapp/static/to_compile/controllers/carte/carte_address_autocomplete_controller.ts
@@ -1,8 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
 
-const REVERSE_GEOCODE_URL =
-  "https://data.geopf.fr/geocodage/reverse/?lon={lon}&lat={lat}"
-
 interface LocationDetail {
   adresse: string
   latitude: string
@@ -22,7 +19,10 @@ interface NextAutocompleteCommitDetail {
  * listens to.
  *
  * Also handles the synthetic « Autour de moi » option by triggering
- * `navigator.geolocation` + a reverse-geocode on data.geopf.fr.
+ * `navigator.geolocation` and calling the server-side BAN reverse-geocode
+ * proxy (see qfdmo.views.autocomplete.ReverseGeocodeBanView). The browser
+ * never talks to data.geopf.fr directly — the proxy keeps a single
+ * server-side timeout and cache policy and avoids CORS coupling.
  *
  * The combobox plumbing (search, listbox, keyboard nav, commit) belongs to the
  * inner `next-autocomplete` controller mounted by the widget itself. This
@@ -31,12 +31,16 @@ interface NextAutocompleteCommitDetail {
  */
 export default class CarteAddressAutocompleteController extends Controller<HTMLElement> {
   static targets = ["input", "latitude", "longitude", "displayError"]
+  static values = {
+    reverseGeocodeUrl: String,
+  }
 
   declare readonly inputTarget: HTMLInputElement
   declare readonly latitudeTarget: HTMLInputElement
   declare readonly longitudeTarget: HTMLInputElement
   declare readonly displayErrorTarget: HTMLElement
   declare readonly hasDisplayErrorTarget: boolean
+  declare readonly reverseGeocodeUrlValue: string
 
   commit(event: CustomEvent<NextAutocompleteCommitDetail>) {
     const option = event.detail.option
@@ -69,24 +73,28 @@ export default class CarteAddressAutocompleteController extends Controller<HTMLE
   }
 
   async #reverseGeocode(position: GeolocationPosition) {
-    const url = REVERSE_GEOCODE_URL.replace(
-      "{lon}",
-      position.coords.longitude.toString(),
-    ).replace("{lat}", position.coords.latitude.toString())
+    const url = new URL(this.reverseGeocodeUrlValue, window.location.origin)
+    url.searchParams.set("lat", position.coords.latitude.toString())
+    url.searchParams.set("lon", position.coords.longitude.toString())
     try {
-      const response = await fetch(url)
-      const data = await response.json()
-      if (!data.features?.length) {
+      const response = await fetch(url.toString())
+      if (!response.ok) {
         this.#displayInputError(
           "Votre adresse n'a pas pu être déterminée. Vous pouvez ré-essayer ou saisir votre adresse manuellement",
         )
         return
       }
-      const feature = data.features[0]
+      const data = await response.json()
+      if (!data.adresse) {
+        this.#displayInputError(
+          "Votre adresse n'a pas pu être déterminée. Vous pouvez ré-essayer ou saisir votre adresse manuellement",
+        )
+        return
+      }
       this.#setLocation({
-        adresse: feature.properties.label,
-        latitude: feature.geometry.coordinates[1].toString(),
-        longitude: feature.geometry.coordinates[0].toString(),
+        adresse: data.adresse,
+        latitude: data.latitude.toString(),
+        longitude: data.longitude.toString(),
       })
     } catch (error) {
       console.error("reverse geocoding failed:", error)

--- a/webapp/static/to_compile/controllers/shared/next_autocomplete_controller.ts
+++ b/webapp/static/to_compile/controllers/shared/next_autocomplete_controller.ts
@@ -23,17 +23,19 @@ export default class AutocompleteController extends ClickOutsideController<HTMLE
   declare readonly hasHiddenInputTarget: boolean
 
   currentIndex = -1
-  // Tracks the input value at the moment of the last commit (Enter or click
-  // on an option) or at connect-time when the form arrives pre-filled. We
-  // suppress reopening the listbox on refocus when the input still holds
-  // that exact value — the user just picked it; reopening would be ghosty.
-  #lastCommittedValue: string | null = null
+  // Tracks whether the current input value came from the user typing (true)
+  // or from a commit / external programmatic write / page load (false). We
+  // suppress reopening the listbox on refocus when the value was not typed
+  // by the user — the value was set for them; reopening would be ghosty.
+  //
+  // A boolean is safer than snapshotting the value because external writers
+  // (state.ts mirroring sessionStorage into the input on outlet-connect, for
+  // instance) update `inputTarget.value` directly and would not keep a
+  // value snapshot in sync.
+  #userIsTyping = false
 
   connect() {
     this.#hideListbox()
-    // Treat any value present on page load as "already committed" so the
-    // listbox does not pop open the first time the user focuses the input.
-    this.#lastCommittedValue = this.inputTarget.value || null
   }
 
   clickOutside(event) {
@@ -41,14 +43,25 @@ export default class AutocompleteController extends ClickOutsideController<HTMLE
   }
 
   focus(event) {
-    if (!this.showOnFocusValue || !this.inputTarget.value) return
-    if (this.inputTarget.value === this.#lastCommittedValue) return
+    if (!this.showOnFocusValue) return
+    // Empty input: always open so the synthetic top option (e.g. "Autour de
+    // moi" for the carte address combobox) is reachable on the very first
+    // focus. The backend returns it for sub-MIN_QUERY_LENGTH queries.
+    if (!this.inputTarget.value) {
+      this.#loadResults("")
+      return
+    }
+    // Non-empty input: only reopen when the user was mid-typing. A value that
+    // was set programmatically (commit, state restore, server render) is
+    // treated as already committed and must not re-open on refocus.
+    if (!this.#userIsTyping) return
     this.#loadResults(this.inputTarget.value)
   }
 
   search(event) {
-    // Typing invalidates any prior commit: the user is starting a new search.
-    this.#lastCommittedValue = null
+    // Typing means the user is actively searching: clear the "committed" flag
+    // so refocus after a blur reopens the listbox.
+    this.#userIsTyping = true
     this.#loadResults(event.target.value)
   }
 
@@ -222,9 +235,9 @@ export default class AutocompleteController extends ClickOutsideController<HTMLE
       this.hiddenInputTarget.value = value
     }
     this.inputTarget.value = selectedValue
-    // Remember the committed value so a subsequent refocus does not re-open
-    // the listbox with the same suggestions the user just picked.
-    this.#lastCommittedValue = selectedValue
+    // Clear the typing flag so a subsequent refocus does not re-open the
+    // listbox with the same suggestions the user just picked.
+    this.#userIsTyping = false
     this.#hideListbox()
 
     const commitEvent = new CustomEvent("next-autocomplete:commit", {

--- a/webapp/static/to_compile/controllers/shared/next_autocomplete_controller.ts
+++ b/webapp/static/to_compile/controllers/shared/next_autocomplete_controller.ts
@@ -23,9 +23,17 @@ export default class AutocompleteController extends ClickOutsideController<HTMLE
   declare readonly hasHiddenInputTarget: boolean
 
   currentIndex = -1
+  // Tracks the input value at the moment of the last commit (Enter or click
+  // on an option) or at connect-time when the form arrives pre-filled. We
+  // suppress reopening the listbox on refocus when the input still holds
+  // that exact value — the user just picked it; reopening would be ghosty.
+  #lastCommittedValue: string | null = null
 
   connect() {
     this.#hideListbox()
+    // Treat any value present on page load as "already committed" so the
+    // listbox does not pop open the first time the user focuses the input.
+    this.#lastCommittedValue = this.inputTarget.value || null
   }
 
   clickOutside(event) {
@@ -33,12 +41,14 @@ export default class AutocompleteController extends ClickOutsideController<HTMLE
   }
 
   focus(event) {
-    if (this.showOnFocusValue && this.inputTarget.value) {
-      this.#loadResults(this.inputTarget.value)
-    }
+    if (!this.showOnFocusValue || !this.inputTarget.value) return
+    if (this.inputTarget.value === this.#lastCommittedValue) return
+    this.#loadResults(this.inputTarget.value)
   }
 
   search(event) {
+    // Typing invalidates any prior commit: the user is starting a new search.
+    this.#lastCommittedValue = null
     this.#loadResults(event.target.value)
   }
 
@@ -73,10 +83,20 @@ export default class AutocompleteController extends ClickOutsideController<HTMLE
     this.#showListbox()
   }
 
+  // Keyboard handling follows W3C APG "combobox-autocomplete-list":
+  // https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list/
+  //
+  // Important invariants:
+  // - DOM focus stays on the textbox at all times while the listbox is open.
+  //   "Focused" option is conveyed only via `aria-activedescendant` and
+  //   `aria-selected` — we never call `link.focus()` or `option.focus()`.
+  // - `Home`/`End` are left to the browser so they act on the textbox caret.
+  // - Arrow navigation does NOT wrap (last → first or first → last).
+  // - First Down/Up press on a closed listbox only opens it; a second press
+  //   moves visual focus into the listbox.
   navigate(event: KeyboardEvent) {
     const key = event.key
 
-    // Allow Tab key to work normally for keyboard navigation
     if (key === "Tab") {
       this.#hideListbox()
       return
@@ -85,58 +105,43 @@ export default class AutocompleteController extends ClickOutsideController<HTMLE
     switch (key) {
       case "ArrowDown":
         event.preventDefault()
-        // Alt+Down: Open listbox without moving focus
-        if (event.altKey) {
+        // Alt+Down (and a plain Down on a closed listbox): open the listbox
+        // WITHOUT moving visual focus — APG explicitly forbids advancing.
+        if (event.altKey || this.resultsTarget.hidden) {
           this.#showListbox()
           return
         }
-        // Down Arrow: Opens the listbox if closed and moves focus to first option
-        // If already open, moves focus to next option
-        if (this.resultsTarget.hidden) {
-          this.#openListboxAndFocus(0)
-        } else {
-          this.#moveFocus(1)
-        }
+        this.#moveFocus(1)
         break
 
       case "ArrowUp":
         event.preventDefault()
-        // Up Arrow: Opens the listbox if closed and moves focus to last option
-        // If already open, moves focus to previous option
-        if (this.resultsTarget.hidden) {
-          this.#openListboxAndFocus(this.optionTargets.length - 1)
-        } else {
-          this.#moveFocus(-1)
+        if (event.altKey) {
+          // Alt + Up Arrow: close the listbox without changing the value.
+          this.#hideListbox()
+          return
         }
+        if (this.resultsTarget.hidden) {
+          // Up on a closed listbox opens it without moving visual focus.
+          this.#showListbox()
+          return
+        }
+        this.#moveFocus(-1)
         break
 
       case "Enter":
         event.preventDefault()
-        // Enter: Accepts the focused value, closes listbox
         this.commitSelection()
         break
 
       case "Escape":
         event.preventDefault()
-        // Escape: Closes the listbox if displayed, otherwise clears the combobox
         this.#escapeAction()
         break
 
-      case "Home":
-        // Home: Moves focus to first option (if listbox is open)
-        if (this.#isListboxOpenWithOptions()) {
-          event.preventDefault()
-          this.#setVisualFocus(0)
-        }
-        break
-
-      case "End":
-        // End: Moves focus to last option (if listbox is open)
-        if (this.#isListboxOpenWithOptions()) {
-          event.preventDefault()
-          this.#setVisualFocus(this.optionTargets.length - 1)
-        }
-        break
+      // Home / End intentionally not handled: APG says they move the caret
+      // in the textbox, which is the browser default. Intercepting would
+      // break users navigating long queries.
     }
   }
 
@@ -148,17 +153,6 @@ export default class AutocompleteController extends ClickOutsideController<HTMLE
     this.currentIndex = -1
   }
 
-  #isListboxOpenWithOptions(): boolean {
-    return !this.resultsTarget.hidden && this.optionTargets.length > 0
-  }
-
-  #openListboxAndFocus(index: number) {
-    this.#showListbox()
-    if (this.optionTargets.length > 0) {
-      this.#setVisualFocus(index)
-    }
-  }
-
   #getLinkFromOption(option: HTMLElement): HTMLAnchorElement | null {
     return option.querySelector("a")
   }
@@ -168,19 +162,26 @@ export default class AutocompleteController extends ClickOutsideController<HTMLE
       return
     }
 
-    // Calculate new index with wrapping
-    let newIndex = this.currentIndex + direction
+    // No wrap — APG says Down does nothing on the last option and Up does
+    // nothing on the first. From `currentIndex = -1` (no option focused yet)
+    // a Down jumps to 0 and Up jumps to the last option.
+    let newIndex: number
+    if (this.currentIndex === -1) {
+      newIndex = direction > 0 ? 0 : this.optionTargets.length - 1
+    } else {
+      newIndex = this.currentIndex + direction
+    }
 
-    // Wrap around
-    if (newIndex < 0) {
-      newIndex = this.optionTargets.length - 1
-    } else if (newIndex >= this.optionTargets.length) {
-      newIndex = 0
+    if (newIndex < 0 || newIndex >= this.optionTargets.length) {
+      return
     }
 
     this.#setVisualFocus(newIndex)
   }
 
+  // Visual focus only — DOM focus stays on the textbox. The selected option
+  // is conveyed by `aria-activedescendant` on the input and `aria-selected`
+  // on the option, per APG combobox-autocomplete-list.
   #setVisualFocus(index: number) {
     if (index < 0 || index >= this.optionTargets.length) {
       return
@@ -189,24 +190,9 @@ export default class AutocompleteController extends ClickOutsideController<HTMLE
     this.currentIndex = index
     const currentOption = this.optionTargets[this.currentIndex]
 
-    // Remove aria-selected from all options
     this.#removeSelection()
-
-    // Set aria-selected on current option
     currentOption.setAttribute("aria-selected", "true")
-
-    // If option contains a link, focus it. Otherwise keep focus on input
-    const link = this.#getLinkFromOption(currentOption)
-    if (link) {
-      link.focus()
-    } else {
-      // Keep focus on input, update aria-activedescendant
-      this.inputTarget.focus()
-    }
-
     this.inputTarget.setAttribute("aria-activedescendant", currentOption.id || "")
-
-    // Scroll into view if needed
     currentOption.scrollIntoView({ block: "nearest", behavior: "smooth" })
   }
 
@@ -236,6 +222,9 @@ export default class AutocompleteController extends ClickOutsideController<HTMLE
       this.hiddenInputTarget.value = value
     }
     this.inputTarget.value = selectedValue
+    // Remember the committed value so a subsequent refocus does not re-open
+    // the listbox with the same suggestions the user just picked.
+    this.#lastCommittedValue = selectedValue
     this.#hideListbox()
 
     const commitEvent = new CustomEvent("next-autocomplete:commit", {

--- a/webapp/static/to_compile/controllers/shared/next_autocomplete_controller.ts
+++ b/webapp/static/to_compile/controllers/shared/next_autocomplete_controller.ts
@@ -20,6 +20,7 @@ export default class AutocompleteController extends ClickOutsideController<HTMLE
   declare readonly fieldNameValue: string
   declare readonly inputTarget: HTMLInputElement
   declare readonly hiddenInputTarget: HTMLInputElement
+  declare readonly hasHiddenInputTarget: boolean
 
   currentIndex = -1
 
@@ -229,7 +230,11 @@ export default class AutocompleteController extends ClickOutsideController<HTMLE
     const value = selected.dataset.value?.trim() || ""
     const selectedValue = selected.dataset.selectedValue?.trim() || ""
 
-    this.hiddenInputTarget.value = value
+    // When `display_value` is True the visible input itself carries the form
+    // value and there is no hidden sibling — see input.html.
+    if (this.hasHiddenInputTarget) {
+      this.hiddenInputTarget.value = value
+    }
     this.inputTarget.value = selectedValue
     this.#hideListbox()
 

--- a/webapp/static/to_compile/js/carte.ts
+++ b/webapp/static/to_compile/js/carte.ts
@@ -6,6 +6,7 @@ import GenericAutocompleteController from "../controllers/shared/generic_autocom
 import ScrollController from "../controllers/shared/scroll_controller"
 
 import AddressAutocompleteController from "../controllers/carte/address_autocomplete_controller"
+import CarteAddressAutocompleteController from "../controllers/carte/carte_address_autocomplete_controller"
 import MapController from "../controllers/carte/map_controller"
 import SearchSolutionFormController from "../controllers/carte/search_solution_form_controller"
 import SsCatObjectAutocompleteController from "../controllers/formulaire/ss_cat_object_autocomplete_controller"
@@ -25,6 +26,7 @@ window.stimulus = Application.start()
 stimulus.register("map", MapController)
 stimulus.register("ss-cat-object-autocomplete", SsCatObjectAutocompleteController)
 stimulus.register("address-autocomplete", AddressAutocompleteController)
+stimulus.register("carte-address-autocomplete", CarteAddressAutocompleteController)
 stimulus.register("search-solution-form", SearchSolutionFormController)
 stimulus.register("autocomplete", GenericAutocompleteController)
 stimulus.register("copy", CopyController)

--- a/webapp/templates/ui/components/carte/adresse_input_form.html
+++ b/webapp/templates/ui/components/carte/adresse_input_form.html
@@ -16,10 +16,13 @@
         </div>
         {{ forms.map.latitude }}
         {{ forms.map.longitude }}
+        {# `role="alert"` (implicit aria-live=assertive + aria-atomic=true)   #}
+        {# so geolocation / reverse-geocode errors are announced immediately. #}
         <p
             class="fr-error-text fr-mt-1v qf-hidden"
             data-search-solution-form-target="adresseError"
             data-carte-address-autocomplete-target="displayError"
+            role="alert"
         >
             Veuillez saisir une adresse
         </p>

--- a/webapp/templates/ui/components/carte/adresse_input_form.html
+++ b/webapp/templates/ui/components/carte/adresse_input_form.html
@@ -3,6 +3,7 @@
     <div
         data-controller="carte-address-autocomplete"
         data-action="next-autocomplete:commit->carte-address-autocomplete#commit"
+        data-carte-address-autocomplete-reverse-geocode-url-value="{% url 'qfdmo:reverse_geocode_address' %}"
         data-testid="rechercher-adresses-submit"
     >
         <div class="form-group">

--- a/webapp/templates/ui/components/carte/adresse_input_form.html
+++ b/webapp/templates/ui/components/carte/adresse_input_form.html
@@ -1,12 +1,8 @@
 {# Recherche adresse #}
 <div data-search-solution-form-target="adresseGroup">
     <div
-        data-controller="address-autocomplete"
-        data-address-autocomplete-max-option-displayed-value=5
-        data-address-autocomplete-is-ban-address-value='true'
-        data-with-controls="{{ is_carte|yesno:'false,true' }}"
-        data-without-zone="true"
-        data-with-dynamic-form-panel="{{ is_carte|yesno:'false,true' }}"
+        data-controller="carte-address-autocomplete"
+        data-action="next-autocomplete:commit->carte-address-autocomplete#commit"
         data-testid="rechercher-adresses-submit"
     >
         <div class="form-group">
@@ -20,8 +16,12 @@
         </div>
         {{ forms.map.latitude }}
         {{ forms.map.longitude }}
+        <p
+            class="fr-error-text fr-mt-1v qf-hidden"
+            data-search-solution-form-target="adresseError"
+            data-carte-address-autocomplete-target="displayError"
+        >
+            Veuillez saisir une adresse
+        </p>
     </div>
-    <p class="fr-error-text fr-mt-1v qf-hidden" data-search-solution-form-target="adresseError">
-        Veuillez saisir une adresse
-    </p>
 </div>

--- a/webapp/templates/ui/components/formulaire/adresse_input_form.html
+++ b/webapp/templates/ui/components/formulaire/adresse_input_form.html
@@ -1,0 +1,31 @@
+{# Recherche adresse — formulaire (legacy address-autocomplete) #}
+{# Mirrors the carte's adresse_input_form.html but mounts the legacy        #}
+{# `address-autocomplete` controller, since the formulaire's view renders   #}
+{# FormulaireForm (not MapForm) and that form still uses the JSON-based     #}
+{# client-side AutoCompleteInput widget.                                    #}
+<div data-search-solution-form-target="adresseGroup">
+    <div
+        data-controller="address-autocomplete"
+        data-address-autocomplete-max-option-displayed-value=5
+        data-address-autocomplete-is-ban-address-value='true'
+        data-with-controls="true"
+        data-without-zone="true"
+        data-with-dynamic-form-panel="true"
+        data-testid="rechercher-adresses-submit"
+    >
+        <div class="form-group">
+            {{ forms.map.adresse.label_tag }}
+            {% if forms.map.adresse.help_text %}
+                <span class="fr-hint-text fr-mt-1v" id="{{ form.adresse.id_for_label }}_helptext">
+                    {{ forms.map.adresse.help_text }}
+                </span>
+            {% endif %}
+            {{ forms.map.adresse }}
+        </div>
+        {{ forms.map.latitude }}
+        {{ forms.map.longitude }}
+    </div>
+    <p class="fr-error-text fr-mt-1v qf-hidden" data-search-solution-form-target="adresseError">
+        Veuillez saisir une adresse
+    </p>
+</div>

--- a/webapp/templates/ui/components/formulaire/search_form.html
+++ b/webapp/templates/ui/components/formulaire/search_form.html
@@ -25,7 +25,7 @@
 
                 {# Recherche adresse #}
                 <div class="fr-mt-3w fr-px-1v fr-input-group">
-                    {% include "ui/components/carte/adresse_input_form.html" %}
+                    {% include "ui/components/formulaire/adresse_input_form.html" %}
                 </div>
 
                 {# Gestes #}

--- a/webapp/templates/ui/forms/widgets/autocomplete/address_results.html
+++ b/webapp/templates/ui/forms/widgets/autocomplete/address_results.html
@@ -1,15 +1,31 @@
 {% extends "ui/forms/widgets/autocomplete/results.html" %}
 {% load l10n %}
 
+{# Polite live region announcing the result count to screen readers each   #}
+{# time the Turbo Frame swaps. Visually hidden via qf-sr-only.             #}
+{# Lives outside the <ul role="listbox"> so it's not picked up as an option. #}
+{% block status %}
+    <div role="status" aria-live="polite" class="qf-sr-only">
+        {% if results %}
+            {{ results|length }} suggestion{{ results|length|pluralize }} d'adresse
+        {% else %}
+            Aucune adresse trouvée
+        {% endif %}
+    </div>
+{% endblock status %}
+
 {% block results %}
     {% for option in results %}
+        {# No tabindex on options: per APG combobox-autocomplete-list, DOM   #}
+        {# focus never moves into the listbox. The active option is signaled #}
+        {# via aria-activedescendant on the combobox input and aria-selected #}
+        {# here. Visual state is driven by aria-[selected=true]:… utilities. #}
         <li
             id="option-{{ forloop.counter }}"
             role="option"
-            tabindex="-1"
-            class="qf-flex qf-flex-col sm:qf-flex-row sm:qf-justify-between sm:qf-items-baseline qf-gap-1v qf-list-none qf-p-1w qf-bg-white qf-border-b qf-border-solid qf-border-x-0 qf-border-t-0 qf-border-grey-625-425 focus:qf-bg-blue-france-sun-113-625 focus:qf-text-white focus-within:qf-bg-blue-france-sun-113-625 focus-within:qf-text-white aria-[selected=true]:qf-bg-blue-france-sun-113-625 aria-[selected=true]:qf-text-white hover:qf-bg-grey-1000-50-hover qf-cursor-pointer"
+            class="qf-flex qf-flex-col sm:qf-flex-row sm:qf-justify-between sm:qf-items-baseline qf-gap-1v qf-list-none qf-p-1w qf-bg-white qf-border-b qf-border-solid qf-border-x-0 qf-border-t-0 qf-border-grey-625-425 aria-[selected=true]:qf-bg-blue-france-sun-113-625 aria-[selected=true]:qf-text-white hover:qf-bg-grey-1000-50-hover qf-cursor-pointer"
             data-next-autocomplete-target="option"
-            data-action="keydown->next-autocomplete#navigate:prevent click->next-autocomplete#commitSelection"
+            data-action="click->next-autocomplete#commitSelection"
             data-value="{{ option.label }}"
             data-selected-value="{{ option.label }}"
             {% if option.geolocate %}data-geolocate="true"{% else %}data-lat="{{ option.latitude|unlocalize }}" data-lon="{{ option.longitude|unlocalize }}"{% endif %}

--- a/webapp/templates/ui/forms/widgets/autocomplete/address_results.html
+++ b/webapp/templates/ui/forms/widgets/autocomplete/address_results.html
@@ -1,0 +1,25 @@
+{% extends "ui/forms/widgets/autocomplete/results.html" %}
+{% load l10n %}
+
+{% block results %}
+    {% for option in results %}
+        <li
+            id="option-{{ forloop.counter }}"
+            role="option"
+            tabindex="-1"
+            class="qf-flex qf-flex-col sm:qf-flex-row sm:qf-justify-between sm:qf-items-baseline qf-gap-1v qf-list-none qf-p-1w qf-bg-white qf-border-b qf-border-solid qf-border-x-0 qf-border-t-0 qf-border-grey-625-425 focus:qf-bg-blue-france-sun-113-625 focus:qf-text-white focus-within:qf-bg-blue-france-sun-113-625 focus-within:qf-text-white aria-[selected=true]:qf-bg-blue-france-sun-113-625 aria-[selected=true]:qf-text-white hover:qf-bg-grey-1000-50-hover qf-cursor-pointer"
+            data-next-autocomplete-target="option"
+            data-action="keydown->next-autocomplete#navigate:prevent click->next-autocomplete#commitSelection"
+            data-value="{{ option.label }}"
+            data-selected-value="{{ option.label }}"
+            {% if option.geolocate %}data-geolocate="true"{% else %}data-lat="{{ option.latitude|unlocalize }}" data-lon="{{ option.longitude|unlocalize }}"{% endif %}
+        >
+            <span>{{ option.label }}</span>
+            {% if option.sub_label %}<small class="fr-text--sm fr-m-0 qf-italic">{{ option.sub_label }}</small>{% endif %}
+        </li>
+    {% empty %}
+        <li class="qf-list-none qf-px-2w qf-py-1w qf-text-gray-500">
+            Aucune adresse trouvée
+        </li>
+    {% endfor %}
+{% endblock results %}

--- a/webapp/templates/ui/forms/widgets/autocomplete/input.html
+++ b/webapp/templates/ui/forms/widgets/autocomplete/input.html
@@ -10,7 +10,11 @@
     {% for key, value in wrapper_attrs.items %}{% if key != "data-controller" %}{{ key }}="{{ value }}" {% endif %}{% endfor %}
     class="qf-relative"
 >
-    {# Input, copy pasted from django/forms/widgets/input.html #}
+    {# Input, copy pasted from django/forms/widgets/input.html               #}
+    {# When `display_value` is True (e.g. carte address combobox), the       #}
+    {# visible search box IS the form input: it carries the `name` and the  #}
+    {# submitted value. When False (e.g. homepage search), the visible box  #}
+    {# is decorative and the hidden sibling below carries the form value.   #}
     <input
         type="search"
         {% include "django/forms/widgets/attrs.html" %}
@@ -27,11 +31,13 @@
         data-action="next-autocomplete#search keydown->next-autocomplete#navigate focus->next-autocomplete#focus"
         data-next-autocomplete-target="input"
     >
+    {% if not display_value %}
     <input
         type="hidden"
         data-next-autocomplete-target="hiddenInput"
         name="{{ widget.name }}"{% if widget.value != None %} value="{{ widget.value }}"{% endif %}
     >
+    {% endif %}
 
     {# Results #}
     {% include "ui/forms/widgets/autocomplete/results.html" %}

--- a/webapp/templates/ui/forms/widgets/autocomplete/input.html
+++ b/webapp/templates/ui/forms/widgets/autocomplete/input.html
@@ -27,7 +27,9 @@
         aria-controls="{{ turbo_frame_id }}-listbox"
         aria-expanded="false"
         aria-activedescendant=""
-        aria-autocomplete="both"
+        {# `list` (not `both`): we surface suggestions in the listbox below but #}
+        {# we do NOT inline-complete the typed text — APG combobox-autocomplete-list. #}
+        aria-autocomplete="list"
         data-action="next-autocomplete#search keydown->next-autocomplete#navigate focus->next-autocomplete#focus"
         data-next-autocomplete-target="input"
     >

--- a/webapp/templates/ui/forms/widgets/autocomplete/results.html
+++ b/webapp/templates/ui/forms/widgets/autocomplete/results.html
@@ -3,6 +3,9 @@
     class="qf-peer qf-absolute qf-left-0 qf-right-0 qf-z-50 qf-bg-white qf-shadow-md qf-rounded-b-lg qf-overflow-hidden {{ extra_classes }}"
     style="--underline-img: linear-gradient(0deg, currentColor, currentColor);"
 >
+    {# Optional live region for assistive tech. Subclasses provide a #}
+    {# role=status element here that re-announces on each frame swap. #}
+    {% block status %}{% endblock %}
     <ul
         id="{{ turbo_frame_id }}-listbox"
         role="listbox"

--- a/webapp/templates/ui/layout/assistant.html
+++ b/webapp/templates/ui/layout/assistant.html
@@ -86,11 +86,12 @@ parsing, which raises VariableDoesNotExist when seo is not in context (e.g., err
         {% endif %}
         data-state-map-outlet="[data-controller='map']"
         data-state-address-autocomplete-outlet="[data-controller='address-autocomplete']"
+        data-state-carte-address-autocomplete-outlet="[data-controller~='carte-address-autocomplete']"
         data-state-search-solution-form-outlet="[data-controller='search-solution-form']"
         {% posthog_data_attributes assistant.POSTHOG_KEY %}
         data-analytics-initial-action-value="{% block analytics_action %}{% endblock %}"
         {# Actions #}
-        data-action="address-autocomplete:change->state#setLocation"
+        data-action="address-autocomplete:change->state#setLocation carte-address-autocomplete:change->state#setLocation"
     >
         {# Skip links for accessibility - using DSFR component #}
         {% dsfr_skiplinks skiplinks %}

--- a/webapp/templates/ui/layout/base.html
+++ b/webapp/templates/ui/layout/base.html
@@ -49,11 +49,12 @@
         data-map-location-value="{{ location }}"
         {% endif %}
         data-state-address-autocomplete-outlet="[data-controller='address-autocomplete']"
+        data-state-carte-address-autocomplete-outlet="[data-controller~='carte-address-autocomplete']"
         data-state-map-outlet="[data-controller='map']"
         data-state-search-solution-form-outlet="[data-controller='search-solution-form']"
         {% posthog_data_attributes assistant.POSTHOG_KEY %}
         {% sentry_data_attributes %}
-        data-action="address-autocomplete:change->state#setLocation"
+        data-action="address-autocomplete:change->state#setLocation carte-address-autocomplete:change->state#setLocation"
         {% if STIMULUS_DEBUG %}data-stimulus-debug="true"{% endif %}
     >
         <main id="solutions" class="qf-h-full qf-overflow-y-auto qf-overflow-x-hidden">

--- a/webapp/templates/ui/pages/carte.html
+++ b/webapp/templates/ui/pages/carte.html
@@ -22,7 +22,7 @@
         data-action="
         map:updateBbox->search-solution-form#updateBboxInput
         search-solution-form:captureInteraction->analytics#captureInteractionWithMap
-        address-autocomplete:formSubmit->search-solution-form#submitForm"
+        carte-address-autocomplete:change->search-solution-form#submitForm"
         class="
         qf-rounded-lg qf-border qf-border-solid qf-border-grey-900
         qf-group

--- a/webapp/templates/ui/pages/carte.html
+++ b/webapp/templates/ui/pages/carte.html
@@ -19,10 +19,16 @@
         data-controller="search-solution-form"
         data-search-solution-form-target="searchForm"
         data-search-solution-form-is-iframe-value="{{ is_embedded }}"
+        {# Address picks are submitted via the state controller, NOT a direct  #}
+        {# listener here. State#setLocation runs first (it owns the body-level #}
+        {# data-action), clears any stale bbox via resetBboxInputs(), then     #}
+        {# calls submitForm via #updateUIFromGlobalState. Listening for the    #}
+        {# change event on the form too would race with state and submit with  #}
+        {# the previous bbox still set, so the server scopes acteurs to the   #}
+        {# old map view instead of the new address.                            #}
         data-action="
         map:updateBbox->search-solution-form#updateBboxInput
-        search-solution-form:captureInteraction->analytics#captureInteractionWithMap
-        carte-address-autocomplete:change->search-solution-form#submitForm"
+        search-solution-form:captureInteraction->analytics#captureInteractionWithMap"
         class="
         qf-rounded-lg qf-border qf-border-solid qf-border-grey-900
         qf-group

--- a/webapp/unit_tests/qfdmo/test_autocomplete_address_view.py
+++ b/webapp/unit_tests/qfdmo/test_autocomplete_address_view.py
@@ -11,6 +11,7 @@ Covers the boundary cases that aren't easy to exercise in e2e:
 Network calls to data.geopf.fr are mocked with `responses`.
 """
 
+import json
 from unittest.mock import patch
 
 import pytest
@@ -20,8 +21,10 @@ from django.urls import reverse
 
 from qfdmo.views.autocomplete import (
     BAN_API_URL,
+    BAN_REVERSE_API_URL,
     GEOLOCATE_OPTION,
     AutocompleteBanAddressView,
+    ReverseGeocodeBanView,
 )
 
 
@@ -233,3 +236,105 @@ class TestGeolocateOption:
         # `navigator.geolocation` instead of any baked-in lat/lon.
         assert GEOLOCATE_OPTION["latitude"] is None
         assert GEOLOCATE_OPTION["longitude"] is None
+
+
+def _reverse_request(**get_params):
+    factory = RequestFactory()
+    return factory.get(reverse("qfdmo:reverse_geocode_address"), data=get_params)
+
+
+@pytest.mark.django_db
+class TestReverseGeocodeBanView:
+    """JSON proxy in front of BAN reverse-geocode (Autour de moi → adresse)."""
+
+    def _ban_returns_one_match(self):
+        return {
+            "features": [
+                {
+                    "properties": {"label": "10 Rue de Paris, 56400 Auray"},
+                    "geometry": {"coordinates": [-2.990838, 47.668099]},
+                }
+            ]
+        }
+
+    def test_returns_label_and_swapped_coordinates(self):
+        with patch("qfdmo.views.autocomplete.requests.get") as ban:
+            ban.return_value.raise_for_status.return_value = None
+            ban.return_value.json.return_value = self._ban_returns_one_match()
+            response = ReverseGeocodeBanView.as_view()(
+                _reverse_request(lat="47.668099", lon="-2.990838")
+            )
+        assert response.status_code == 200
+        assert json.loads(response.content) == {
+            "adresse": "10 Rue de Paris, 56400 Auray",
+            "latitude": 47.668099,
+            "longitude": -2.990838,
+        }
+
+    def test_targets_ban_reverse_endpoint_with_parsed_floats(self):
+        with patch("qfdmo.views.autocomplete.requests.get") as ban:
+            ban.return_value.raise_for_status.return_value = None
+            ban.return_value.json.return_value = self._ban_returns_one_match()
+            ReverseGeocodeBanView.as_view()(
+                _reverse_request(lat="47.668099", lon="-2.990838")
+            )
+        assert ban.call_args.args[0] == BAN_REVERSE_API_URL
+        # Parsed as floats — protects against query-string passthrough.
+        assert ban.call_args.kwargs["params"] == {
+            "lat": 47.668099,
+            "lon": -2.990838,
+        }
+        assert ban.call_args.kwargs["timeout"] == 3
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {},
+            {"lat": "47.6"},
+            {"lon": "2.3"},
+            {"lat": "not-a-number", "lon": "2.3"},
+            {"lat": "47.6", "lon": "abc"},
+        ],
+    )
+    def test_missing_or_malformed_params_return_400(self, params):
+        response = ReverseGeocodeBanView.as_view()(_reverse_request(**params))
+        assert response.status_code == 400
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {"lat": "91", "lon": "2.3"},
+            {"lat": "-91", "lon": "2.3"},
+            {"lat": "47", "lon": "181"},
+            {"lat": "47", "lon": "-181"},
+        ],
+    )
+    def test_out_of_range_params_return_400(self, params):
+        response = ReverseGeocodeBanView.as_view()(_reverse_request(**params))
+        assert response.status_code == 400
+
+    def test_ban_timeout_returns_502(self):
+        with patch("qfdmo.views.autocomplete.requests.get") as ban:
+            ban.side_effect = requests.Timeout("BAN slow")
+            response = ReverseGeocodeBanView.as_view()(
+                _reverse_request(lat="47.6", lon="2.3")
+            )
+        assert response.status_code == 502
+
+    def test_empty_features_returns_404(self):
+        with patch("qfdmo.views.autocomplete.requests.get") as ban:
+            ban.return_value.raise_for_status.return_value = None
+            ban.return_value.json.return_value = {"features": []}
+            response = ReverseGeocodeBanView.as_view()(
+                _reverse_request(lat="47.6", lon="2.3")
+            )
+        assert response.status_code == 404
+
+    def test_malformed_feature_returns_502(self):
+        with patch("qfdmo.views.autocomplete.requests.get") as ban:
+            ban.return_value.raise_for_status.return_value = None
+            ban.return_value.json.return_value = {"features": [{"properties": {}}]}
+            response = ReverseGeocodeBanView.as_view()(
+                _reverse_request(lat="47.6", lon="2.3")
+            )
+        assert response.status_code == 502

--- a/webapp/unit_tests/qfdmo/test_autocomplete_address_view.py
+++ b/webapp/unit_tests/qfdmo/test_autocomplete_address_view.py
@@ -1,0 +1,235 @@
+"""Unit tests for AutocompleteBanAddressView (the carte BAN proxy).
+
+Covers the boundary cases that aren't easy to exercise in e2e:
+
+  - short / oversized / blank queries
+  - `limit` parameter clamping
+  - BAN returning a non-JSON or malformed response
+  - one malformed feature shouldn't poison the rest
+  - the synthetic "Autour de moi" geolocate option
+
+Network calls to data.geopf.fr are mocked with `responses`.
+"""
+
+from unittest.mock import patch
+
+import pytest
+import requests
+from django.test import RequestFactory
+from django.urls import reverse
+
+from qfdmo.views.autocomplete import (
+    BAN_API_URL,
+    GEOLOCATE_OPTION,
+    AutocompleteBanAddressView,
+)
+
+
+def _view_response(request):
+    """Invoke the class-based view and return the rendered HttpResponse.
+
+    ListView returns a TemplateResponse which is lazy. We call `.render()`
+    so `.content` is available to assertions.
+    """
+    response = AutocompleteBanAddressView.as_view()(request)
+    response.render()
+    return response
+
+
+def _make_request(**get_params):
+    factory = RequestFactory()
+    return factory.get(reverse("qfdmo:autocomplete_address"), data=get_params)
+
+
+@pytest.mark.django_db
+class TestAutocompleteBanAddressViewQueryHandling:
+    """Behavior driven by the GET parameters before any BAN call."""
+
+    def test_short_query_returns_only_geolocate_option(self):
+        response = _view_response(_make_request(q="ab", turbo_frame_id="frame-1"))
+        assert response.status_code == 200
+        assert b"Autour de moi" in response.content
+        assert b'data-geolocate="true"' in response.content
+
+    def test_blank_query_returns_only_geolocate_option(self):
+        response = _view_response(_make_request(q="", turbo_frame_id="frame-1"))
+        assert b"Autour de moi" in response.content
+
+    def test_missing_query_returns_only_geolocate_option(self):
+        response = _view_response(_make_request(turbo_frame_id="frame-1"))
+        assert b"Autour de moi" in response.content
+
+    def test_oversized_query_is_truncated_before_calling_ban(self):
+        long_q = "x" * (AutocompleteBanAddressView.MAX_QUERY_LENGTH + 50)
+        with patch("qfdmo.views.autocomplete.requests.get") as ban:
+            ban.return_value.json.return_value = {"features": []}
+            ban.return_value.raise_for_status.return_value = None
+            _view_response(_make_request(q=long_q, turbo_frame_id="f"))
+        sent_q = ban.call_args.kwargs["params"]["q"]
+        assert len(sent_q) == AutocompleteBanAddressView.MAX_QUERY_LENGTH
+
+
+@pytest.mark.django_db
+class TestAutocompleteBanAddressViewLimitClamping:
+    """The `limit` parameter must fall back / clamp safely."""
+
+    @pytest.mark.parametrize(
+        "limit_param,expected_capped",
+        [
+            ("3", 3),
+            ("0", 1),
+            ("-5", 1),
+            ("9999", AutocompleteBanAddressView.MAX_LIMIT),
+            ("not-a-number", AutocompleteBanAddressView.DEFAULT_LIMIT),
+            (None, AutocompleteBanAddressView.DEFAULT_LIMIT),
+        ],
+    )
+    def test_limit_is_clamped_to_safe_bounds(self, limit_param, expected_capped):
+        features = [
+            {
+                "properties": {"label": f"Result {i}", "context": "ctx"},
+                "geometry": {"coordinates": [1.0 + i, 2.0 + i]},
+            }
+            for i in range(50)
+        ]
+        params = {"q": "Paris", "turbo_frame_id": "frame"}
+        if limit_param is not None:
+            params["limit"] = limit_param
+
+        with patch("qfdmo.views.autocomplete.requests.get") as ban:
+            ban.return_value.json.return_value = {"features": features}
+            ban.return_value.raise_for_status.return_value = None
+            response = _view_response(_make_request(**params))
+
+        assert response.status_code == 200
+        rendered_count = response.content.count(b'role="option"')
+        assert rendered_count == expected_capped
+
+
+@pytest.mark.django_db
+class TestAutocompleteBanAddressViewBanResilience:
+    """Network and parsing failures must degrade gracefully."""
+
+    def test_ban_timeout_returns_empty_listbox(self):
+        with patch("qfdmo.views.autocomplete.requests.get") as ban:
+            ban.side_effect = requests.Timeout("BAN slow")
+            response = _view_response(_make_request(q="Paris", turbo_frame_id="frame"))
+        assert response.status_code == 200
+        # "Aucune adresse trouvée" is the empty-state message
+        assert b"Aucune adresse trouv" in response.content
+
+    def test_ban_returns_invalid_json(self):
+        with patch("qfdmo.views.autocomplete.requests.get") as ban:
+            ban.return_value.raise_for_status.return_value = None
+            ban.return_value.json.side_effect = ValueError("not json")
+            response = _view_response(_make_request(q="Paris", turbo_frame_id="frame"))
+        assert response.status_code == 200
+        assert b"Aucune adresse trouv" in response.content
+
+    def test_one_malformed_feature_is_skipped(self):
+        good = {
+            "properties": {"label": "Auray", "context": "56, Morbihan"},
+            "geometry": {"coordinates": [-2.99, 47.66]},
+        }
+        malformed = {"properties": {}, "geometry": {}}
+        with patch("qfdmo.views.autocomplete.requests.get") as ban:
+            ban.return_value.raise_for_status.return_value = None
+            ban.return_value.json.return_value = {"features": [malformed, good]}
+            response = _view_response(_make_request(q="Auray", turbo_frame_id="frame"))
+        body = response.content.decode()
+        # The good entry rendered, the malformed one was silently dropped.
+        assert "Auray" in body
+        assert body.count('role="option"') == 1
+
+    def test_ban_returns_null_features(self):
+        with patch("qfdmo.views.autocomplete.requests.get") as ban:
+            ban.return_value.raise_for_status.return_value = None
+            ban.return_value.json.return_value = {"features": None}
+            response = _view_response(_make_request(q="Paris", turbo_frame_id="frame"))
+        assert response.status_code == 200
+        assert b"Aucune adresse trouv" in response.content
+
+
+@pytest.mark.django_db
+class TestAutocompleteBanAddressViewRendering:
+    """The Turbo Frame contract: id matches the query param, lat/lon are
+    unlocalized (`.` separator), structure carries ARIA roles."""
+
+    def _ban_returns_one_result(self):
+        return {
+            "features": [
+                {
+                    "properties": {
+                        "label": "Auray",
+                        "context": "56, Morbihan, Bretagne",
+                    },
+                    "geometry": {"coordinates": [-2.990838, 47.668099]},
+                }
+            ]
+        }
+
+    def test_turbo_frame_id_echoes_the_request_param(self):
+        with patch("qfdmo.views.autocomplete.requests.get") as ban:
+            ban.return_value.raise_for_status.return_value = None
+            ban.return_value.json.return_value = self._ban_returns_one_result()
+            response = _view_response(
+                _make_request(q="Auray", turbo_frame_id="some-uuid-here")
+            )
+        assert b'id="some-uuid-here"' in response.content
+        assert b'id="some-uuid-here-listbox"' in response.content
+
+    def test_listbox_role_is_present(self):
+        with patch("qfdmo.views.autocomplete.requests.get") as ban:
+            ban.return_value.raise_for_status.return_value = None
+            ban.return_value.json.return_value = self._ban_returns_one_result()
+            response = _view_response(_make_request(q="Auray", turbo_frame_id="frame"))
+        assert b'role="listbox"' in response.content
+        assert b'role="option"' in response.content
+
+    def test_lat_lon_are_unlocalized(self):
+        # Coordinates must use `.` decimal separator regardless of LOCALE so
+        # the JS dataset can parseFloat them.
+        with patch("qfdmo.views.autocomplete.requests.get") as ban:
+            ban.return_value.raise_for_status.return_value = None
+            ban.return_value.json.return_value = self._ban_returns_one_result()
+            response = _view_response(_make_request(q="Auray", turbo_frame_id="frame"))
+        body = response.content.decode()
+        assert 'data-lat="47.668099"' in body
+        assert 'data-lon="-2.990838"' in body
+        # Belt-and-suspenders: no French decimal slipped through.
+        assert "47,668099" not in body
+
+    def test_sub_label_is_rendered_when_present(self):
+        with patch("qfdmo.views.autocomplete.requests.get") as ban:
+            ban.return_value.raise_for_status.return_value = None
+            ban.return_value.json.return_value = self._ban_returns_one_result()
+            response = _view_response(_make_request(q="Auray", turbo_frame_id="frame"))
+        assert b"56, Morbihan, Bretagne" in response.content
+
+
+@pytest.mark.django_db
+class TestAutocompleteBanAddressViewBanRequest:
+    """The view must hit BAN with the expected URL and a short timeout."""
+
+    def test_request_targets_data_geopf_with_query(self):
+        with patch("qfdmo.views.autocomplete.requests.get") as ban:
+            ban.return_value.raise_for_status.return_value = None
+            ban.return_value.json.return_value = {"features": []}
+            _view_response(_make_request(q="Paris", turbo_frame_id="frame"))
+        assert ban.call_args.args[0] == BAN_API_URL
+        assert ban.call_args.kwargs["params"] == {"q": "Paris"}
+        # Hardcoded 3s timeout — guards against the carte hanging on slow BAN.
+        assert ban.call_args.kwargs["timeout"] == 3
+
+
+class TestGeolocateOption:
+    """Smoke check on the constant — it's referenced from results templates,
+    so a typo would silently disable the « Autour de moi » entry."""
+
+    def test_geolocate_option_carries_required_keys(self):
+        assert GEOLOCATE_OPTION["geolocate"] is True
+        assert GEOLOCATE_OPTION["label"] == "Autour de moi"
+        # Coordinates are intentionally None: the client uses
+        # `navigator.geolocation` instead of any baked-in lat/lon.
+        assert GEOLOCATE_OPTION["latitude"] is None
+        assert GEOLOCATE_OPTION["longitude"] is None

--- a/webapp/unit_tests/qfdmo/test_carte_address_widget.py
+++ b/webapp/unit_tests/qfdmo/test_carte_address_widget.py
@@ -1,0 +1,124 @@
+"""Tests for CarteAddressAutocompleteInput widget rendering.
+
+The carte address combobox must implement the W3C APG
+combobox-autocomplete-list pattern for RGAA criteria 7.1, 7.3, 11.10.
+These assertions pin the contract:
+
+- visible <input> carries role=combobox + aria-controls + aria-autocomplete
+- Turbo Frame results <ul> carries role=listbox
+- the visible input is the only `name=carte_map-adresse` (the fix for the
+  duplicate-name resubmit loop) and carries `display_value` correctly
+- lat/lng hidden inputs target the carte-address-autocomplete controller
+"""
+
+import pytest
+
+from qfdmo.forms import MapForm
+
+
+@pytest.mark.django_db
+class TestCarteAddressAutocompleteInputRendering:
+    """The widget is rendered via Django's form helpers, so we instantiate
+    MapForm without bound data and inspect the rendered field HTML."""
+
+    def setup_method(self):
+        form = MapForm()
+        self.adresse_html = str(form["adresse"])
+        self.latitude_html = str(form["latitude"])
+        self.longitude_html = str(form["longitude"])
+
+    def test_visible_input_has_combobox_role(self):
+        assert 'role="combobox"' in self.adresse_html
+
+    def test_visible_input_has_aria_controls_pointing_at_listbox(self):
+        assert 'aria-controls="' in self.adresse_html
+        assert '-listbox"' in self.adresse_html
+
+    def test_visible_input_starts_with_aria_expanded_false(self):
+        assert 'aria-expanded="false"' in self.adresse_html
+
+    def test_visible_input_declares_aria_activedescendant(self):
+        # The controller writes the focused option id into this attr on
+        # keyboard navigation; it must be present even when empty.
+        assert "aria-activedescendant" in self.adresse_html
+
+    def test_visible_input_advertises_inline_and_list_autocomplete(self):
+        assert 'aria-autocomplete="both"' in self.adresse_html
+
+    def test_results_ul_has_listbox_role(self):
+        assert 'role="listbox"' in self.adresse_html
+
+
+@pytest.mark.django_db
+class TestCarteAddressAutocompleteInputFormSerialization:
+    """Regression: the visible search input used to share its `name` with a
+    hidden sibling. The duplicate caused the form to submit two fields with
+    the same name; the hidden's empty value won, triggering a resubmit loop.
+
+    Now the visible input IS the form input (carries `name`), and the hidden
+    sibling is only rendered when display_value=False (homepage search)."""
+
+    def setup_method(self):
+        self.html = str(MapForm()["adresse"])
+
+    def test_visible_input_carries_the_form_name(self):
+        # `display_value=True` flips the widget to put `name` on the visible
+        # search box so the chosen label is what the form serializes.
+        # MapForm's prefix defaults to "map" when no map_container_id is set;
+        # the carte template passes "carte" → "carte_map". We assert on the
+        # bare-prefix render to stay decoupled from carte view wiring.
+        assert 'name="map-adresse"' in self.html
+
+    def test_no_hidden_sibling_input_is_rendered(self):
+        # The old structure rendered two inputs with the same name. The fix
+        # drops the hidden sibling when display_value is True.
+        assert 'type="hidden"' not in self.html
+        assert self.html.count('name="map-adresse"') == 1
+
+
+@pytest.mark.django_db
+class TestCarteAddressAutocompleteInputStimulusWiring:
+    """Carte-specific Stimulus attributes that bind the widget to the
+    `next-autocomplete` controller (combobox engine) and to the outer
+    `carte-address-autocomplete` controller (lat/lng + geolocation)."""
+
+    def setup_method(self):
+        form = MapForm()
+        self.adresse_html = str(form["adresse"])
+        self.latitude_html = str(form["latitude"])
+        self.longitude_html = str(form["longitude"])
+
+    def test_widget_mounts_next_autocomplete_controller(self):
+        assert 'data-controller="next-autocomplete"' in self.adresse_html
+
+    def test_visible_input_targets_next_autocomplete(self):
+        assert 'data-next-autocomplete-target="input"' in self.adresse_html
+
+    def test_visible_input_targets_outer_carte_controller(self):
+        # The outer wrapper mounts `carte-address-autocomplete`; the visible
+        # input is also a target of that controller so it can populate the
+        # input on geolocation success / reset on error.
+        assert 'data-carte-address-autocomplete-target="input"' in self.adresse_html
+
+    def test_show_on_focus_is_enabled(self):
+        assert 'data-next-autocomplete-show-on-focus-value="true"' in self.adresse_html
+
+    def test_endpoint_url_points_at_namespaced_view(self):
+        assert (
+            'data-next-autocomplete-endpoint-url-value="/qfdmo/autocomplete/address"'
+            in self.adresse_html
+        )
+
+    def test_latitude_hidden_input_targets_carte_controller(self):
+        assert 'data-carte-address-autocomplete-target="latitude"' in self.latitude_html
+
+    def test_longitude_hidden_input_targets_carte_controller(self):
+        assert (
+            'data-carte-address-autocomplete-target="longitude"' in self.longitude_html
+        )
+
+    def test_no_legacy_address_autocomplete_target_on_lat_lng(self):
+        # Before the migration, lat/lng were targets of the legacy
+        # address-autocomplete controller. They must point at the new one.
+        assert "data-address-autocomplete-target" not in self.latitude_html
+        assert "data-address-autocomplete-target" not in self.longitude_html

--- a/webapp/unit_tests/qfdmo/test_carte_address_widget.py
+++ b/webapp/unit_tests/qfdmo/test_carte_address_widget.py
@@ -42,8 +42,13 @@ class TestCarteAddressAutocompleteInputRendering:
         # keyboard navigation; it must be present even when empty.
         assert "aria-activedescendant" in self.adresse_html
 
-    def test_visible_input_advertises_inline_and_list_autocomplete(self):
-        assert 'aria-autocomplete="both"' in self.adresse_html
+    def test_visible_input_advertises_list_autocomplete(self):
+        # APG combobox-autocomplete-list: aria-autocomplete is "list"
+        # (we surface suggestions in the listbox but do NOT inline-complete
+        # the typed text — `"both"` would lie to assistive tech).
+        assert 'aria-autocomplete="list"' in self.adresse_html
+        # Explicitly assert the old value isn't there to flag regressions.
+        assert 'aria-autocomplete="both"' not in self.adresse_html
 
     def test_results_ul_has_listbox_role(self):
         assert 'role="listbox"' in self.adresse_html


### PR DESCRIPTION
# Description succincte du problème résolu

Le champ « Adresse » de la carte ne respectait pas le pattern combobox du RGAA : suggestions non annoncées au lecteur d'écran, navigation clavier incomplète, absence d'attributs ARIA...

**🗺️ contexte**: Accessibilité RGAA

**💡 quoi**: 
- Combobox autocomplete ARIA pour le champ adresse de la carte 
- proxy serveur de l'API BAN (geopf)
- dépréciation des anciens autocomplete (utilisés uniquement pour le formulaire)

**🎯 pourquoi**: 
Conformité au pattern W3C APG `combobox-autocomplete-list` et levée d'une remontée bloquant la conformité RGAA


**🤔 comment**:
- Vue `AutocompleteBanAddressView` qui proxy `data.geopf.fr/geocodage/search/` et rend les options en Turbo Frame
- mise en cache nginx
- Contrôleur Stimulus `carte_address_autocomplete_controller.ts` (gestion clavier, ARIA `aria-activedescendant`, `aria-expanded`, `role=\"listbox\"` / `role=\"option\"`)

**🤓 comment tester**:
1. Ouvrir la carte, focus sur le champ adresse
2. Taper moins de 3 caractères : seule l'option « Autour de moi » apparaît
3. Taper une adresse : suggestions BAN listées sous l'option de géolocalisation
4. Vérifier la navigation clavier (flèches, Entrée, Échap) et l'annonce VoiceOver/NVDA

## Auto-review

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [x] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] Pas de nouvelle variable d'environnement
- [ ] Pas de nouvelle dépendance
