### PR TITLE
Évite qu'une recherche synonyme ne soit conservée lors de la navigation

### DIFF
--- a/webapp/e2e_tests/search.spec.ts
+++ b/webapp/e2e_tests/search.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test"
+import { expect, Locator, test } from "@playwright/test"
 import {
   navigateTo,
   SEARCH_INPUT_SELECTOR,
@@ -177,5 +177,59 @@ test.describe("Recherche de produits", () => {
     expect(nextUrl).toBeTruthy()
     const response = await page.goto(nextUrl)
     expect(response?.status()).toBe(200)
+  })
+
+  test("Le synonyme de recherche n'est pas conservé pour la recherche suivante", async ({
+    page,
+  }) => {
+    // Étape 1 : rechercher via un synonyme (SearchTag) et naviguer vers la fiche
+    await typeSearchQuery(page, "canapé d'angle")
+    const results = await waitForResults(page)
+    const count = await results.count()
+    expect(count).toBeGreaterThan(0)
+
+    let searchTagAnchor: Locator | null = null
+    for (let i = 0; i < count; i++) {
+      const anchor = results.nth(i)
+      if (await anchor.getAttribute("data-search-term-id")) {
+        searchTagAnchor = anchor
+        break
+      }
+    }
+    expect(searchTagAnchor).not.toBeNull()
+    await searchTagAnchor!.click()
+
+    // La fiche d'arrivée doit afficher le bandeau « Votre recherche … »
+    // car on est arrivé via un synonyme.
+    const heading = page.getByText(/Votre recherche.*correspond aux recommandations/)
+    await expect(heading).toBeVisible({ timeout: TIMEOUT.DEFAULT })
+
+    // Étape 2 : depuis la fiche, lancer une nouvelle recherche dont le résultat
+    // sélectionné n'est pas un SearchTag (pas de data-search-term-id).
+    await typeSearchQuery(page, "lave")
+    const nextResults = await waitForResults(page)
+    const nextCount = await nextResults.count()
+    expect(nextCount).toBeGreaterThan(0)
+
+    let nonSearchTagAnchor: Locator | null = null
+    for (let i = 0; i < nextCount; i++) {
+      const anchor = nextResults.nth(i)
+      if (!(await anchor.getAttribute("data-search-term-id"))) {
+        nonSearchTagAnchor = anchor
+        break
+      }
+    }
+    expect(nonSearchTagAnchor).not.toBeNull()
+    await nonSearchTagAnchor!.click()
+    await page.waitForLoadState("domcontentloaded")
+
+    // Le bandeau précédent ne doit pas être conservé sur la nouvelle page.
+    await expect(
+      page.getByText(/Votre recherche.*correspond aux recommandations/),
+    ).toHaveCount(0)
+
+    // Le cookie qf_search_term_id doit avoir été effacé côté navigateur.
+    const cookies = await page.context().cookies()
+    expect(cookies.find((c) => c.name === "qf_search_term_id")).toBeUndefined()
   })
 })

--- a/webapp/static/to_compile/controllers/shared/analytics.ts
+++ b/webapp/static/to_compile/controllers/shared/analytics.ts
@@ -312,7 +312,9 @@ export default class extends Controller<HTMLElement> {
         searchTermName,
       })
       if (searchTermId) {
-        document.cookie = `qf_search_term_id=${searchTermId}; path=/; max-age=60; SameSite=Lax`
+        document.cookie = `qf_search_term_id=${searchTermId}; path=/; max-age=10; SameSite=Lax`
+      } else {
+        document.cookie = `qf_search_term_id=; path=/; max-age=0; SameSite=Lax`
       }
     })
   }


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [[Recherche] Si synonyme de recherche, il est conservé pour l'affichage de la recherche suivante](https://www.notion.so/3566523d57d780619c84e6c5d46507db)

**Tag** : `bug`

**🗺️ contexte** :
rechercher « chaussons » → fiche chaussure → rechercher « vêtements » → la fiche vêtements affiche « Votre recherche chaussons correspond aux recommandations ».


**💡 quoi** : 
effacer le cookie `qf_search_term_id` quand le résultat cliqué ne porte pas de `data-search-term-id`, et réduire la durée de vie du cookie de 60s à 10s pour borner la fenêtre de staleness restante.

**🎯 pourquoi** : 
 quand l'utilisateur arrive sur une fiche via un synonyme de recherche, un cookie `qf_search_term_id` est posé pour 60s afin d'afficher le bandeau « Votre recherche … correspond aux recommandations de la fiche suivante ».

Si l'utilisateur relance une nouvelle recherche dans les 60s et clique sur un résultat qui n'est pas un SearchTag (Synonyme ou ProduitPage), le cookie n'est ni mis à jour ni effacé : le bandeau de la **précédente** recherche est conservé sur la nouvelle fiche.

**🤔 comment** :

- Dans `analytics.ts`, le listener `next-autocomplete:result-click` pose le cookie quand `searchTermId` est présent, sinon le supprime explicitement
- `max-age` passe de `60` à `10` pour limiter le risque de bandeau périmé en cas de navigation directe (suivant/précédent, autre onglet).
- Ajout d'un test e2e

**🤓 comment tester** :

1. Sur la home, rechercher un synonyme renvoyant vers une fiche (ex. « canapé d'angle ») et cliquer sur le résultat marqué SearchTag → la fiche d'arrivée affiche « Votre recherche … correspond aux recommandations ».
2. Depuis cette fiche, relancer une recherche (ex. « lave ») et cliquer sur un résultat ProduitPage / Synonyme → la nouvelle fiche ne doit plus afficher le bandeau précédent.
3. DevTools → Application → Cookies : `qf_search_term_id` doit être absent après l'étape 2 (et son `Max-Age` est désormais `10` après l'étape 1).
4. Tests : `cd webapp && npx playwright test e2e_tests/search.spec.ts -g "synonyme de recherche n'est pas conservé"`.

## Auto-review

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [x] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template` (n/a)
- [x] J'ai ajouté des tests qui couvrent le nouveau code
- [x] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours (n/a)