### PR TITLE
Affiche la famille dans les résultats de recherche pour tous les utilisateurs

### DIFF
--- a/webapp/templates/ui/components/search/autocomplete_results.html
+++ b/webapp/templates/ui/components/search/autocomplete_results.html
@@ -9,7 +9,7 @@
             id="option-{{ forloop.counter }}"
             role="option"
             tabindex="-1"
-            class="qf-list-none qf-p-1w qf-inline-block qf-justify-between"
+            class="qf-list-none qf-p-1w qf-flex qf-flex-nowrap qf-items-center qf-gap-x-2w"
             data-next-autocomplete-target="option"
             data-action="keydown->next-autocomplete#navigate:prevent click->next-autocomplete#resultClick"
         >

--- a/webapp/templates/ui/components/search/search_result.html
+++ b/webapp/templates/ui/components/search/search_result.html
@@ -1,13 +1,15 @@
-<a
-    href="{% block href %}{{ result.url }}{% endblock %}"
-    data-turbo="false"
-    class="fr-link"
-    tabindex="0"
-    {% block anchor_attrs %}{% endblock %}
->
-    {% block nom %}
-    {{ result|capfirst }}
-    {% endblock nom %}
-</a>
+<span>
+    <a
+        href="{% block href %}{{ result.url }}{% endblock %}"
+        data-turbo="false"
+        class="fr-link"
+        tabindex="0"
+        {% block anchor_attrs %}{% endblock %}
+    >
+        {% block nom %}
+        {{ result|capfirst }}
+        {% endblock nom %}
+    </a>
+</span>
 
 {% block parent %}{% endblock parent %}

--- a/webapp/templates/ui/components/search/search_result_searchtag.html
+++ b/webapp/templates/ui/components/search/search_result_searchtag.html
@@ -5,4 +5,4 @@
 {% block anchor_attrs %}data-search-term-id="{{ result.pk }}" data-search-term-name="{{ result.name|urlencode }}"{% endblock %}
 
 {% block nom %}{{ result.name|capfirst }}{% endblock %}
-{% block parent %}{% if result.page and request.beta %} <span class="qf-text-grey-200-850 qf-italic">{{ result.page.titre_phrase|capfirst }}</span>{% endif %}{% endblock parent %}
+{% block parent %}{% if result.page %}<span class="qf-text-grey-200-850 qf-italic qf-ml-auto qf-text-right">{{ result.page.titre_phrase|capfirst }}</span>{% endif %}{% endblock parent %}


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [[Recherche] Affichage de la famille au niveau de la recherche](https://www.notion.so/3116523d57d780938e5fd428d115c533)


**🗺️ contexte** : Recherche 

**💡 quoi** :

la famille (titre de la `ProduitPage` parente) était affichée à droite du synonyme dans les résultats de recherche, mais uniquement pour les utilisateurs `beta` 

On supprime le feature flag + corrige l'affichage


**🎯 pourquoi** : rendre la famille immédiatement lisible pour tous les utilisateurs

**🤔 comment** :

- Suppression du feature flag `request.beta` : la famille est désormais visible pour tous les utilisateurs.
- Mise en page deux colonnes : synonyme à gauche, famille à droite 

**🤓 comment tester** :

1. Sur la home, rechercher « canapé » : les résultats de type synonyme (SearchTag) doivent afficher à droite la famille (ex. *Canapé*, *Banquette/Clic-clac/BZ*…), italique gris.
2. Tester avec un synonyme long comme *Housse rembourrée (chaise, canapé)* : le lien doit wrapper sur deux lignes 
3. Vérifier en viewport mobile (≤ 360px) : les deux termes restent visible

<img width="334" height="442" alt="Capture d’écran 2026-05-14 à 18 31 16" src="https://github.com/user-attachments/assets/ba0536fe-a9c8-4533-87c3-2c9d427c2bb4" />


## Auto-review

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [x] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template` (n/a)
- [x] J'ai ajouté des tests qui couvrent le nouveau code (couverture existante)
- [x] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours (n/a)