### PR TITLE
Fixer la version de la CLI de scaleway dans la supply chain

### DIFF
--- a/.github/workflows/_scaleway-container-deploy.yml
+++ b/.github/workflows/_scaleway-container-deploy.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Setup Scaleway CLI
       uses: scaleway/action-scw@2e34a1eb35cf3cac627f24643a101fea269cbd83
+      with:
+        version: v2.56.0
 
     # See https://www.scaleway.com/en/docs/serverless-containers/api-cli/deploy-container-cli/
     # Note: since Scaleway CLI v2.56.0 the container API migrated from v1beta1

--- a/.github/workflows/sync_databases.yml
+++ b/.github/workflows/sync_databases.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           save-config: true
           export-config: true
-          version: v2.24.0
+          version: v2.56.0
           access-key: ${{ env.SCW_ACCESS_KEY }}
           secret-key: ${{ env.SCW_SECRET_KEY }}
           default-project-id: ${{ env.SCW_DEFAULT_PROJECT_ID }}


### PR DESCRIPTION
# Description succincte du problème résolu

Tech : pour la sécu, maitriser la version de la CLI de scaleway en CD


**🗺️ contexte**: CD

**💡 quoi**: version de la CLI de scaleway

**🎯 pourquoi**: maitriser les version de CLI utilisé, éviterles attaque de supply chain

**🤔 comment**: fixer la version

**🤓 comment tester**: exécuter la CD


## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
