### PR TITLE
Adaptation de github CD à la version v1 du CLI scw

### DIFF
--- a/.github/workflows/_scaleway-container-deploy.yml
+++ b/.github/workflows/_scaleway-container-deploy.yml
@@ -25,10 +25,12 @@ jobs:
       uses: scaleway/action-scw@2e34a1eb35cf3cac627f24643a101fea269cbd83
 
     # See https://www.scaleway.com/en/docs/serverless-containers/api-cli/deploy-container-cli/
+    # Note: since Scaleway CLI v2.56.0 the container API migrated from v1beta1
+    # to v1, which renamed `registry-image` to `image`.
     - name: Update image
       run: |
         scw container container update $CONTAINER_ID \
-          registry-image=$REGISTRY_IMAGE \
+          image=$REGISTRY_IMAGE \
           region=$SCW_DEFAULT_REGION
 
     - name: Check deployment status


### PR DESCRIPTION
# Description succincte du problème résolu

Nouvelle version de l'API v1
l'action github utiise la dernière version du cli et donc de l'API
du coup, le paramètre nommé `registry-image` est renommé `image`
donc on adapte github CD


**🗺️ contexte**: CD

**💡 quoi**: incompatibilité API v1

**🎯 pourquoi**: évolution de l'API scaleway

**🤔 comment**: adaptation de la CD

**🤓 comment tester**: exécution de la CD


## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## 📆 A faire (prochaine PR)

- [ ] Voir si on fixe la version du cli pour éviter ces écueuils
