### PR TITLE
[Dependabot] inclure toutes les dépendances dans les propositions de Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
       time: "06:00" # UTC
     cooldown:
       default-days: 7
+    allow:
+      - dependency-type: "all"
   - package-ecosystem: "uv"
     directory: "/data-platform"
     schedule:
@@ -18,6 +20,8 @@ updates:
       time: "06:05" # UTC
     cooldown:
       default-days: 7
+    allow:
+      - dependency-type: "all"
   - package-ecosystem: "npm"
     directory: "/webapp"
     schedule:
@@ -26,6 +30,8 @@ updates:
       time: "06:15" # UTC
     cooldown:
       default-days: 7
+    allow:
+      - dependency-type: "all"
     groups:
       parcel:
         patterns:
@@ -45,6 +51,8 @@ updates:
       time: "06:30" # UTC
     cooldown:
       default-days: 7
+    allow:
+      - dependency-type: "all"
   - package-ecosystem: "terraform"
     directory: "/infrastructure"
     schedule:
@@ -53,3 +61,5 @@ updates:
       time: "06:45" # UTC
     cooldown:
       default-days: 7
+    allow:
+      - dependency-type: "all"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,11 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
+
 updates:
   - package-ecosystem: "uv"
     directory: "/webapp"
+    open-pull-requests-limit: 100
     schedule:
       interval: "weekly"
       day: "tuesday"
@@ -14,6 +16,7 @@ updates:
       - dependency-type: "all"
   - package-ecosystem: "uv"
     directory: "/data-platform"
+    open-pull-requests-limit: 100
     schedule:
       interval: "weekly"
       day: "tuesday"
@@ -24,6 +27,7 @@ updates:
       - dependency-type: "all"
   - package-ecosystem: "npm"
     directory: "/webapp"
+    open-pull-requests-limit: 100
     schedule:
       interval: "weekly"
       day: "tuesday"
@@ -45,6 +49,7 @@ updates:
           - "*eslint*"
   - package-ecosystem: "github-actions"
     directory: "/"
+    open-pull-requests-limit: 100
     schedule:
       interval: "weekly"
       day: "tuesday"
@@ -55,6 +60,7 @@ updates:
       - dependency-type: "all"
   - package-ecosystem: "terraform"
     directory: "/infrastructure"
+    open-pull-requests-limit: 100
     schedule:
       interval: "weekly"
       day: "tuesday"


### PR DESCRIPTION
# Description succincte du problème résolu

SECU : Retour de pentest, certaine de nos lib js sont très en retard
Le pb vient du faite que dependabot ne met pas à jour les dépendances des dépendances

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: dependabot js

**💡 quoi**: dépendance de dépendance à prendre en compte par dependabot

**🎯 pourquoi**: eviter les retard de mise à jour

**🤔 comment**: <!-- Descrire l'ensemble des tâches réalisées (bullet points) -->

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#dependency-type-allow

Dans le doute, je l'ai ajouté à chaque bloc même si l'erreur a été relevé pour les lib JS

**🤓 comment tester**: <!-- Descrire les étapes pour tester la fonctionnalité -->

vérifier que les dependances sont aussi mise à jour par dependabot

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)
