### PR TITLE
Commande pour aligner les propositions de service

### DIFF
--- a/data-platform/dbt/models/intermediate/stats/int_acteur_with_revision.sql
+++ b/data-platform/dbt/models/intermediate/stats/int_acteur_with_revision.sql
@@ -1,3 +1,3 @@
 SELECT acteur.* FROM {{ ref('base_acteur') }} as acteur
 INNER JOIN {{ ref('base_revisionacteur') }} as revision ON acteur.identifiant_unique = revision.identifiant_unique
-WHERE revision.identifiant_unique IS NOT NULL
+WHERE revision.identifiant_unique IS NOT NULL and revision.statut = 'ACTIF'

--- a/webapp/qfdmo/management/commands/realign_acteur_and_revision_proposition_service.py
+++ b/webapp/qfdmo/management/commands/realign_acteur_and_revision_proposition_service.py
@@ -46,14 +46,23 @@ class Command(BaseCommand):
             action=argparse.BooleanOptionalAction,
             default=False,
         )
+        parser.add_argument(
+            "--source-codes",
+            help="Source codes to copy proposition service from revision",
+            action="append",
+            default=[],
+        )
 
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
         for_selected_sources = options["for_selected_sources"]
         if_empty = options["if_empty"]
+        source_codes = options["source_codes"]
+        if not source_codes:
+            source_codes = SOURCE_CODES
         if for_selected_sources:
             self.copy_proposition_service_from_revision_for_selected_sources(
-                dry_run=dry_run
+                source_codes=source_codes, dry_run=dry_run
             )
         if if_empty:
             self.copy_proposition_service_from_revision_if_empty(dry_run=dry_run)

--- a/webapp/qfdmo/management/commands/realign_acteur_and_revision_proposition_service.py
+++ b/webapp/qfdmo/management/commands/realign_acteur_and_revision_proposition_service.py
@@ -31,18 +31,32 @@ class Command(BaseCommand):
             action=argparse.BooleanOptionalAction,
             default=False,
         )
+        parser.add_argument(
+            "--for-selected-sources",
+            help="Copy proposition service from revision for selected sources",
+            action=argparse.BooleanOptionalAction,
+            default=False,
+        )
+        parser.add_argument(
+            "--if-empty",
+            help=(
+                "Copy proposition service from revision if acteur has no proposition"
+                " service"
+            ),
+            action=argparse.BooleanOptionalAction,
+            default=False,
+        )
 
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
-        self.stdout.write(
-            self.style.SUCCESS(
-                "Copying proposition service from revision for selected sources"
-                f"{' [DRY RUN]' if dry_run else ''}"
+        for_selected_sources = options["for_selected_sources"]
+        if_empty = options["if_empty"]
+        if for_selected_sources:
+            self.copy_proposition_service_from_revision_for_selected_sources(
+                dry_run=dry_run
             )
-        )
-        self.copy_proposition_service_from_revision_for_selected_sources(
-            dry_run=dry_run
-        )
+        if if_empty:
+            self.copy_proposition_service_from_revision_if_empty(dry_run=dry_run)
 
     def _copy_ps_from_revision_to_acteur(
         self, acteur: Acteur, revision_acteur: RevisionActeur, dry_run: bool
@@ -61,18 +75,28 @@ class Command(BaseCommand):
                     proposition_service.sous_categories.set(
                         revision_proposition_service.sous_categories.all()
                     )
-                self.stdout.write(
-                    self.style.SUCCESS(
-                        "Copied proposition service from revision for acteur "
-                        f"{acteur.identifiant_unique}"
+                else:
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            "DRY RUN: Would have copied proposition service"
+                            " from revision for acteur "
+                            f"{acteur.identifiant_unique}"
+                        )
                     )
-                )
 
     def copy_proposition_service_from_revision_for_selected_sources(
         self,
         source_codes: list[str] = SOURCE_CODES,
         dry_run: bool = False,
     ):
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Copying proposition service from revision for selected sources"
+                f"{' [DRY RUN]' if dry_run else ''}"
+            )
+        )
+        count = 0
+        total = Acteur.objects.filter(source__code__in=source_codes).count()
         for acteur in Acteur.objects.filter(source__code__in=source_codes):
             try:
                 revision_acteur = RevisionActeur.objects.get(
@@ -81,12 +105,25 @@ class Command(BaseCommand):
             except RevisionActeur.DoesNotExist:
                 continue
             self._copy_ps_from_revision_to_acteur(acteur, revision_acteur, dry_run)
+            count += 1
+            if count % 100 == 0:
+                self.stdout.write(
+                    self.style.SUCCESS(f"Processed {count} / {total} acteurs")
+                )
 
     def copy_proposition_service_from_revision_if_empty(
         self,
         dry_run: bool = False,
     ):
-        # get acteur without proposition service
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Copying proposition service from revision if acteur has no proposition"
+                " service"
+                f"{' [DRY RUN]' if dry_run else ''}"
+            )
+        )
+        count = 0
+        total = Acteur.objects.filter(proposition_services__isnull=True).count()
         acteurs = Acteur.objects.filter(proposition_services__isnull=True)
         for acteur in acteurs:
             try:
@@ -96,3 +133,8 @@ class Command(BaseCommand):
             except RevisionActeur.DoesNotExist:
                 continue
             self._copy_ps_from_revision_to_acteur(acteur, revision_acteur, dry_run)
+            count += 1
+            if count % 100 == 0:
+                self.stdout.write(
+                    self.style.SUCCESS(f"Processed {count} / {total} acteurs")
+                )

--- a/webapp/qfdmo/management/commands/realign_acteur_and_revision_proposition_service.py
+++ b/webapp/qfdmo/management/commands/realign_acteur_and_revision_proposition_service.py
@@ -1,0 +1,98 @@
+import argparse
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from qfdmo.models.acteur import Acteur, PropositionService, RevisionActeur
+
+#'+ report de revision sur source si pas de proposition de service sur l'acteur importé
+
+
+# `+ filtre sur statut
+SOURCE_CODES = [
+    "ademedigitaux",
+    "ademelocales",
+    "ademelocation",
+    "ademenationales",
+    "bibliotheques",
+    "communautelvao",
+    "lvao",
+    "recyclivrebal",
+    "sinoe",
+]
+
+
+class Command(BaseCommand):
+    help = "Realign acteur and revision proposition service"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            help="Run command without writing changes to the database",
+            action=argparse.BooleanOptionalAction,
+            default=False,
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Copying proposition service from revision for selected sources"
+                f"{' [DRY RUN]' if dry_run else ''}"
+            )
+        )
+        self.copy_proposition_service_from_revision_for_selected_sources(
+            dry_run=dry_run
+        )
+
+    def _copy_ps_from_revision_to_acteur(
+        self, acteur: Acteur, revision_acteur: RevisionActeur, dry_run: bool
+    ):
+        with transaction.atomic():
+            if not dry_run:
+                PropositionService.objects.filter(acteur=acteur).delete()
+            for (
+                revision_proposition_service
+            ) in revision_acteur.proposition_services.all():
+                if not dry_run:
+                    proposition_service = PropositionService.objects.create(
+                        acteur=acteur,
+                        action=revision_proposition_service.action,
+                    )
+                    proposition_service.sous_categories.set(
+                        revision_proposition_service.sous_categories.all()
+                    )
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        "Copied proposition service from revision for acteur "
+                        f"{acteur.identifiant_unique}"
+                    )
+                )
+
+    def copy_proposition_service_from_revision_for_selected_sources(
+        self,
+        source_codes: list[str] = SOURCE_CODES,
+        dry_run: bool = False,
+    ):
+        for acteur in Acteur.objects.filter(source__code__in=source_codes):
+            try:
+                revision_acteur = RevisionActeur.objects.get(
+                    identifiant_unique=acteur.identifiant_unique
+                )
+            except RevisionActeur.DoesNotExist:
+                continue
+            self._copy_ps_from_revision_to_acteur(acteur, revision_acteur, dry_run)
+
+    def copy_proposition_service_from_revision_if_empty(
+        self,
+        dry_run: bool = False,
+    ):
+        # get acteur without proposition service
+        acteurs = Acteur.objects.filter(proposition_services__isnull=True)
+        for acteur in acteurs:
+            try:
+                revision_acteur = RevisionActeur.objects.get(
+                    identifiant_unique=acteur.identifiant_unique
+                )
+            except RevisionActeur.DoesNotExist:
+                continue
+            self._copy_ps_from_revision_to_acteur(acteur, revision_acteur, dry_run)


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [Rattraper notre retard sur les modifs apportées par nos sources (EOs) - Problème causé par les Révisions globales.](https://www.notion.so/accelerateur-transition-ecologique-ademe/Rattraper-notre-retard-sur-les-modifs-apport-es-par-nos-sources-EOs-Probl-me-caus-par-les-R-vis-2e06523d57d7800b889cf67d2bc2dee2?v=7fa49e1bda7e4f8baed5d646aef65fbe&source=copy_link)

**🗺️ contexte**: Django command

**💡 quoi**: commande permettant de ré-aligner les propositions de services pour les acteurs avec correction qui appartiennent aux sources identifiées à aligner ainsi que les acteurs qui n'ont pas de proposition de services

ces acteurs sont désynchronisé car ils ont été créés directement via l'interface (objet correction), c'est donc la correction qui fait foi

**🎯 pourquoi**: 
Corriger les anomalie si il y en a, réduire le bruit sur les cas qui sont plus difficiles à résoudre, cf. [tableau de qualité](https://qfdmo-metabase.osc-secnum-fr1.scalingo.io/dashboard/3-qfdmod-tableau-de-bord-qualite-donnees?tab=4-diff-acteur-vs-revision)

**🤔 comment**: 

- Création d'une commande
- On en profite pour réduire les stats aux acteurs / corrections ACTIF

**🤓 comment tester**: 

- Lancer la commande et constater
- Lancer le DAG de stats
- Constater que le nombre de diff acteur vs correction à drastiquement chuté

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)
