### PR TITLE
Recherche: Correction d'une erreur 500 sur l'import des synonymes de recherche (page vélo)

### DIFF
--- a/webapp/qfdmd/views.py
+++ b/webapp/qfdmd/views.py
@@ -231,8 +231,8 @@ def import_legacy_synonymes(request, id):
                     f"{len(truncated)} synonyme(s) ont été tronqué(s) à "
                     f"{_SEARCH_TAG_MAX_LENGTH} caractères (limite des "
                     f"synonymes de recherche) : {preview}. "
-                    f"Vous pouvez renommer ces synonymes legacy pour les "
-                    f"raccourcir avant un nouvel import.",
+                    "Vous pouvez renommer le synonyme de recherche"
+                    "après l'import",
                 )
         else:
             messages.info(

--- a/webapp/qfdmd/views.py
+++ b/webapp/qfdmd/views.py
@@ -101,12 +101,20 @@ def _import_one_synonyme(page, synonyme):
     Wrapped in a savepoint by the caller so a per-synonyme failure rolls
     back only this iteration. Raises any DB exception so the caller can
     record it.
+
+    Returns True when the synonyme's name or slug had to be truncated to
+    fit SearchTag's 100-char limit (the caller surfaces those to the user
+    so they can rename the legacy record).
     """
     # Replace commas with fullwidth commas to prevent taggit from splitting
     # the tag name on commas during admin round-trips.
-    tag_name = synonyme.nom.replace(", ", "\uff0c").replace(",", "\uff0c")
-    tag_name = tag_name[:_SEARCH_TAG_MAX_LENGTH]
-    slug = (synonyme.slug or "")[:_SEARCH_TAG_MAX_LENGTH]
+    tag_name_full = synonyme.nom.replace(", ", "\uff0c").replace(",", "\uff0c")
+    slug_full = synonyme.slug or ""
+    tag_name = tag_name_full[:_SEARCH_TAG_MAX_LENGTH]
+    slug = slug_full[:_SEARCH_TAG_MAX_LENGTH]
+    truncated = len(tag_name_full) > _SEARCH_TAG_MAX_LENGTH or (
+        len(slug_full) > _SEARCH_TAG_MAX_LENGTH
+    )
 
     search_tag = SearchTag.objects.filter(slug=slug).first()
     if search_tag is None:
@@ -132,20 +140,23 @@ def _import_one_synonyme(page, synonyme):
         synonyme.imported_as_search_tag = search_tag
         synonyme.save(update_fields=["imported_as_search_tag"])
 
+    return truncated
+
 
 def _execute_import(page, all_synonymes):
     """Execute the import of legacy synonymes as SearchTags.
 
     Each synonyme is imported in its own savepoint: a failure on one
     (collision, malformed data) rolls back only that iteration and the
-    rest of the import proceeds. Returns the list of names of synonymes
-    that could not be imported, so the caller can warn the user.
+    rest of the import proceeds. Returns a (failed, truncated) tuple of
+    name lists so the caller can warn the user about each category.
     """
     failed = []
+    truncated = []
     for synonyme in all_synonymes:
         try:
             with transaction.atomic():
-                _import_one_synonyme(page, synonyme)
+                was_truncated = _import_one_synonyme(page, synonyme)
         except (IntegrityError, DataError) as exc:
             logger.warning(
                 "Skipped synonyme %s (id=%s) during legacy import: %s",
@@ -154,7 +165,16 @@ def _execute_import(page, all_synonymes):
                 exc,
             )
             failed.append(synonyme.nom)
-    return failed
+        else:
+            if was_truncated:
+                logger.info(
+                    "Truncated synonyme %s (id=%s) to %s chars during import",
+                    synonyme.nom,
+                    synonyme.pk,
+                    _SEARCH_TAG_MAX_LENGTH,
+                )
+                truncated.append(synonyme.nom)
+    return failed, truncated
 
 
 def import_legacy_synonymes(request, id):
@@ -184,7 +204,7 @@ def import_legacy_synonymes(request, id):
 
     if request.method == "POST":
         if all_synonymes:
-            failed = _execute_import(page, all_synonymes)
+            failed, truncated = _execute_import(page, all_synonymes)
             imported_count = len(all_synonymes) - len(failed)
             if imported_count:
                 messages.success(
@@ -201,6 +221,18 @@ def import_legacy_synonymes(request, id):
                     f"{len(failed)} synonyme(s) n'ont pas pu être importé(s) "
                     f"(ils sont probablement en doublon ou mal formés) : "
                     f"{preview}",
+                )
+            if truncated:
+                preview = ", ".join(truncated[:5])
+                if len(truncated) > 5:
+                    preview += f"… (+{len(truncated) - 5})"
+                messages.warning(
+                    request,
+                    f"{len(truncated)} synonyme(s) ont été tronqué(s) à "
+                    f"{_SEARCH_TAG_MAX_LENGTH} caractères (limite des "
+                    f"synonymes de recherche) : {preview}. "
+                    f"Vous pouvez renommer ces synonymes legacy pour les "
+                    f"raccourcir avant un nouvel import.",
                 )
         else:
             messages.info(

--- a/webapp/qfdmd/views.py
+++ b/webapp/qfdmd/views.py
@@ -94,6 +94,30 @@ def _collect_synonymes_for_page(page):
 # the import alive instead of bubbling a DataError up to the user.
 _SEARCH_TAG_MAX_LENGTH = 100
 
+# How many names to show in the "first N items" preview of warning messages
+# before collapsing the tail into a "+overflow" count.
+_PREVIEW_LIMIT = 5
+
+
+def _preview_names(names: list[str]) -> str:
+    """Render a comma-joined preview of up to _PREVIEW_LIMIT names, with a
+    trailing "… (+N)" when more were skipped."""
+    head = ", ".join(names[:_PREVIEW_LIMIT])
+    if len(names) > _PREVIEW_LIMIT:
+        return f"{head}… (+{len(names) - _PREVIEW_LIMIT})"
+    return head
+
+
+class _EmptySlugError(Exception):
+    """Raised when a legacy Synonyme has an empty slug.
+
+    Synonyme.slug is an AutoSlugField populated from .nom, so an empty
+    value points at a malformed legacy record (e.g. nom containing only
+    punctuation). We refuse to import it instead of silently coalescing
+    to "" \u2014 which would otherwise collide with every other empty-slug
+    tag and mask the data problem.
+    """
+
 
 def _import_one_synonyme(page, synonyme):
     """Import a single Synonyme as a SearchTag, linked to the given page.
@@ -105,11 +129,16 @@ def _import_one_synonyme(page, synonyme):
     Returns True when the synonyme's name or slug had to be truncated to
     fit SearchTag's 100-char limit (the caller surfaces those to the user
     so they can rename the legacy record).
+
+    Raises _EmptySlugError when synonyme.slug is missing \u2014 the caller
+    surfaces those separately so the admin can fix the underlying record.
     """
     # Replace commas with fullwidth commas to prevent taggit from splitting
     # the tag name on commas during admin round-trips.
     tag_name_full = synonyme.nom.replace(", ", "\uff0c").replace(",", "\uff0c")
     slug_full = synonyme.slug or ""
+    if not slug_full:
+        raise _EmptySlugError(synonyme.nom)
     tag_name = tag_name_full[:_SEARCH_TAG_MAX_LENGTH]
     slug = slug_full[:_SEARCH_TAG_MAX_LENGTH]
     truncated = len(tag_name_full) > _SEARCH_TAG_MAX_LENGTH or (
@@ -148,15 +177,24 @@ def _execute_import(page, all_synonymes):
 
     Each synonyme is imported in its own savepoint: a failure on one
     (collision, malformed data) rolls back only that iteration and the
-    rest of the import proceeds. Returns a (failed, truncated) tuple of
-    name lists so the caller can warn the user about each category.
+    rest of the import proceeds. Returns a (failed, truncated, empty_slug)
+    tuple of name lists so the caller can warn the user about each
+    category.
     """
     failed = []
     truncated = []
+    empty_slug = []
     for synonyme in all_synonymes:
         try:
             with transaction.atomic():
                 was_truncated = _import_one_synonyme(page, synonyme)
+        except _EmptySlugError:
+            logger.warning(
+                "Skipped synonyme %s (id=%s): empty slug",
+                synonyme.nom,
+                synonyme.pk,
+            )
+            empty_slug.append(synonyme.nom)
         except (IntegrityError, DataError) as exc:
             logger.warning(
                 "Skipped synonyme %s (id=%s) during legacy import: %s",
@@ -174,7 +212,7 @@ def _execute_import(page, all_synonymes):
                     _SEARCH_TAG_MAX_LENGTH,
                 )
                 truncated.append(synonyme.nom)
-    return failed, truncated
+    return failed, truncated, empty_slug
 
 
 def import_legacy_synonymes(request, id):
@@ -204,8 +242,9 @@ def import_legacy_synonymes(request, id):
 
     if request.method == "POST":
         if all_synonymes:
-            failed, truncated = _execute_import(page, all_synonymes)
-            imported_count = len(all_synonymes) - len(failed)
+            failed, truncated, empty_slug = _execute_import(page, all_synonymes)
+            skipped_count = len(failed) + len(empty_slug)
+            imported_count = len(all_synonymes) - skipped_count
             if imported_count:
                 messages.success(
                     request,
@@ -213,25 +252,27 @@ def import_legacy_synonymes(request, id):
                     f"avec succès.",
                 )
             if failed:
-                preview = ", ".join(failed[:5])
-                if len(failed) > 5:
-                    preview += f"… (+{len(failed) - 5})"
                 messages.warning(
                     request,
                     f"{len(failed)} synonyme(s) n'ont pas pu être importé(s) "
                     f"(ils sont probablement en doublon ou mal formés) : "
-                    f"{preview}",
+                    f"{_preview_names(failed)}",
+                )
+            if empty_slug:
+                messages.warning(
+                    request,
+                    f"{len(empty_slug)} synonyme(s) ont été ignoré(s) car "
+                    f"leur slug est vide : {_preview_names(empty_slug)}. "
+                    "Vérifiez le champ « nom » du synonyme legacy puis "
+                    "relancez l'import.",
                 )
             if truncated:
-                preview = ", ".join(truncated[:5])
-                if len(truncated) > 5:
-                    preview += f"… (+{len(truncated) - 5})"
                 messages.warning(
                     request,
                     f"{len(truncated)} synonyme(s) ont été tronqué(s) à "
                     f"{_SEARCH_TAG_MAX_LENGTH} caractères (limite des "
-                    f"synonymes de recherche) : {preview}. "
-                    "Vous pouvez renommer le synonyme de recherche"
+                    f"synonymes de recherche) : {_preview_names(truncated)}. "
+                    "Vous pouvez renommer le synonyme de recherche "
                     "après l'import",
                 )
         else:

--- a/webapp/qfdmd/views.py
+++ b/webapp/qfdmd/views.py
@@ -4,7 +4,13 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import django_filters
 from django.contrib import messages
-from django.db import OperationalError, connection
+from django.db import (
+    DataError,
+    IntegrityError,
+    OperationalError,
+    connection,
+    transaction,
+)
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
 from django.utils.decorators import method_decorator
@@ -83,37 +89,72 @@ def _collect_synonymes_for_page(page):
     )
 
 
+# taggit's TagBase imposes max_length=100 on both name and slug. Legacy
+# Synonyme records can have longer values, so we truncate to fit and keep
+# the import alive instead of bubbling a DataError up to the user.
+_SEARCH_TAG_MAX_LENGTH = 100
+
+
+def _import_one_synonyme(page, synonyme):
+    """Import a single Synonyme as a SearchTag, linked to the given page.
+
+    Wrapped in a savepoint by the caller so a per-synonyme failure rolls
+    back only this iteration. Raises any DB exception so the caller can
+    record it.
+    """
+    # Replace commas with fullwidth commas to prevent taggit from splitting
+    # the tag name on commas during admin round-trips.
+    tag_name = synonyme.nom.replace(", ", "\uff0c").replace(",", "\uff0c")
+    tag_name = tag_name[:_SEARCH_TAG_MAX_LENGTH]
+    slug = (synonyme.slug or "")[:_SEARCH_TAG_MAX_LENGTH]
+
+    search_tag = SearchTag.objects.filter(slug=slug).first()
+    if search_tag is None:
+        search_tag = SearchTag.objects.filter(name=tag_name).first()
+    if search_tag is None:
+        search_tag = SearchTag.objects.create(name=tag_name, slug=slug)
+
+    if search_tag.legacy_existing_synonyme is None:
+        search_tag.legacy_existing_synonyme = synonyme
+        search_tag.save(update_fields=["legacy_existing_synonyme"])
+
+    TaggedSearchTag.objects.get_or_create(
+        tag=search_tag,
+        content_object=page,
+    )
+
+    # Re-index now that the tag is linked to the page, since the post_save
+    # signal fired before the TaggedSearchTag existed and get_indexed_objects
+    # excluded the orphan tag.
+    insert_or_update_object(search_tag)
+
+    if synonyme.imported_as_search_tag is None:
+        synonyme.imported_as_search_tag = search_tag
+        synonyme.save(update_fields=["imported_as_search_tag"])
+
+
 def _execute_import(page, all_synonymes):
-    """Execute the import of legacy synonymes as SearchTags."""
+    """Execute the import of legacy synonymes as SearchTags.
 
+    Each synonyme is imported in its own savepoint: a failure on one
+    (collision, malformed data) rolls back only that iteration and the
+    rest of the import proceeds. Returns the list of names of synonymes
+    that could not be imported, so the caller can warn the user.
+    """
+    failed = []
     for synonyme in all_synonymes:
-        # Replace commas with fullwidth commas to prevent taggit from
-        # splitting the tag name on commas during admin round-trips.
-        tag_name = synonyme.nom.replace(", ", "\uff0c").replace(",", "\uff0c")
-
-        search_tag = SearchTag.objects.filter(slug=synonyme.slug).first()
-        if search_tag is None:
-            search_tag = SearchTag.objects.filter(name=tag_name).first()
-        if search_tag is None:
-            search_tag = SearchTag.objects.create(name=tag_name, slug=synonyme.slug)
-
-        if search_tag.legacy_existing_synonyme is None:
-            search_tag.legacy_existing_synonyme = synonyme
-            search_tag.save(update_fields=["legacy_existing_synonyme"])
-
-        TaggedSearchTag.objects.get_or_create(
-            tag=search_tag,
-            content_object=page,
-        )
-
-        # Re-index now that the tag is linked to the page, since the
-        # post_save signal fired before the TaggedSearchTag existed
-        # and get_indexed_objects excluded the orphan tag.
-        insert_or_update_object(search_tag)
-
-        if synonyme.imported_as_search_tag is None:
-            synonyme.imported_as_search_tag = search_tag
-            synonyme.save(update_fields=["imported_as_search_tag"])
+        try:
+            with transaction.atomic():
+                _import_one_synonyme(page, synonyme)
+        except (IntegrityError, DataError) as exc:
+            logger.warning(
+                "Skipped synonyme %s (id=%s) during legacy import: %s",
+                synonyme.nom,
+                synonyme.pk,
+                exc,
+            )
+            failed.append(synonyme.nom)
+    return failed
 
 
 def import_legacy_synonymes(request, id):
@@ -143,12 +184,24 @@ def import_legacy_synonymes(request, id):
 
     if request.method == "POST":
         if all_synonymes:
-            _execute_import(page, all_synonymes)
-            messages.success(
-                request,
-                f"{len(all_synonymes)} synonyme(s) de recherche importé(s) "
-                f"avec succès.",
-            )
+            failed = _execute_import(page, all_synonymes)
+            imported_count = len(all_synonymes) - len(failed)
+            if imported_count:
+                messages.success(
+                    request,
+                    f"{imported_count} synonyme(s) de recherche importé(s) "
+                    f"avec succès.",
+                )
+            if failed:
+                preview = ", ".join(failed[:5])
+                if len(failed) > 5:
+                    preview += f"… (+{len(failed) - 5})"
+                messages.warning(
+                    request,
+                    f"{len(failed)} synonyme(s) n'ont pas pu être importé(s) "
+                    f"(ils sont probablement en doublon ou mal formés) : "
+                    f"{preview}",
+                )
         else:
             messages.info(
                 request,

--- a/webapp/unit_tests/qfdmd/test_import_legacy_synonymes.py
+++ b/webapp/unit_tests/qfdmd/test_import_legacy_synonymes.py
@@ -234,6 +234,97 @@ class TestImportLegacySynonymesView:
 
 
 @pytest.mark.django_db
+class TestImportSurvivesMalformedSynonymes:
+    """A single bad synonyme must not 500 the whole import. Failed entries are
+    skipped, the rest proceed, and the user gets a warning message listing them.
+    Regression: Notion ticket 3160 — 500 on vélo legacy import."""
+
+    def test_overlong_nom_is_skipped_not_500(self, produit_page):
+        produit = ProduitFactory(nom="Produit")
+        # SearchTag.name is max_length=100; a longer Synonyme.nom used to
+        # raise DataError unhandled.
+        bad = SynonymeFactory(nom="a" * 150, produit=produit)
+        good = SynonymeFactory(nom="Vélo", produit=produit)
+        LegacyIntermediateSynonymePage.objects.create(page=produit_page, synonyme=bad)
+        LegacyIntermediateSynonymePage.objects.create(page=produit_page, synonyme=good)
+
+        request = _make_request("post")
+        # Must not raise.
+        import_legacy_synonymes(request, produit_page.id)
+
+        # Long-nom synonyme imports successfully thanks to length truncation
+        # (defensive), and the good one too. Important: the import does NOT
+        # 500 the whole flow.
+        assert SearchTag.objects.filter(name="Vélo").exists()
+
+    def test_warning_message_lists_failed_synonymes(self, produit_page, monkeypatch):
+        """When a synonyme genuinely cannot be imported (IntegrityError raised
+        by the inner call), the view records a warning rather than 500.
+        We force the failure via monkeypatch to keep the test deterministic."""
+        from django.db import IntegrityError
+
+        from qfdmd import views
+
+        produit = ProduitFactory(nom="Produit")
+        bad = SynonymeFactory(nom="boom", produit=produit)
+        good = SynonymeFactory(nom="OK", produit=produit)
+        LegacyIntermediateSynonymePage.objects.create(page=produit_page, synonyme=bad)
+        LegacyIntermediateSynonymePage.objects.create(page=produit_page, synonyme=good)
+
+        original = views._import_one_synonyme
+
+        def fake_import(page, synonyme):
+            if synonyme.nom == "boom":
+                raise IntegrityError("forced")
+            return original(page, synonyme)
+
+        monkeypatch.setattr(views, "_import_one_synonyme", fake_import)
+
+        request = _make_request("post")
+        import_legacy_synonymes(request, produit_page.id)
+
+        msgs = [str(m) for m in get_messages(request)]
+        assert any("OK" not in msg and "boom" in msg for msg in msgs)
+        # The good synonyme made it through despite the bad one failing
+        assert SearchTag.objects.filter(name="OK").exists()
+        # And the bad one did not leave partial state
+        assert not SearchTag.objects.filter(name="boom").exists()
+
+    def test_per_synonyme_failure_rolls_back_only_that_iteration(
+        self, produit_page, monkeypatch
+    ):
+        """The savepoint must roll back the failed iteration without
+        rolling back synonymes imported earlier."""
+        from django.db import IntegrityError
+
+        from qfdmd import views
+
+        produit = ProduitFactory(nom="Produit")
+        first = SynonymeFactory(nom="First", produit=produit)
+        bad = SynonymeFactory(nom="boom", produit=produit)
+        third = SynonymeFactory(nom="Third", produit=produit)
+        LegacyIntermediateSynonymePage.objects.create(page=produit_page, synonyme=first)
+        LegacyIntermediateSynonymePage.objects.create(page=produit_page, synonyme=bad)
+        LegacyIntermediateSynonymePage.objects.create(page=produit_page, synonyme=third)
+
+        original = views._import_one_synonyme
+
+        def fake_import(page, synonyme):
+            if synonyme.nom == "boom":
+                raise IntegrityError("forced")
+            return original(page, synonyme)
+
+        monkeypatch.setattr(views, "_import_one_synonyme", fake_import)
+
+        request = _make_request("post")
+        import_legacy_synonymes(request, produit_page.id)
+
+        assert SearchTag.objects.filter(name="First").exists()
+        assert SearchTag.objects.filter(name="Third").exists()
+        assert not SearchTag.objects.filter(name="boom").exists()
+
+
+@pytest.mark.django_db
 class TestImportConfirmationPage:
     """GET shows a confirmation page, POST executes the import."""
 

--- a/webapp/unit_tests/qfdmd/test_import_legacy_synonymes.py
+++ b/webapp/unit_tests/qfdmd/test_import_legacy_synonymes.py
@@ -234,6 +234,55 @@ class TestImportLegacySynonymesView:
 
 
 @pytest.mark.django_db
+class TestImportTruncationWarning:
+    """When a Synonyme.nom is longer than SearchTag's 100-char limit we
+    truncate the value before insert (so the import does not 500) and
+    surface a warning to the user listing the affected synonymes so they
+    can shorten them and reimport."""
+
+    def test_overlong_nom_emits_truncation_warning(self, produit_page):
+        produit = ProduitFactory(nom="Produit")
+        SynonymeFactory(nom="x" * 150, produit=produit)
+        LegacyIntermediateProduitPage.objects.create(page=produit_page, produit=produit)
+
+        request = _make_request("post")
+        import_legacy_synonymes(request, produit_page.id)
+
+        msgs = [str(m) for m in get_messages(request)]
+        truncation_msgs = [m for m in msgs if "tronqué" in m]
+        assert len(truncation_msgs) == 1
+        assert "x" * 50 in truncation_msgs[0]
+        # And the synonyme made it in with a truncated name.
+        assert SearchTag.objects.filter(name="x" * 100).exists()
+
+    def test_no_truncation_warning_when_all_within_limit(self, produit_page):
+        produit = ProduitFactory(nom="Produit")
+        SynonymeFactory(nom="Lave-linge", produit=produit)
+        LegacyIntermediateProduitPage.objects.create(page=produit_page, produit=produit)
+
+        request = _make_request("post")
+        import_legacy_synonymes(request, produit_page.id)
+
+        msgs = [str(m) for m in get_messages(request)]
+        assert not any("tronqué" in m for m in msgs)
+
+    def test_truncation_warning_lists_multiple_synonymes(self, produit_page):
+        produit = ProduitFactory(nom="Produit")
+        SynonymeFactory(nom="a" * 150, produit=produit)
+        SynonymeFactory(nom="b" * 150, produit=produit)
+        SynonymeFactory(nom="Court", produit=produit)
+        LegacyIntermediateProduitPage.objects.create(page=produit_page, produit=produit)
+
+        request = _make_request("post")
+        import_legacy_synonymes(request, produit_page.id)
+
+        msgs = [str(m) for m in get_messages(request)]
+        truncation_msgs = [m for m in msgs if "tronqué" in m]
+        assert len(truncation_msgs) == 1
+        assert "2 synonyme(s) ont été tronqué" in truncation_msgs[0]
+
+
+@pytest.mark.django_db
 class TestImportSurvivesMalformedSynonymes:
     """A single bad synonyme must not 500 the whole import. Failed entries are
     skipped, the rest proceed, and the user gets a warning message listing them.

--- a/webapp/unit_tests/qfdmd/test_import_legacy_synonymes.py
+++ b/webapp/unit_tests/qfdmd/test_import_legacy_synonymes.py
@@ -374,6 +374,66 @@ class TestImportSurvivesMalformedSynonymes:
 
 
 @pytest.mark.django_db
+class TestImportSkipsEmptySlug:
+    """Synonyme.slug is an AutoSlugField populated from .nom, so an empty
+    slug means the legacy record is malformed (e.g. nom only contained
+    punctuation). We skip those rows, warn the user, and keep importing
+    the rest — silently coercing to "" would otherwise collide with every
+    other empty-slug tag and mask the data problem."""
+
+    def _force_empty_slug(self, synonyme):
+        """AutoSlugField repopulates on save, so we have to bypass it
+        with a queryset .update() to simulate the malformed-legacy case."""
+        from qfdmd.models import Synonyme
+
+        Synonyme.objects.filter(pk=synonyme.pk).update(slug="")
+        synonyme.refresh_from_db()
+
+    def test_empty_slug_synonyme_is_skipped(self, produit_page):
+        produit = ProduitFactory(nom="Produit")
+        bad = SynonymeFactory(nom="Empty slug one", produit=produit)
+        self._force_empty_slug(bad)
+        good = SynonymeFactory(nom="Vélo", produit=produit)
+        LegacyIntermediateSynonymePage.objects.create(page=produit_page, synonyme=bad)
+        LegacyIntermediateSynonymePage.objects.create(page=produit_page, synonyme=good)
+
+        request = _make_request("post")
+        import_legacy_synonymes(request, produit_page.id)
+
+        # The good synonyme made it through; the empty-slug one did not.
+        assert SearchTag.objects.filter(name="Vélo").exists()
+        assert not SearchTag.objects.filter(name="Empty slug one").exists()
+
+    def test_empty_slug_emits_dedicated_warning(self, produit_page):
+        produit = ProduitFactory(nom="Produit")
+        bad = SynonymeFactory(nom="Empty slug one", produit=produit)
+        self._force_empty_slug(bad)
+        LegacyIntermediateSynonymePage.objects.create(page=produit_page, synonyme=bad)
+
+        request = _make_request("post")
+        import_legacy_synonymes(request, produit_page.id)
+
+        msgs = [str(m) for m in get_messages(request)]
+        empty_slug_msgs = [m for m in msgs if "slug est vide" in m]
+        assert len(empty_slug_msgs) == 1
+        assert "Empty slug one" in empty_slug_msgs[0]
+
+    def test_empty_slug_not_counted_as_failed(self, produit_page):
+        """The 'doublon ou mal formés' warning must not fire — empty-slug
+        synonymes get their own dedicated message instead."""
+        produit = ProduitFactory(nom="Produit")
+        bad = SynonymeFactory(nom="Empty", produit=produit)
+        self._force_empty_slug(bad)
+        LegacyIntermediateSynonymePage.objects.create(page=produit_page, synonyme=bad)
+
+        request = _make_request("post")
+        import_legacy_synonymes(request, produit_page.id)
+
+        msgs = [str(m) for m in get_messages(request)]
+        assert not any("doublon ou mal formés" in m for m in msgs)
+
+
+@pytest.mark.django_db
 class TestImportConfirmationPage:
     """GET shows a confirmation page, POST executes the import."""
 


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [\[Recherche\] Erreur 500 sur l'import des synonymes de recherche pour la nouvelle page \"vélo\"](https://www.notion.so/34a6523d57d780e18332fba8d31c5a3f)

**🗺️ contexte** : Import de synonymes / produits

**💡 quoi** : L'impor sur velo échoue avec une erreur 500

**🎯 pourquoi** : 
L'import crée des SearchTag a partir de Synonyme.nom sauf que cela échoue car SearchTag hérite de modeles de tierce partie (taggit) et qu'on ne maitrise pas la limite de longueur du tag (100 caracteres)


**🤔 comment** :

- on tronque les champs name / slug si la longueur a importer dépasse ce qu'on attend
- on affiche un avertissement a l'utilisateur

**🤓 comment tester** :

1. Aller sur `https://quefairedemesdechets.ademe.local/cms/pages/487/edit/#tab-migration`
2. Cliquer sur "Importer les synonymes de recherche" dans les boutons en bas
3. Vérifier qu'il n'y a plus de 500. Le banner Django affiche le nombre de synonymes importés et, le cas échéant, le nombre de synonymes ignorés avec un aperçu de leurs noms.

<img width="1014" height="188" alt="image" src="https://github.com/user-attachments/assets/860d441e-eb2e-40f3-ae3b-bc6088a54326" />


## Auto-review

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [x] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code
- [x] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours

## 📆 A faire (prochaine PR)

- [ ] Sur la fiche vélo en prod, vérifier qu'on peut relancer l'import (ou le faire à la main si `migree_depuis_synonymes_legacy=True` est déjà figé) pour finir d'importer les synonymes manquants.
- [ ] Envisager d'ajouter un `max_length=100` explicite sur `Synonyme.nom` côté admin pour empêcher la création de synonymes trop longs en amont.