### PR TITLE
SuggestionGroupe: ne pas remplacer la valeur éditée

### DIFF
--- a/webapp/data/models/suggestions/source.py
+++ b/webapp/data/models/suggestions/source.py
@@ -548,15 +548,15 @@ class SuggestionGroupeTypeSource(SuggestionGroupeType):
 
     def _revision_replace_text(self, field: str) -> str:
         return (
-            getattr(self.revision_acteur_suggestions, field, None)
-            or getattr(self.acteur_suggestions, field, None)
+            getattr(self.revision_acteur_suggestions, field)
+            or getattr(self.revision_acteur_values, field)
             or ""
         )
 
     def _parent_replace_text(self, field: str) -> str:
         return (
-            getattr(self.parent_revision_acteur_suggestions, field, None)
-            or getattr(self.acteur_suggestions, field, None)
+            getattr(self.parent_revision_acteur_suggestions, field)
+            or getattr(self.parent_revision_acteur_values, field)
             or ""
         )
 


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [[Diff v3] Cliquer sur une valeur de la colonne Parent ne devrait pas faire la même chose que cliquer sur les flèches de propagation](https://www.notion.so/accelerateur-transition-ecologique-ademe/Diff-v3-Cliquer-sur-une-valeur-de-la-colonne-Parent-ne-devrait-pas-faire-la-m-me-chose-que-cliquer--32f6523d57d7807ba77dcbf42521a3b5?v=7fa49e1bda7e4f8baed5d646aef65fbe&source=copy_link)

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Dajngo admin > Suggestion Groupe

**💡 quoi**: Quand on édite un champ d'une suggestion, on ne doit pas remplacer la valeur existante par la valeur suggéré au niveau Acteur

**🎯 pourquoi**: Demande de Christian, ne n'est pas pratique car la valeur disparait et on ne peut pas la copier pour la vérifier
pour reporter la valeur, on a déjà les boutons de report de modification

**🤔 comment**: Edition de la valeur de remplacement pour la lire à partir des objets de correction et parent pour ne pas remplacer avec la valeur de suggestion acteur

**🤓 comment tester**: 

Dans django admin > Suggestion groupe
Filtrer par `has_parent = True`
editer des champs, la valeur à éditer est celle de l'objet ou de sa correction

## Exemple résultats / UI / Data

<img width="800" height="330" alt="CleanShot 2026-05-11 at 15 29 09" src="https://github.com/user-attachments/assets/b6d87d1e-e549-429c-86ce-f111d74defb9" />

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
