### PR TITLE
Bump dbt-core from 1.11.8 to 1.11.11 in /data-plateform

### DIFF
--- a/data-platform/uv.lock
+++ b/data-platform/uv.lock
@@ -972,7 +972,7 @@ wheels = [
 
 [[package]]
 name = "dbt-core"
-version = "1.11.8"
+version = "1.11.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agate" },
@@ -998,9 +998,9 @@ dependencies = [
     { name = "sqlparse" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/54/4f/5524b85f0bd94053ee51fe7e8b0011295f056da707c754975ed7da3888f9/dbt_core-1.11.8.tar.gz", hash = "sha256:1bfe0b40c958785680a1b2b894b0851f5bf780ddc058747dd1e62c389b0d3b1d", size = 972635, upload-time = "2026-04-08T19:01:46.63Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/62/af8f4ab1e3e979b5677e876444f3a9c1b1021c2d4e77143e80f421bdc1f7/dbt_core-1.11.11.tar.gz", hash = "sha256:e53cfccc8c9c13a082e518bf80cf3bb33c2f1fdc3cab48ec822ef93737eccb81", size = 973079, upload-time = "2026-05-20T11:10:01.8Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/47/a07061c70e0872d8f49fbd12cf93f481b22cabb2e75016ce00aa3520a7ab/dbt_core-1.11.8-py3-none-any.whl", hash = "sha256:13ff79252a7ae9c9acc7de243789b72f04f7f915f05930d3407edeeea3758b6f", size = 1061289, upload-time = "2026-04-08T19:01:44.83Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d2/9e1eb5d3c8f375d4e5523b9123b2ae25ea21d85abb044db2eff2e3ee9c1d/dbt_core-1.11.11-py3-none-any.whl", hash = "sha256:7f9e11f3f5400e20f40f544440800ace23fa0755086f87b08e9446181f8720e1", size = 1061938, upload-time = "2026-05-20T11:09:59.856Z" },
 ]
 
 [[package]]
@@ -1276,7 +1276,7 @@ wheels = [
 [[package]]
 name = "django-dsfr"
 version = "3.4.2"
-source = { git = "https://github.com/fabienheureux/django-dsfr?rev=b5ac6f508c6b46672b898129576f34e1b74d10d5#b5ac6f508c6b46672b898129576f34e1b74d10d5" }
+source = { git = "https://github.com/fabienheureux/django-dsfr?rev=b110ff5360c4b0503374efcc10ac4b7879a7cd96#b110ff5360c4b0503374efcc10ac4b7879a7cd96" }
 dependencies = [
     { name = "django" },
     { name = "django-widget-tweaks" },
@@ -4477,7 +4477,7 @@ requires-dist = [
     { name = "django-admin-sortable2", specifier = ">=2.2.8" },
     { name = "django-colorfield", specifier = ">=0.14.0,<0.15" },
     { name = "django-cors-headers", specifier = ">=4.6.0,<5" },
-    { name = "django-dsfr", git = "https://github.com/fabienheureux/django-dsfr?rev=b5ac6f508c6b46672b898129576f34e1b74d10d5" },
+    { name = "django-dsfr", git = "https://github.com/fabienheureux/django-dsfr?rev=b110ff5360c4b0503374efcc10ac4b7879a7cd96" },
     { name = "django-extensions", specifier = "~=4.1" },
     { name = "django-import-export", extras = ["xls", "xlsx"], specifier = ">=4.4.1,<5" },
     { name = "django-lookbook", specifier = ">=1.0.2,<2" },


### PR DESCRIPTION
# Description succincte du problème résolu

Dependencies dbt-core


**🗺️ contexte**: Dependencies

**💡 quoi**: Update DBT-CORE

**🎯 pourquoi**: Réparer dependabot 🤞

**🤔 comment**: `uv lock --upgrade-package dbt-core`

**🤓 comment tester**: Airflow DAG de raffraichissement et de stats fonctionne toujours


## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
