### PR TITLE
Ameliorer les groupes dans dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,23 +4,14 @@ version: 2
 
 updates:
   - package-ecosystem: "uv"
-    directory: "/webapp"
+    directories:
+      - "/webapp"
+      - "/data-platform"
     open-pull-requests-limit: 100
     schedule:
       interval: "weekly"
       day: "tuesday"
       time: "06:00" # UTC
-    cooldown:
-      default-days: 7
-    allow:
-      - dependency-type: "all"
-  - package-ecosystem: "uv"
-    directory: "/data-platform"
-    open-pull-requests-limit: 100
-    schedule:
-      interval: "weekly"
-      day: "tuesday"
-      time: "06:05" # UTC
     cooldown:
       default-days: 7
     allow:
@@ -37,10 +28,29 @@ updates:
     allow:
       - dependency-type: "all"
     groups:
+      babel:
+        patterns:
+          - "@babel/*"
       parcel:
         patterns:
           - "@parcel/*"
           - "parcel"
+      protobufjs:
+        patterns:
+          - "@protobufjs/*"
+          - "protobufjs"
+      swc:
+        patterns:
+          - "@swc/*"
+          - "swc"
+      mapbox:
+        patterns:
+          - "@mapbox/*"
+          - "mapbox*"
+      sentry:
+        patterns:
+          - "@sentry/*"
+          - "sentry*"
       jest:
         patterns:
           - "*jest*"
@@ -59,7 +69,9 @@ updates:
     allow:
       - dependency-type: "all"
   - package-ecosystem: "terraform"
-    directory: "/infrastructure"
+    directories:
+      - "/infrastructure/modules/*"
+      - "/infrastructure/environments/*/*"
     open-pull-requests-limit: 100
     schedule:
       interval: "weekly"


### PR DESCRIPTION
# Description succincte du problème résolu

tech

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Dependabot

**💡 quoi**: config pour grouper et corriger la partie terraform

**🎯 pourquoi**: pour que dependabot marche mieux, mon de PR par run

**🤔 comment**: 

- groupe dans la partie JS
- même process uv dans les 2 repo `data-plateform` et `webapp` à voir si ça propose une seul PR par dependance pour les 2 sous environnements
- essayer de lui donner des `directories` plus précis pour terraform

**🤓 comment tester**: faire tourner dependabot

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
