### PR TITLE
ajout d'un nouvel outil infotri dans posthog

### DIFF
--- a/webapp/e2e_tests/analytics.spec.ts
+++ b/webapp/e2e_tests/analytics.spec.ts
@@ -169,6 +169,16 @@ test.describe("📊 Analytics & Tracking", () => {
         expectedPageType: "quefaire",
         expectedPageSlug: "",
       },
+      {
+        testId: "iframe-infotri-configurateur",
+        expectedPageType: "infotri-configurateur",
+        expectedPageSlug: "",
+      },
+      {
+        testId: "iframe-infotri",
+        expectedPageType: "infotri",
+        expectedPageSlug: "",
+      },
     ]
 
     for (const { testId, expectedPageType, expectedPageSlug } of iframeCases) {

--- a/webapp/static/to_compile/controllers/shared/analytics.ts
+++ b/webapp/static/to_compile/controllers/shared/analytics.ts
@@ -399,8 +399,11 @@ export default class extends Controller<HTMLElement> {
     if (pathname.startsWith("/formulaire")) {
       return { pageType: "formulaire", pageSlug: "" }
     }
-    if (pathname.startsWith("/infotri")) {
+    if (pathname.startsWith("/infotri/embed")) {
       return { pageType: "infotri", pageSlug: "" }
+    }
+    if (pathname.startsWith("/infotri")) {
+      return { pageType: "infotri-configurateur", pageSlug: "" }
     }
     return { pageType: "quefaire", pageSlug: pathname.replace(/^\//, "") }
   }

--- a/webapp/templates/ui/tests/t_18_iframe_page_properties.html
+++ b/webapp/templates/ui/tests/t_18_iframe_page_properties.html
@@ -1,7 +1,7 @@
 {% load dsfr_tags %}
 
 <div style="padding-top: 2000px;">
-  {% dsfr_callout title="Test pageType / pageSlug dans les événements iframe" text="Cette page intègre 4 iframes (carte, carte sur mesure, formulaire, assistant) pour vérifier que les événements PostHog iframe_page_viewed et interacted_with_iframe contiennent les bonnes propriétés pageType et pageSlug." icon_class="fr-icon-flask-line" %}
+  {% dsfr_callout title="Test pageType / pageSlug dans les événements iframe" text="Cette page intègre plusieurs iframes (carte, carte sur mesure, formulaire, assistant, info-tri configurateur, info-tri widget) pour vérifier que les événements PostHog iframe_page_viewed et interacted_with_iframe contiennent les bonnes propriétés pageType et pageSlug." icon_class="fr-icon-flask-line" %}
 
   <p>Scrollez jusqu'à chaque iframe pour déclencher les événements.</p>
 
@@ -23,5 +23,15 @@
   <h2>Assistant (<code>/</code>)</h2>
   <div data-testid="iframe-assistant" style="margin-bottom: 2rem;">
     <script src="{{ base_url }}/iframe.js"></script>
+  </div>
+
+  <h2>Info-tri configurateur (<code>/infotri</code>)</h2>
+  <div data-testid="iframe-infotri-configurateur" style="margin-bottom: 2rem;">
+    <script src="{{ base_url }}/infotri/configurateur.js"></script>
+  </div>
+
+  <h2>Info-tri widget (<code>/infotri/embed</code>)</h2>
+  <div data-testid="iframe-infotri" style="margin-bottom: 2rem;">
+    <script src="{{ base_url }}/infotri/iframe.js"></script>
   </div>
 </div>


### PR DESCRIPTION
# Description succincte du problème résolu

**🗺️ contexte**: posthog

**💡 quoi**: distinction de l'infotri et du configurateur dans la super property `outil`
de posthog

**🎯 pourquoi**: pour aider Guillaume à mesurer son ROI :D

**🤔 comment**:
- ajout d'une nouvelle valeur `infotri-configurateur` à la super property `outil`
- découpe de la logique de routing : `/infotri/embed` → `infotri`, `/infotri` →
`infotri-configurateur`

**🤓 comment tester**:

- charger /infotri
- vérifier dans le projet posthog que les events (ex: `$pageview`) ont bien `outil:
infotri-configurateur`
- charger /infotri/embed
- vérifier dans le projet posthog que les events ont bien `outil: infotri`