### PR TITLE
corrige le bouton 'Voir la fiche' en mode liste (régression) & tests e2e

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
     build:
       context: ./webapp
       dockerfile: nginx/Dockerfile
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       - 80:80
       - 443:443

--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -138,6 +138,11 @@ integration-test:
 .PHONY: prepare-e2e-test
 prepare-e2e-test:
 	make migrate
+	# Mirror CI: ensure unaccent / pg_trgm extensions and the f_unaccent()
+	# wrapper exist before rebuilding the search index. Without these, the
+	# autocomplete fuzzy search raises ProgrammingError at runtime.
+	$(DJANGO_ADMIN) enable_unaccent
+	$(DJANGO_ADMIN) enable_trigram
 	make rebuild-search-index
 	make createsuperuser-example
 	BASE_URL=http://localhost:8888 npm run build

--- a/webapp/e2e_tests/carte_address_combobox.spec.ts
+++ b/webapp/e2e_tests/carte_address_combobox.spec.ts
@@ -405,14 +405,18 @@ test.describe("⌨️ Carte combobox — APG keyboard contract", () => {
     // geolocation option, not wait for the user to type something first.
     await navigateTo(page, "/carte")
     const input = page.locator(CARTE_INPUT)
-    await input.click()
 
-    await page.waitForResponse(
+    // The focus handler fires the request synchronously after click and the
+    // Turbo Frame can resolve before we have a chance to await waitForResponse,
+    // so arm the listener BEFORE clicking to avoid losing the race.
+    const responsePromise = page.waitForResponse(
       (response) =>
         response.url().includes("/qfdmo/autocomplete/address") &&
         response.status() === 200,
       { timeout: TIMEOUT.DEFAULT },
     )
+    await input.click()
+    await responsePromise
 
     await expect(input).toHaveAttribute("aria-expanded", "true")
     await expect(page.locator(`${CARTE_OPTION}[data-geolocate="true"]`)).toBeVisible({

--- a/webapp/e2e_tests/search.spec.ts
+++ b/webapp/e2e_tests/search.spec.ts
@@ -210,8 +210,13 @@ test.describe("Recherche de produits", () => {
     await expect(heading).toBeVisible({ timeout: TIMEOUT.DEFAULT })
 
     // Étape 2 : depuis la fiche, lancer une nouvelle recherche dont le résultat
-    // sélectionné n'est pas un SearchTag (pas de data-search-term-id).
-    await typeSearchQuery(page, "lave")
+    // sélectionné n'est pas un SearchTag (pas de data-search-term-id). La
+    // fiche produit n'expose que la search input du header (préfixe
+    // "header-autocomplete"), pas celle de la home, d'où le sélecteur explicite.
+    const headerSearchInput = page.locator("#id_header-autocomplete-search")
+    await headerSearchInput.click()
+    await headerSearchInput.fill("")
+    await headerSearchInput.pressSequentially("lave", { delay: 50 })
     const nextResults = await waitForResults(page)
     const nextCount = await nextResults.count()
     expect(nextCount).toBeGreaterThan(0)

--- a/webapp/e2e_tests/search.spec.ts
+++ b/webapp/e2e_tests/search.spec.ts
@@ -202,8 +202,11 @@ test.describe("Recherche de produits", () => {
     await searchTagAnchor!.click()
 
     // La fiche d'arrivée doit afficher le bandeau « Votre recherche … »
-    // car on est arrivé via un synonyme.
-    const heading = page.getByText(/Votre recherche.*correspond aux recommandations/)
+    // car on est arrivé via un synonyme. Le terme est inséré via dsfr_tag qui
+    // rend un <p>, donc le texte est réparti sur plusieurs lignes — d'où [\s\S].
+    const heading = page.getByText(
+      /Votre recherche[\s\S]*correspond aux recommandations/,
+    )
     await expect(heading).toBeVisible({ timeout: TIMEOUT.DEFAULT })
 
     // Étape 2 : depuis la fiche, lancer une nouvelle recherche dont le résultat
@@ -227,7 +230,7 @@ test.describe("Recherche de produits", () => {
 
     // Le bandeau précédent ne doit pas être conservé sur la nouvelle page.
     await expect(
-      page.getByText(/Votre recherche.*correspond aux recommandations/),
+      page.getByText(/Votre recherche[\s\S]*correspond aux recommandations/),
     ).toHaveCount(0)
 
     // Le cookie qf_search_term_id doit avoir été effacé côté navigateur.

--- a/webapp/pyproject.toml
+++ b/webapp/pyproject.toml
@@ -145,4 +145,4 @@ dev = [
 package = true
 
 [tool.uv.sources]
-django-dsfr = { git = "https://github.com/fabienheureux/django-dsfr", rev = "b5ac6f508c6b46672b898129576f34e1b74d10d5" } # pragma: allowlist secret
+django-dsfr = { git = "https://github.com/fabienheureux/django-dsfr", rev = "b110ff5360c4b0503374efcc10ac4b7879a7cd96" } # pragma: allowlist secret

--- a/webapp/uv.lock
+++ b/webapp/uv.lock
@@ -403,7 +403,7 @@ wheels = [
 [[package]]
 name = "django-dsfr"
 version = "3.4.2"
-source = { git = "https://github.com/fabienheureux/django-dsfr?rev=b5ac6f508c6b46672b898129576f34e1b74d10d5#b5ac6f508c6b46672b898129576f34e1b74d10d5" }
+source = { git = "https://github.com/fabienheureux/django-dsfr?rev=b110ff5360c4b0503374efcc10ac4b7879a7cd96#b110ff5360c4b0503374efcc10ac4b7879a7cd96" }
 dependencies = [
     { name = "django" },
     { name = "django-widget-tweaks" },
@@ -1778,7 +1778,7 @@ requires-dist = [
     { name = "django-admin-sortable2", specifier = ">=2.2.8" },
     { name = "django-colorfield", specifier = ">=0.14.0,<0.15" },
     { name = "django-cors-headers", specifier = ">=4.6.0,<5" },
-    { name = "django-dsfr", git = "https://github.com/fabienheureux/django-dsfr?rev=b5ac6f508c6b46672b898129576f34e1b74d10d5" },
+    { name = "django-dsfr", git = "https://github.com/fabienheureux/django-dsfr?rev=b110ff5360c4b0503374efcc10ac4b7879a7cd96" },
     { name = "django-extensions", specifier = "~=4.1" },
     { name = "django-import-export", extras = ["xls", "xlsx"], specifier = ">=4.4.1,<5" },
     { name = "django-lookbook", specifier = ">=1.0.2,<2" },


### PR DESCRIPTION
# Description succincte du problème résolu


**🗺️ contexte**: Régression introduite par une upgrade de django-dsfr

**💡 quoi**: mise à jour dans django_dsfr (notre fork) qui réécrit data_attributes pour retourner une SafeString via format_html_join.

On avait dropé le `safe` à la demande de Christophe mais ce n'était pas fou 

**🎯 pourquoi**: 
Restaurer l'ouverture de la modale au clic du bouton "Voir la fiche" en mode liste 

**🤔 comment**:

- Correction côté fork
- Bump du pin dans webapp/pyproject.toml + uv sync.

**🤓 comment tester**:

- cd webapp && uv sync
- Lancer la stack locale
- Carte > mode liste > cliquer sur "Voir la fiche"
- Vérifier que le panneau s'ouvre via Turbo Frame et que l'attribut DOM est data-turbo-frame="carte:acteur-detail" (sans &quot;)

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [x] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code
- [x] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)