### PR TITLE
Besoin de trier les intervals car on n'est pas garanti de l'ordre

### DIFF
--- a/data-platform/dags/sources/tasks/transform/opening_hours.py
+++ b/data-platform/dags/sources/tasks/transform/opening_hours.py
@@ -19,10 +19,12 @@ DAYS_OF_WEEK = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]
 def merge_consecutive_tuples(tuples: list[tuple[Any, Any]]) -> list[tuple[Any, Any]]:
     result = []
     if tuples:
-        current_start, current_end = tuples[0]
-        for next_start, next_end in tuples[1:]:
-            if current_end == next_start:
-                current_end = next_end
+        # Sort to ensure the tuples are in chronological order
+        sorted_tuples = sorted(tuples)
+        current_start, current_end = sorted_tuples[0]
+        for next_start, next_end in sorted_tuples[1:]:
+            if next_start <= current_end:
+                current_end = max(current_end, next_end)
             else:
                 result.append((current_start, current_end))
                 current_start, current_end = next_start, next_end

--- a/data-platform/uv.lock
+++ b/data-platform/uv.lock
@@ -4286,7 +4286,7 @@ wheels = [
 
 [[package]]
 name = "wagtail"
-version = "7.4"
+version = "7.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyascii" },
@@ -4308,9 +4308,9 @@ dependencies = [
     { name = "telepath" },
     { name = "willow", extra = ["heif"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/10/ad6e496beed01a58656ddc70c16f8a8c269698a568d9054d3d5a57b56655/wagtail-7.4.tar.gz", hash = "sha256:9570c51d61ee524cc5558a84df40e2ccc03f7c50c6dad343644a45d037096d13", size = 6939468, upload-time = "2026-05-05T16:51:18.534Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/da/c060bd9ec00335336e04a610cd1d6762e459ade9c4983f7ecddae15af36d/wagtail-7.4.1.tar.gz", hash = "sha256:c7232cbe16afa5842c236e069b2baead3b3e87e9dc90a7493330b54b69e18b83", size = 6944979, upload-time = "2026-05-19T17:26:18.762Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/c1/d8effc43aaf3ba84754f247c2fb97e119534b579486b278d991068629af1/wagtail-7.4-py3-none-any.whl", hash = "sha256:24a4d55e6bed22ccce4aae1b3f7e22a46605c4bc4dc9894d5a415cde418840c6", size = 9587583, upload-time = "2026-05-05T16:51:12.575Z" },
+    { url = "https://files.pythonhosted.org/packages/53/c8/162fff3c5ef9e158127c9f4aa1f0d38edd8d1fa242629ae1d8af3b6306c7/wagtail-7.4.1-py3-none-any.whl", hash = "sha256:a42dc18b0fb818649c0d704ea50a2dea06d1b75614abdf837e90766263645c76", size = 9597601, upload-time = "2026-05-19T17:26:12.53Z" },
 ]
 
 [[package]]
@@ -4503,7 +4503,7 @@ requires-dist = [
     { name = "shortuuid", specifier = ">=1.0.13,<2" },
     { name = "sites-conformes", specifier = "==3.1.0rc4" },
     { name = "unidecode", specifier = ">=1.4.0,<2" },
-    { name = "wagtail", specifier = "==7.4" },
+    { name = "wagtail", specifier = "==7.4.1" },
     { name = "wagtail-honeypot", specifier = ">=1.3.0" },
     { name = "wagtailmenus", specifier = ">=4.0.7" },
     { name = "whitenoise", specifier = ">=6.8.2,<7" },
@@ -4526,7 +4526,7 @@ dev = [
     { name = "pytest-dotenv", specifier = ">=0.5.2,<0.6" },
     { name = "pytest-mock", specifier = ">=3.14.1,<4" },
     { name = "ruff", specifier = ">=0.15.14,<0.16" },
-    { name = "wagtail-factories", specifier = ">=4.4.0,<5" },
+    { name = "wagtail-factories", specifier = ">=4.2.1,<5" },
 ]
 
 [[package]]


### PR DESCRIPTION

# Description succincte du problème résolu

Besoin de trier les interval car on n'est pas garanti de l'ordre des plages horaires avant fusion
Changement de comportement de la lib [opening-hours-rs](https://github.com/remi-dupre/opening-hours-rs/tree/master) en version 1.3.1

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Data-platform

**💡 quoi**: correction de la fonction de merge des plages horaire

**🎯 pourquoi**: car opening-hours-rs ne garanti plus l'ordre chronologique des plages horaires retournées

**🤔 comment**: tri des plages horaires avant le merge

**🤓 comment tester**: les tests passent, l'ingestion des horaires au format OSM doit fonctionner -> dag de type source


## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
