### PR TITLE
Ne pas compiler les .map en prod

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,12 +1,12 @@
 {
   "type": "module",
   "scripts": {
-    "build": "parcel build",
+    "build": "parcel build --target prod",
     "lint": "eslint . --fix",
     "format:check": "prettier --check static/to_compile",
     "format": "prettier static/to_compile --write",
     "test": "jest ./static/to_compile",
-    "watch": "parcel watch --no-hmr",
+    "watch": "parcel watch --target dev --no-hmr",
     "e2e_test": " npx playwright test --update-snapshots"
   },
   "source": [
@@ -23,7 +23,11 @@
     "static/to_compile/qfdmo.ts"
   ],
   "targets": {
-    "default": {
+    "prod": {
+      "distDir": "./static/compiled",
+      "sourceMap": false
+    },
+    "dev": {
       "distDir": "./static/compiled"
     }
   },


### PR DESCRIPTION
# Description succincte du problème résolu

Secu : ne pas exposer les .js.map en prod et preprod


**🗺️ contexte**: Sécu

**💡 quoi**: build sans les .map pour ne pas exposer notre code (même si il est opensource)

**🎯 pourquoi**: retour des pentests

**🤔 comment**: ne pas compiler les .map en prod et preprod, nouveau target avec `mapSource: false`

**🤓 comment tester**: ne pas voir les .map dans l'onglet réseau des devtools du navigateur

- npm watch -> .map
- npm build -> pas de .map

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

