### PR TITLE
Ré-appliquer les splits par fuzzy et par distance après le traitement intra-source

### DIFF
--- a/data-platform/dags/cluster/tasks/business_logic/cluster_acteurs_clusters.py
+++ b/data-platform/dags/cluster/tasks/business_logic/cluster_acteurs_clusters.py
@@ -19,6 +19,8 @@ import pandas as pd
 from cluster.tasks.business_logic.misc.cluster_exclude_intra_source import (
     split_clusters_infra_source,
 )
+from scipy.sparse import csr_matrix, triu
+from scipy.sparse.csgraph import connected_components
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 from slugify import slugify
@@ -41,14 +43,13 @@ def cluster_id_from_strings(strings: list[str]) -> str:
     return "_".join(str(slugify(unidecode(str(x)))).lower() for x in strings)
 
 
-def values_to_similarity_matrix(values: list[str]) -> np.ndarray:
-    """Compute similarity matrix using TF-IDF vectorization
-    on a list of values."""
+def values_to_similarity_matrix_sparse(values: list[str]) -> csr_matrix:
+    """Compute a sparse similarity matrix using TF-IDF vectorization."""
     vectorizer = TfidfVectorizer(
         tokenizer=str.split, binary=False, token_pattern=None  # type: ignore
     )  # type: ignore
     tfidf_matrix = vectorizer.fit_transform(values)
-    return cosine_similarity(tfidf_matrix)
+    return cosine_similarity(tfidf_matrix, dense_output=False).tocsr()
 
 
 def score_normalize(score: np.float64, precision=5) -> int | float:
@@ -62,66 +63,71 @@ def score_normalize(score: np.float64, precision=5) -> int | float:
     return round(float(score), precision)
 
 
-def similarity_matrix_to_tuples(
-    similarity_matrix,
-    indexes: list | None = None,
-) -> list[tuple[int, int, float]]:
-    """Convertit une matrice de similarité
-    en une liste de tuples (index_a, index_b, score)
-    Optionnel: on peut passer une liste d'indexes à
-    mapper avec la matrix, par exemple pour mapper des indexes
-    à des identifiants, des indexes non contigus, etc.
-    """
-    indices = np.triu_indices_from(similarity_matrix, k=1)
-    tuples = [
-        (int(i), int(j), score_normalize(similarity_matrix[i, j]))
-        for i, j in zip(*indices)
-    ]
-    tuples.sort(key=lambda x: x[2], reverse=True)
-    if indexes:
-        tuples = [(indexes[i], indexes[j], score) for i, j, score in tuples]
-    return tuples
-
-
-def score_tuples_to_clusters(
-    tuples: list[tuple[int, int, float]], threshold
+def sparse_similarity_matrix_to_clusters(
+    similarity_matrix: csr_matrix,
+    indexes: list[int],
+    threshold: float,
 ) -> list[list[int]]:
-    """Convert tuples (index_a, index_b, score) into clusters if score >= threshold"""
+    """Convert a sparse similarity matrix into clusters above a threshold."""
+    if len(indexes) < 2:
+        return []
 
-    # We should discard empty clusters and never find ourselves here
-    if not tuples:
-        raise ValueError("Liste de tuples d'entrée vide, on ne devrait pas être ici")
+    # With TF-IDF cosine similarity, scores are always in [0, 1].
+    # threshold <= 0 therefore means a fully connected graph.
+    if threshold <= 0:
+        return [indexes]
 
-    # Sorting to work on most to least similar
-    tuples.sort(key=lambda x: x[2], reverse=True)
+    # keep half of the matrix (upper triangle)
+    similarity_upper = triu(similarity_matrix, k=1, format="csr")
+    # keep only the non-zero values
+    rows, cols = similarity_upper.nonzero()
+    # normalize the scores to be in [0, 1]
+    normalized_scores = np.where(
+        similarity_upper.data >= 1,
+        1.0,
+        np.round(similarity_upper.data.astype(float), 5),
+    )
+    # create a mask to keep only the values >= threshold as boolean
+    mask = normalized_scores >= threshold
+    if not mask.any():
+        return []
 
-    clusters = []
-    for index_a, index_b, score in tuples:
-        # Being sorted, we know we can exist if below threshold
-        if score < threshold:
-            break
+    # keep only the values >= threshold for rows and cols and scores
+    rows = rows[mask]
+    cols = cols[mask]
+    scores = normalized_scores[mask]
 
-        # On cherche si index_a ou index_b sont déjà dans un cluster
-        cluster_a = next((c for c in clusters if index_a in c), None)
-        cluster_b = next((c for c in clusters if index_b in c), None)
+    # create matrix with only the rows and cols with values >= threshold
+    adjacency = csr_matrix(
+        (np.ones(len(rows), dtype=np.int8), (rows, cols)),
+        shape=similarity_upper.shape,
+    )
+    adjacency = adjacency + adjacency.T
 
-        # a and b are in the same cluster = merge
-        if cluster_a and cluster_b:
-            if cluster_a != cluster_b:
-                # Merge the clusters if they are different
-                cluster_a.update(cluster_b)
-                clusters.remove(cluster_b)
-        # a already in a cluster, add b to it
-        elif cluster_a:
-            cluster_a.add(index_b)
-        # b already in a cluster, add a to it
-        elif cluster_b:
-            cluster_b.add(index_a)
-        else:
-            # a and b are not in any cluster, create a new one
-            clusters.append(set([index_a, index_b]))
+    # find connected components, create the clusters,
+    # if A is linked to B
+    # and if A is linked to C
+    # then A, B and C are in the same cluster
+    _, labels = connected_components(adjacency, directed=False, return_labels=True)
 
-    return [list(cluster) for cluster in clusters]
+    # convert the labels to indexes
+    clusters_by_label: dict[int, list[int]] = {}
+    for local_index, label in enumerate(labels):
+        clusters_by_label.setdefault(int(label), []).append(indexes[local_index])
+
+    component_order: list[int] = []
+    labels_seen: set[int] = set()
+    for edge_index in np.argsort(-scores, kind="stable"):
+        label = int(labels[rows[edge_index]])
+        if label not in labels_seen:
+            labels_seen.add(label)
+            component_order.append(label)
+
+    return [
+        clusters_by_label[label]
+        for label in component_order
+        if len(clusters_by_label[label]) > 1
+    ]
 
 
 def cluster_to_subclusters(
@@ -133,10 +139,8 @@ def cluster_to_subclusters(
     """Split 1 cluster into subclusters based on a column matching threshold"""
     df_cluster = df.loc[cluster]
     column_values = df_cluster[column].astype(str).values
-    similarity_matrix = values_to_similarity_matrix(column_values)  # type: ignore
-    tuples = similarity_matrix_to_tuples(similarity_matrix, indexes=cluster)
-    sub_clusters = score_tuples_to_clusters(tuples, threshold)
-    return sub_clusters
+    similarity_matrix = values_to_similarity_matrix_sparse(column_values.tolist())
+    return sparse_similarity_matrix_to_clusters(similarity_matrix, cluster, threshold)
 
 
 def haversine(lon1: float, lat1: float, lon2: float, lat2: float) -> float:
@@ -254,6 +258,71 @@ def cluster_cols_group_fuzzy(
     return result_dfs
 
 
+def _groups_with_revalidation_keys(
+    keys: list[str], subclusters: list[pd.DataFrame], step_name: str
+) -> list[tuple[list[str], pd.DataFrame]]:
+    """Keep the original keys when a split keeps a single cluster.
+
+    If the split creates several valid subclusters, append a suffix to keep
+    generated cluster ids unique.
+    """
+
+    if not subclusters:
+        return []
+    if len(subclusters) == 1:
+        return [(keys, subclusters[0])]
+    return [
+        (keys + [step_name, str(i + 1)], rows) for i, rows in enumerate(subclusters)
+    ]
+
+
+def revalidate_groups_after_intra_source_split(
+    groups: list[tuple[list[str], pd.DataFrame]],
+    cluster_fields_fuzzy: list[str],
+    cluster_fuzzy_threshold: float,
+    distance_in_cluster: int,
+) -> list[tuple[list[str], pd.DataFrame]]:
+    """Re-apply clustering constraints after intra-source splitting.
+
+    The intra-source split is source-based only and can create subsets that no
+    longer satisfy the original fuzzy or distance constraints.
+    """
+
+    if not cluster_fields_fuzzy and distance_in_cluster <= 0:
+        return groups
+
+    revalidated_groups = []
+    for keys, rows in groups:
+        groups_after_fuzzy = [(keys, rows)]
+        if cluster_fields_fuzzy:
+            subclusters_fuzzy = cluster_cols_group_fuzzy(
+                df_src=rows,
+                columns_fuzzy=cluster_fields_fuzzy,
+                threshold=cluster_fuzzy_threshold,
+            )
+            groups_after_fuzzy = _groups_with_revalidation_keys(
+                keys, subclusters_fuzzy, "fuzzy_recheck"
+            )
+
+        groups_after_distance = groups_after_fuzzy
+        if distance_in_cluster > 0:
+            groups_after_distance = []
+            for fuzzy_keys, fuzzy_rows in groups_after_fuzzy:
+                subclusters_distance = split_clusters_by_distance(
+                    df_src=fuzzy_rows,
+                    distance_threshold=distance_in_cluster,
+                )
+                groups_after_distance.extend(
+                    _groups_with_revalidation_keys(
+                        fuzzy_keys, subclusters_distance, "distance_recheck"
+                    )
+                )
+
+        revalidated_groups.extend(groups_after_distance)
+
+    return revalidated_groups
+
+
 def cluster_acteurs_clusters(
     df: pd.DataFrame,
     cluster_fields_exact: list[str] = [],
@@ -360,6 +429,12 @@ def cluster_acteurs_clusters(
     if not cluster_intra_source_is_allowed:
         groups_after_distance_match = split_clusters_infra_source(
             groups_after_distance_match
+        )
+        groups_after_distance_match = revalidate_groups_after_intra_source_split(
+            groups=groups_after_distance_match,
+            cluster_fields_fuzzy=cluster_fields_fuzzy,
+            cluster_fuzzy_threshold=cluster_fuzzy_threshold,
+            distance_in_cluster=distance_in_cluster,
         )
 
     logger.warning(

--- a/data-platform/dags/tests/cluster/tasks/business_logic/test_cluster_acteurs_clusters.py
+++ b/data-platform/dags/tests/cluster/tasks/business_logic/test_cluster_acteurs_clusters.py
@@ -1,11 +1,9 @@
-import numpy as np
 import pandas as pd
 import pytest
 from cluster.tasks.business_logic.cluster_acteurs_clusters import (
     cluster_acteurs_clusters,
     cluster_cols_group_fuzzy,
-    score_tuples_to_clusters,
-    similarity_matrix_to_tuples,
+    cluster_to_subclusters,
     split_clusters_by_distance,
 )
 
@@ -414,79 +412,6 @@ class TestClusterColsGroupFuzzy:
         assert len(clusters) == 0
 
 
-class TestSimilarityMatrixToTuples:
-
-    def test_basic(self):
-
-        matrix = np.array([[1, 0.8, 0.4], [0.8, 1, 0.9], [0.4, 0.9, 1]])
-        expected = [
-            (1, 2, 0.9),
-            (0, 1, 0.8),
-            (0, 2, 0.4),
-        ]
-        assert similarity_matrix_to_tuples(matrix) == expected
-
-    def test_index_replacements(self):
-
-        matrix = np.array([[1, 0.8, 0.4], [0.8, 1, 0.9], [0.4, 0.9, 1]])
-        expected = [
-            ("b", "c", 0.9),
-            ("a", "b", 0.8),
-            ("a", "c", 0.4),
-        ]
-        assert similarity_matrix_to_tuples(matrix, indexes=["a", "b", "c"]) == expected
-
-
-class TestScoreTuplesToClusters:
-
-    # Test cases
-    def test_score_tuples_to_clusters(self):
-        data = [
-            (1, 2, 0.6),
-            (2, 3, 0.6),
-            (4, 5, 0.6),
-            (5, 6, 0.3),  # ignored because it is below the threshold
-        ]
-        threshold = 0.5
-        expected = [[1, 2, 3], [4, 5]]
-        assert score_tuples_to_clusters(data, threshold) == expected
-
-    def test_score_tuples_to_clusters_applies_sorting(self):
-        """Check that clusters are sorted by decreasing score.
-
-        This should hold even if the input data is not sorted.
-        """
-        data = [
-            (5, 6, 0.3),
-            (1, 2, 0.6),
-            (2, 3, 0.6),
-            (4, 5, 0.6),
-        ]
-        threshold = 0.5
-        expected = [[1, 2, 3], [4, 5]]
-        assert score_tuples_to_clusters(data, threshold) == expected
-
-    def test_score_tuples_to_clusters_empty_exception(self):
-
-        data = []
-        threshold = 0.5
-        with pytest.raises(ValueError, match="Liste de tuples d'entrée vide"):
-            score_tuples_to_clusters(data, threshold)
-
-    def test_score_tuples_to_clusters_no_clusters_below_threshold(self):
-
-        data = [(1, 2, 0.3), (3, 4, 0.2)]
-        threshold = 0.5
-        assert score_tuples_to_clusters(data, threshold) == []
-
-    def test_score_tuples_to_clusters_all_in_one_cluster(self):
-
-        data = [(1, 2, 0.9), (2, 3, 0.8), (3, 4, 0.7)]
-        threshold = 0.5
-        expected = [[1, 2, 3, 4]]
-        assert score_tuples_to_clusters(data, threshold) == expected
-
-
 class TestClusterExcludeIntraSource:
 
     @pytest.fixture
@@ -540,6 +465,25 @@ class TestClusterExcludeIntraSource:
             cluster_intra_source_is_allowed=False,
         )
         assert df_clusters["cluster_id"].nunique() == 3
+
+    def test_cluster_split_clusterintra_source_revalidates_fuzzy_constraints(self):
+        df = pd.DataFrame(
+            {
+                "identifiant_unique": ["bridge", "left", "right"],
+                "source_codes": [["s1", "s2"], ["s2"], ["s1"]],
+                "nom": ["alpha beta", "alpha", "beta"],
+            }
+        )
+
+        df_clusters = cluster_acteurs_clusters(
+            df,
+            cluster_fields_exact=[],
+            cluster_fields_fuzzy=["nom"],
+            cluster_fuzzy_threshold=0.5,
+            cluster_intra_source_is_allowed=False,
+        )
+
+        assert df_clusters.empty
 
 
 class TestSplitClustersByDistance:
@@ -597,3 +541,65 @@ class TestSplitClustersByDistance:
         subclusters = split_clusters_by_distance(df_src=df, distance_threshold=15)
         assert len(subclusters) == 1
         assert sorted(subclusters[0]["identifiant_unique"].tolist()) == ["a", "b", "c"]
+
+
+class TestClusterToSubclusters:
+
+    def test_returns_only_non_singleton_subclusters(self):
+        df = pd.DataFrame(
+            {
+                "nom": [
+                    "maison du velo",
+                    "maison du velo",
+                    "repair cafe",
+                    "valeur unique",
+                ]
+            },
+            index=[10, 20, 30, 40],
+        )
+
+        subclusters = cluster_to_subclusters(
+            df=df,
+            column="nom",
+            cluster=[10, 20, 30, 40],
+            threshold=0.9,
+        )
+
+        assert subclusters == [[10, 20]]
+
+    def test_uses_only_rows_from_the_given_cluster(self):
+        df = pd.DataFrame(
+            {
+                "nom": [
+                    "alpha",
+                    "alpha",
+                    "beta",
+                    "beta",
+                ]
+            },
+            index=[100, 200, 300, 400],
+        )
+
+        subclusters = cluster_to_subclusters(
+            df=df,
+            column="nom",
+            cluster=[200, 300, 400],
+            threshold=0.9,
+        )
+
+        assert subclusters == [[300, 400]]
+
+    def test_threshold_zero_keeps_the_whole_cluster(self):
+        df = pd.DataFrame(
+            {"nom": ["alpha", "beta", "gamma"]},
+            index=[5, 7, 9],
+        )
+
+        subclusters = cluster_to_subclusters(
+            df=df,
+            column="nom",
+            cluster=[5, 7, 9],
+            threshold=0,
+        )
+
+        assert subclusters == [[5, 7, 9]]


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [[Clustering] Ne respecte pas mon critère de fuzzy match de 40%](https://www.notion.so/accelerateur-transition-ecologique-ademe/Clustering-Ne-respecte-pas-mon-crit-re-de-fuzzy-match-de-40-2cb6523d57d7807db12ad0ea86b73ec6?v=7fa49e1bda7e4f8baed5d646aef65fbe&source=copy_link)

**🗺️ contexte**: Airflow Clustering

**💡 quoi**: 

- Suppression du bruit : ne pas proposer des clusters qui ne respecte pas le critère de fuzzymatch ou de distance
- Optimisation : la gestion des cluster fuzzy est amélioré avec `sparce`

**🎯 pourquoi**: <!-- pourquoi on fait ce changement -->

### Suppression du bruit

Certaines proposition demeurait obscure car le fuzzy match présenté ne semblait pas être appliqué, cela venait du split des clusters quand on interdit des acteurs de même source.
lors de la création de cluster on éxécute les taches suivantes dans cet ordre : 

cluster par exact match -> cluster par fuzzy match -> cluster par distance -> split des clusters si de même source (activable sur paramètre)

après le split, certains critères fuzzy n'était pas respecté car les acteurs extrait ne matchaient plus.

Exemple pour un cluster A,B,C : 
- A, nom: brico de saint mandé, sources:1,2,3
- B, nom: brico, source:1
- C, nom: le roi de saint mandé, source: 2
Ils forment un cluster après un fuzzy permissif car B match A et C match A.

le split intrasource va créé deux clusters A et B,C

B,C dans le même cluster ne respectent pls le critère fuzzy, "brico" et "le roi de saint mandé" n'ont plus de mot en commun

### Optimisation : 

Avant:

```
    similarity_matrix = values_to_similarity_matrix(column_values)  # type: ignore
    tuples = similarity_matrix_to_tuples(similarity_matrix, indexes=cluster)
    sub_clusters = score_tuples_to_clusters(tuples, threshold)
```

Après:

```
    similarity_matrix = values_to_similarity_matrix_sparse(column_values.tolist())
    sub_clusters = sparse_similarity_matrix_to_clusters(similarity_matrix, cluster, threshold)
```

plus besoin de passer par des tuples, on utilise l'objet `csr_matrix` de `scipy.sparse`, c'est plus efficace pour les matrices creuses (qui comportent beaucoup de zéro) car elles ne stockent pas ces valeurs.
Dans notre comparaison fuzzy, on a beaucoup de zéro car souvent les mons n'ont rien à voir

**🤔 comment**: 

### Suppression du bruit

Pour éviter de présenter des clusters qui ne matchent pas les critères, on relance le split des clusters avec les critères fuzzy et distance après le split par intrasource.


**🤓 comment tester**: 

Lancer le DAG de clustering avec un seuil relativement bas et observer qu'il n'y a pas de cluster qui ne respectent pas les critères fuzzy

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [x] J'ai ajouté des tests qui couvrent le nouveau code
