### PR TITLE
Ajout du filtre des suggestion groupe quand il a un suggestion unitaire sur un champ donné

### DIFF
--- a/webapp/data/admin.py
+++ b/webapp/data/admin.py
@@ -13,10 +13,11 @@ from data.views import get_context_from_suggestion_groupe
 from django.contrib import admin, messages
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
-from django.db.models import QuerySet
+from django.db.models import Exists, OuterRef, Q, QuerySet
 from django.template.loader import render_to_string
 from django.utils.html import format_html, mark_safe
 from djangoql.admin import DjangoQLSearchMixin
+from djangoql.exceptions import DjangoQLSchemaError
 from djangoql.schema import BoolField, DjangoQLSchema, IntField, StrField
 
 NB_SUGGESTIONS_DISPLAYED_WHEN_DELETING = 100
@@ -309,6 +310,28 @@ def apply_suggestions_to_revision(self, request, queryset):
     )
 
 
+class HasSuggestionUnitaireWithChampField(StrField):
+    """Permet de filtrer par champ de suggestion unitaire individuel"""
+
+    name = "has_suggestion_unitaire_with_champ"
+    suggest_options = False
+
+    def get_lookup(self, path, operator, value):
+        if operator not in {"~", "!~"}:
+            raise DjangoQLSchemaError(
+                f'Field "{self.name}" only supports "~" and "!~" operators'
+            )
+
+        has_matching_suggestion_unitaire = Exists(
+            SuggestionUnitaire.objects.filter(
+                suggestion_groupe_id=OuterRef("pk"),
+                champs__icontains=value,
+            )
+        )
+        q = Q(has_matching_suggestion_unitaire)
+        return ~q if operator == "!~" else q
+
+
 @admin.register(SuggestionGroupe)
 class SuggestionGroupeAdmin(
     DjangoQLSearchMixin, NotEditableMixin, NotSelfDeletableMixin
@@ -336,7 +359,7 @@ class SuggestionGroupeAdmin(
                     IntField(name="suggestion_unitaires_count"),
                     BoolField(name="has_parent"),
                     BoolField(name="has_correction"),
-                ]
+                ] + [HasSuggestionUnitaireWithChampField()]
 
             return fields
 

--- a/webapp/data/models/suggestions/abstract.py
+++ b/webapp/data/models/suggestions/abstract.py
@@ -143,7 +143,6 @@ class SuggestionGroupeType(BaseModel):
     ) -> list[LinkInCell]:
         links = []
 
-        print(field_group, source_valeurs, target_valeurs)
         for champ, source_valeur, target_valeur in zip(
             field_group, source_valeurs, target_valeurs
         ):

--- a/webapp/unit_tests/data/test_admin_actions.py
+++ b/webapp/unit_tests/data/test_admin_actions.py
@@ -1,5 +1,6 @@
 import pytest
 from data.admin import (
+    HasSuggestionUnitaireWithChampField,
     SuggestionGroupeAdmin,
     apply_suggestions_to_parent,
     apply_suggestions_to_revision,
@@ -9,6 +10,7 @@ from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.test import RequestFactory
+from djangoql.exceptions import DjangoQLSchemaError
 from unit_tests.data.models.suggestion_factory import (
     SuggestionGroupeFactory,
     SuggestionUnitaireFactory,
@@ -461,3 +463,70 @@ class TestSuggestionGroupeAdminBooleanFilters:
 
         assert has_parent_ids == {group_with_parent.id}
         assert has_correction_ids == {group_with_correction.id}
+
+
+@pytest.mark.django_db
+class TestHasSuggestionUnitaireWithChampField:
+    def test_contains_operator_matches_partial_champ(self):
+        matching_group = SuggestionGroupeFactory()
+        non_matching_group = SuggestionGroupeFactory()
+
+        SuggestionUnitaireFactory(
+            suggestion_groupe=matching_group,
+            champs=["nom", "telephone"],
+            valeurs=["Nom", "0123456789"],
+        )
+        SuggestionUnitaireFactory(
+            suggestion_groupe=matching_group,
+            champs=["field"],
+            valeurs=["fake"],
+        )
+        SuggestionUnitaireFactory(
+            suggestion_groupe=non_matching_group,
+            champs=["adresse"],
+            valeurs=["1 rue de Paris"],
+        )
+
+        lookup = HasSuggestionUnitaireWithChampField().get_lookup([], "~", "tele")
+
+        result_ids = set(
+            SuggestionGroupe.objects.filter(lookup).values_list("id", flat=True)
+        )
+
+        assert result_ids == {matching_group.id}
+
+    def test_does_not_contain_operator_excludes_groups_with_any_matching_unitaire(
+        self,
+    ):
+        matching_group = SuggestionGroupeFactory()
+        non_matching_group = SuggestionGroupeFactory()
+
+        SuggestionUnitaireFactory(
+            suggestion_groupe=matching_group,
+            champs=["nom", "telephone"],
+            valeurs=["Nom", "0123456789"],
+        )
+        SuggestionUnitaireFactory(
+            suggestion_groupe=matching_group,
+            champs=["field"],
+            valeurs=["fake"],
+        )
+        SuggestionUnitaireFactory(
+            suggestion_groupe=non_matching_group,
+            champs=["adresse"],
+            valeurs=["1 rue de Paris"],
+        )
+
+        lookup = HasSuggestionUnitaireWithChampField().get_lookup([], "!~", "tele")
+
+        result_ids = set(
+            SuggestionGroupe.objects.filter(lookup).values_list("id", flat=True)
+        )
+
+        assert result_ids == {non_matching_group.id}
+
+    def test_only_contains_operators_are_allowed(self):
+        with pytest.raises(
+            DjangoQLSchemaError, match='only supports "~" and "!~" operators'
+        ):
+            HasSuggestionUnitaireWithChampField().get_lookup([], "=", "nom")


### PR DESCRIPTION

# Description succincte du problème résolu

Demande de Christian sur Mattermost
la recherche avancé avec Djangoql ne permet pas nativement de rechercher toutes les suggestion_groupe qui ont au moins une suggestion unitaire concernant plusieurs champs donnés

Exemple : on veut les suggestion_groupe qui modifie en même temps la`lieu_prestation` et le `public_accueilli`

**🗺️ contexte**: Django admin - SuggestionGroupe

**💡 quoi**: ajout du champ de recherche `has_suggestion_unitaire_with_champ`

**🎯 pourquoi**: permettre de cherche les SuggestionGroupe qui on des modifications sur plusieurs champs

**🤔 comment**: Création d'un nouveau champ de recherche

**🤓 comment tester**: 

- executer `make db-restore-local-from-prod`
- dans django admin > SuggestionGroupe
- rechercher : 
```
has_suggestion_unitaire_with_champ ~ "lieu_prestation" and has_suggestion_unitaire_with_champ ~ "public_accueilli" and suggestion_unitaires_count = 2
```


## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [x] J'ai ajouté des tests qui couvrent le nouveau code

