### PR TITLE
Correction de tests e2e

### DIFF
--- a/webapp/e2e_tests/analytics.spec.ts
+++ b/webapp/e2e_tests/analytics.spec.ts
@@ -252,6 +252,11 @@ test.describe("📊 Analytics & Tracking", () => {
         page,
       }, testInfo) => {
         testInfo.setTimeout(90000)
+        // Carte iframe has no same-origin <a href> at idle (Infos modal was
+        // removed in c8d4b728). Search to surface pinpoint /adresse_details links.
+        if (label === "carte") {
+          await mockApiAdresse(page)
+        }
         await navigateTo(page, TEST_PATH)
 
         const iframeEl = page.locator(`[data-testid="${testId}"] iframe`).first()
@@ -261,6 +266,14 @@ test.describe("📊 Analytics & Tracking", () => {
         await resolvedFrame.waitForLoadState("domcontentloaded", {
           timeout: TIMEOUT.LONG,
         })
+
+        if (label === "carte") {
+          const carteFrame = page
+            .locator(`[data-testid="${testId}"] iframe`)
+            .first()
+            .contentFrame()
+          await searchCarteAndWaitForActeurs(page, "Auray", carteFrame)
+        }
 
         // Wait until at least one internal link exists in the iframe
         await expect(resolvedFrame.locator("a[href]").first()).toBeAttached({

--- a/webapp/e2e_tests/carte.spec.ts
+++ b/webapp/e2e_tests/carte.spec.ts
@@ -187,7 +187,7 @@ test.describe("🗺️ Affichage des Labels dans la Fiche Acteur", () => {
     const acteurDetailLabels = iframe.locator(
       "#acteurDetailsPanel [data-testid='acteur-detail-labels']",
     )
-    await expect(acteurDetailLabels).toContainText("économie sociale et solidaire", {
+    await expect(acteurDetailLabels).toContainText(/économie sociale et solidaire/i, {
       timeout: TIMEOUT.SHORT,
     })
   })
@@ -680,8 +680,9 @@ test.describe("🗺️ Mini Carte - Affichage des Pinpoints", () => {
     // Desktop map mode: simulate a pinpoint click (no with_map param).
     // Mini map must stay hidden because the big map remains visible
     // alongside the detail panel.
-    const hrefWithoutMap = href!.replace(/[?&]with_map=1/g, "")
-    await navigateTo(page, hrefWithoutMap)
+    const urlWithoutMap = new URL(href!, page.url())
+    urlWithoutMap.searchParams.delete("with_map")
+    await navigateTo(page, urlWithoutMap.toString())
 
     await expect(page.locator('[data-testid="acteur-detail-about-panel"]')).toBeVisible(
       {

--- a/webapp/e2e_tests/mode_liste.spec.ts
+++ b/webapp/e2e_tests/mode_liste.spec.ts
@@ -13,6 +13,7 @@ import {
 
 test.describe("Mode liste", () => {
   test("Le mode liste affiche la distance", async ({ page }) => {
+    await mockApiAdresse(page)
     await navigateTo(page, "/carte")
 
     await searchCarteAndWaitForActeurs(page, "auray")


### PR DESCRIPTION
# Description succincte du problème résolu

Quatre tests e2e échouent en CI

**🗺️ contexte**: Régression e2e détectée sur la branche `accessibilite-rgaa-bloquant-combobox` (#2793).
Les 4 échecs préexistent et n'ont aucun lien avec la modif de la PR, je les fix ici

**💡 quoi**: Corrige 4 tests e2e :

voir commentaires dans l'onglet files changes 

**🎯 pourquoi**: Débloquer la CI de #2793 et stabiliser ces 4 tests à isoler du périmètre accessibilité champ adresse.

**🤓 comment tester**:

vérifier que la CI passe

## Auto-review

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [x] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template` (N/A)
- [x] J'ai ajouté des tests qui couvrent le nouveau code (N/A — c'est de la correction de tests)
- [x] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours (N/A)

