### PR TITLE
Ajout de filtre has_correction

### DIFF
--- a/webapp/data/admin.py
+++ b/webapp/data/admin.py
@@ -301,7 +301,7 @@ def apply_suggestions_to_parent(
 def apply_suggestions_to_revision(self, request, queryset):
     for suggestion_groupe in queryset:
         # Only for SuggestionGroupe with parent
-        if suggestion_groupe.suggestion_acteur_has_revision():
+        if suggestion_groupe.suggestion_acteur_has_correction():
             _update_or_copy_suggestion_unitaires(suggestion_groupe)
 
     self.message_user(
@@ -335,6 +335,7 @@ class SuggestionGroupeAdmin(
                     ],
                     IntField(name="suggestion_unitaires_count"),
                     BoolField(name="has_parent"),
+                    BoolField(name="has_correction"),
                 ]
 
             return fields
@@ -372,6 +373,7 @@ class SuggestionGroupeAdmin(
             )
             .with_suggestion_unitaire_count()
             .with_has_parent()
+            .with_has_correction()
         )
 
     def groupe_de_suggestions(self, obj):

--- a/webapp/data/models/suggestion.py
+++ b/webapp/data/models/suggestion.py
@@ -424,6 +424,15 @@ class SuggestionGroupeQuerySet(models.QuerySet):
             )
         )
 
+    def with_has_correction(self):
+        """Annotate queryset with has_correction."""
+        return self.annotate(
+            has_correction=ExpressionWrapper(
+                Q(revision_acteur_id__isnull=False),
+                output_field=BooleanField(),
+            )
+        )
+
 
 class SuggestionGroupeManager(models.Manager):
     def get_queryset(self):
@@ -434,6 +443,9 @@ class SuggestionGroupeManager(models.Manager):
 
     def with_has_parent(self):
         return self.get_queryset().with_has_parent()
+
+    def with_has_correction(self):
+        return self.get_queryset().with_has_correction()
 
 
 class _HasOptionalActeurFks(Protocol):
@@ -584,7 +596,7 @@ class SuggestionGroupe(TimestampedModel, SuggestionActeurRelationsMixin):
             and self.acteur_id != self.revision_acteur_id
         )
 
-    def suggestion_acteur_has_revision(self) -> bool:
+    def suggestion_acteur_has_correction(self) -> bool:
         return (
             self.revision_acteur_id is not None
             and self.acteur_id == self.revision_acteur_id

--- a/webapp/unit_tests/data/models/test_suggestion.py
+++ b/webapp/unit_tests/data/models/test_suggestion.py
@@ -1,5 +1,4 @@
 import pytest
-
 from data.models.suggestion import SuggestionAction, SuggestionCohorte, SuggestionGroupe
 from unit_tests.data.models.suggestion_factory import (
     SuggestionCohorteFactory,
@@ -128,19 +127,21 @@ class TestSuggestionGroupeSuggestionActeurHasParent:
 
 @pytest.mark.django_db
 class TestSuggestionGroupeSuggestionActeurHasRevision:
-    def test_suggestion_acteur_has_revision_returns_false_when_no_revision_acteur(self):
+    def test_suggestion_acteur_has_correction_returns_false_when_no_revision_acteur(
+        self,
+    ):
         """
-        Test that suggestion_acteur_has_revision returns False
+        Test that suggestion_acteur_has_correction returns False
         when revision_acteur_id is None
         """
         acteur = ActeurFactory()
         groupe = SuggestionGroupeFactory(acteur=acteur)
 
-        assert groupe.suggestion_acteur_has_revision() is False
+        assert groupe.suggestion_acteur_has_correction() is False
 
-    def test_suggestion_acteur_has_revision_returns_true_when_same_ids(self):
+    def test_suggestion_acteur_has_correction_returns_true_when_same_ids(self):
         """
-        Test that suggestion_acteur_has_revision returns True
+        Test that suggestion_acteur_has_correction returns True
         when acteur_id == revision_acteur_id
         """
         acteur = ActeurFactory()
@@ -154,11 +155,11 @@ class TestSuggestionGroupeSuggestionActeurHasRevision:
 
         # Verify that the IDs are different
         assert groupe.acteur_id == groupe.revision_acteur_id
-        assert groupe.suggestion_acteur_has_revision() is True
+        assert groupe.suggestion_acteur_has_correction() is True
 
-    def test_suggestion_acteur_has_revision_returns_false_when_different_ids(self):
+    def test_suggestion_acteur_has_correction_returns_false_when_different_ids(self):
         """
-        Test that suggestion_acteur_has_revision returns False
+        Test that suggestion_acteur_has_correction returns False
         when acteur_id != revision_acteur_id
         """
         acteur = ActeurFactory()
@@ -170,7 +171,7 @@ class TestSuggestionGroupeSuggestionActeurHasRevision:
 
         # Verify that the IDs are different
         assert groupe.acteur_id != groupe.revision_acteur_id
-        assert groupe.suggestion_acteur_has_revision() is False
+        assert groupe.suggestion_acteur_has_correction() is False
 
 
 @pytest.mark.django_db

--- a/webapp/unit_tests/data/test_admin_actions.py
+++ b/webapp/unit_tests/data/test_admin_actions.py
@@ -1,15 +1,14 @@
 import pytest
-from django.contrib.admin.sites import AdminSite
-from django.contrib.auth.models import AnonymousUser
-from django.contrib.messages.storage.fallback import FallbackStorage
-from django.test import RequestFactory
-
 from data.admin import (
     SuggestionGroupeAdmin,
     apply_suggestions_to_parent,
     apply_suggestions_to_revision,
 )
 from data.models.suggestion import SuggestionGroupe
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth.models import AnonymousUser
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.test import RequestFactory
 from unit_tests.data.models.suggestion_factory import (
     SuggestionGroupeFactory,
     SuggestionUnitaireFactory,
@@ -421,3 +420,44 @@ class TestApplySuggestionsToRevision:
             ).count()
             == 0
         )
+
+
+@pytest.mark.django_db
+class TestSuggestionGroupeAdminBooleanFilters:
+    def test_schema_exposes_has_parent_and_has_correction_fields(self, admin_instance):
+        schema = admin_instance.djangoql_schema(SuggestionGroupe)
+
+        field_names = [
+            field if isinstance(field, str) else field.name
+            for field in schema.get_fields(SuggestionGroupe)
+        ]
+
+        assert "has_parent" in field_names
+        assert "has_correction" in field_names
+
+    def test_get_queryset_annotates_has_parent_and_has_correction(
+        self, admin_instance, mock_request
+    ):
+        group_with_parent = SuggestionGroupeFactory(
+            acteur=ActeurFactory(),
+            parent_revision_acteur=RevisionActeurFactory(),
+        )
+        group_with_correction = SuggestionGroupeFactory(
+            acteur=ActeurFactory(),
+            revision_acteur=RevisionActeurFactory(),
+        )
+        SuggestionGroupeFactory(
+            acteur=ActeurFactory(),
+        )
+
+        queryset = admin_instance.get_queryset(mock_request)
+
+        has_parent_ids = set(
+            queryset.filter(has_parent=True).values_list("id", flat=True)
+        )
+        has_correction_ids = set(
+            queryset.filter(has_correction=True).values_list("id", flat=True)
+        )
+
+        assert has_parent_ids == {group_with_parent.id}
+        assert has_correction_ids == {group_with_correction.id}


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [[Diff v3] “has_parent = FALSE” fonctionne mais pas “has_correction = FALSE”](https://www.notion.so/accelerateur-transition-ecologique-ademe/Diff-v3-has_parent-FALSE-fonctionne-mais-pas-has_correction-FALSE-3516523d57d7804a90c6cf956f39db53?v=7fa49e1bda7e4f8baed5d646aef65fbe&source=copy_link)

**🗺️ contexte**: django admin - suggestion groupe

**💡 quoi**: Ajout du filtre `has_correction` pour afficher les suggestion qui concernent des acteurs avec des corrections

**🎯 pourquoi**: simplifier la gestion par Christian

**🤔 comment**: ajout du filtre dans Djangoql, utilisable dans la barre de recherche

**🤓 comment tester**: 

dans django admin > suggeston groupe
- rechercher avec le filtre `has_correction = True` -> les acteurs concernés par les modifications ont une correction (RevisionActeur)
- rechercher avec le filtre `has_correction = False` -> les acteurs concernés par les modifications n'ont pas de correction

Ne marche que pour les suggestion attaché à un acteur : Suggestion de type "Source"


## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [x] J'ai ajouté des tests qui couvrent le nouveau code
