### PR TITLE
Pas de mention du terme recherché au niveau de la fiche

### DIFF
--- a/webapp/static/to_compile/controllers/shared/analytics.ts
+++ b/webapp/static/to_compile/controllers/shared/analytics.ts
@@ -1,7 +1,11 @@
 import { Controller } from "@hotwired/stimulus"
 import { InteractionType as PosthogUIInteractionType } from "../../js/types"
 import posthog, { PostHogConfig } from "posthog-js"
-import { URL_PARAM_NAME_FOR_IFRAME_SCRIPT_MODE } from "../../js/helpers"
+import {
+  URL_PARAM_NAME_FOR_IFRAME_SCRIPT_MODE,
+  clearSearchTermCookie,
+  setSearchTermCookie,
+} from "../../js/helpers"
 import { initSentry } from "../../js/sentry"
 
 const IFRAME_REFERRER_SESSION_KEY = "qf_ifr"
@@ -333,9 +337,9 @@ export default class extends Controller<HTMLElement> {
         searchTermName,
       })
       if (searchTermId) {
-        document.cookie = `qf_search_term_id=${searchTermId}; path=/; max-age=10; SameSite=Lax`
+        setSearchTermCookie(searchTermId)
       } else {
-        document.cookie = `qf_search_term_id=; path=/; max-age=0; SameSite=Lax`
+        clearSearchTermCookie()
       }
     })
   }

--- a/webapp/static/to_compile/js/helpers.ts
+++ b/webapp/static/to_compile/js/helpers.ts
@@ -22,3 +22,19 @@ export function removeHash() {
     window.location.pathname + window.location.search,
   )
 }
+
+// SameSite=None; Secure; Partitioned lets the cookie survive a navigation
+// inside a cross-site iframe (e.g. the assistant embedded by a partner).
+// Partitioned (CHIPS) scopes the cookie to the embedding top-level site so
+// it cannot be used for cross-site tracking. Secure is required as soon as
+// SameSite=None. Clearing must use the same attributes — some browsers
+// refuse to overwrite a Partitioned cookie with a non-Partitioned one.
+const SEARCH_TERM_COOKIE_ATTRS = "path=/; SameSite=None; Secure; Partitioned"
+
+export function setSearchTermCookie(searchTermId: string | number): void {
+  document.cookie = `qf_search_term_id=${searchTermId}; max-age=10; ${SEARCH_TERM_COOKIE_ATTRS}`
+}
+
+export function clearSearchTermCookie(): void {
+  document.cookie = `qf_search_term_id=; max-age=0; ${SEARCH_TERM_COOKIE_ATTRS}`
+}

--- a/webapp/static/to_compile/tests/helpers.test.ts
+++ b/webapp/static/to_compile/tests/helpers.test.ts
@@ -1,0 +1,74 @@
+import { clearSearchTermCookie, setSearchTermCookie } from "../js/helpers"
+
+describe("search term cookie helpers", () => {
+  let written: string
+
+  beforeEach(() => {
+    written = ""
+    // jsdom returns "" for document.cookie by default. Intercept assignments
+    // so we can inspect the raw cookie string, attributes included (jsdom's
+    // document.cookie getter strips attributes).
+    Object.defineProperty(document, "cookie", {
+      configurable: true,
+      get: () => written,
+      set: (value: string) => {
+        written = value
+      },
+    })
+  })
+
+  describe("setSearchTermCookie", () => {
+    it("writes the cookie name and value", () => {
+      setSearchTermCookie("42")
+
+      expect(written).toContain("qf_search_term_id=42")
+    })
+
+    it("accepts a numeric id", () => {
+      setSearchTermCookie(7)
+
+      expect(written).toContain("qf_search_term_id=7")
+    })
+
+    it("uses attributes that allow cross-site iframe reads", () => {
+      // SameSite=None lets the cookie be sent on iframe navigations from a
+      // different top-level site. Secure is mandatory when SameSite=None.
+      // Partitioned (CHIPS) keeps the cookie scoped to the embedding site so
+      // it cannot be used for cross-site tracking.
+      setSearchTermCookie("42")
+
+      expect(written).toContain("SameSite=None")
+      expect(written).toContain("Secure")
+      expect(written).toContain("Partitioned")
+      expect(written).not.toContain("SameSite=Lax")
+    })
+
+    it("scopes the cookie to the whole site with a short lifetime", () => {
+      setSearchTermCookie("42")
+
+      expect(written).toContain("path=/")
+      expect(written).toContain("max-age=10")
+    })
+  })
+
+  describe("clearSearchTermCookie", () => {
+    it("expires the cookie immediately", () => {
+      clearSearchTermCookie()
+
+      expect(written).toContain("qf_search_term_id=")
+      expect(written).toContain("max-age=0")
+    })
+
+    it("matches the attributes used when writing so the browser overwrites the cookie", () => {
+      // Some browsers refuse to overwrite a Partitioned cookie with a
+      // non-Partitioned one, leaving the original value stale. The clear
+      // attributes must mirror the set attributes.
+      clearSearchTermCookie()
+
+      expect(written).toContain("path=/")
+      expect(written).toContain("SameSite=None")
+      expect(written).toContain("Secure")
+      expect(written).toContain("Partitioned")
+    })
+  })
+})


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [\[iFrame\] Pas de mention du terme recherché au niveau de la fiche](https://www.notion.so/35f6523d57d7802ca3ace948f51d71ce)

**🗺️ contexte** : Assistant embarqué en iframe par un site partenaire.

**💡 quoi** : Le cookie `qf_search_term_id` est posé en `SameSite=None; Secure; Partitioned` au lieu de `SameSite=Lax`.

**🎯 pourquoi** : `Lax` bloque le cookie en iframe cross-site, donc la mention *« Votre recherche [terme] correspond aux recommandations… »* ne s'affichait pas sur la fiche. `Partitioned` (CHIPS) cantonne le cookie au site embarquant pour qu'il ne serve pas à du tracking.

**🤔 comment** : Écriture et suppression du cookie extraites dans deux helpers (`setSearchTermCookie` / `clearSearchTermCookie`) qui partagent les mêmes attributs, couverts par des tests jest.

**🤓 comment tester** :

1. Charger une page embarquant l'assistant en iframe.
2. Rechercher `frigo`.
3. Vérifier que la mention *« Votre recherche [frigo]… »* s'affiche sur
   la fiche.
4. Vérifier que le comportement hors iframe reste correct.

## Auto-review

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [x] `.env.template` _(N/A)_
- [x] J'ai ajouté des tests qui couvrent le nouveau code
- [x] Cooldown dépendances _(N/A)_