### PR TITLE
les float ne sont pas bien gérés dans l'interface Airflow v3

### DIFF
--- a/data-platform/dags/cluster/config/models.py
+++ b/data-platform/dags/cluster/config/models.py
@@ -38,7 +38,7 @@ class ClusterConfig(BaseModel):
     cluster_intra_source_is_allowed: bool
     cluster_fields_exact: list[str]
     cluster_fields_fuzzy: list[str]
-    cluster_fuzzy_threshold: float
+    cluster_fuzzy_threshold: float | int
 
     # DEDUP
     dedup_enrich_fields: list[str]
@@ -124,15 +124,20 @@ class ClusterConfig(BaseModel):
             raise ValueError("La distance dans le cluster doit être positive ou nulle")
 
         if values.get("cluster_fuzzy_threshold") is None:
-            values["cluster_fuzzy_threshold"] = 0.0
+            values["cluster_fuzzy_threshold"] = 0
 
         if (
             values["cluster_fuzzy_threshold"] < 0
-            or values["cluster_fuzzy_threshold"] > 1
+            or values["cluster_fuzzy_threshold"] > 100
         ):
             raise ValueError(
                 "Le seuil de similarité pour le groupage fuzzy doit être entre 0 et 1"
             )
+
+        # Convert to a float between 0 and 1
+        values["cluster_fuzzy_threshold"] = (
+            float(values["cluster_fuzzy_threshold"]) / 100.0
+        )
 
         # SOURCE CODES
         # Si aucun code source fourni alors on inclut toutes les sources

--- a/data-platform/dags/cluster/dags/cluster_acteur_suggestions.py
+++ b/data-platform/dags/cluster/dags/cluster_acteur_suggestions.py
@@ -243,10 +243,13 @@ PARAMS = {
             exemple: ["code_postal", "ville"]""",
     ),
     "cluster_fuzzy_threshold": Param(
-        0.5,
+        50,
         type=["number", "null"],
+        examples=[0, 50, 90],
+        min_value=0,
+        max_value=100,
         description_md=f"""Seuil de similarité pour le groupage fuzzy.
-            0 = pas de similarité, 1 = similarité parfaite
+            0 = pas de similarité, 100 = similarité parfaite
 
             {UI_PARAMS_SEPARATORS.DEDUP_CHOOSE_PARENT}
 

--- a/data-platform/dags/tests/cluster/config/test_model.py
+++ b/data-platform/dags/tests/cluster/config/test_model.py
@@ -25,7 +25,7 @@ class TestClusterConfigModel:
             "cluster_intra_source_is_allowed": False,
             "cluster_fields_exact": ["exact1", "exact2"],
             "cluster_fields_fuzzy": ["fuzzy1", "fuzzy2"],
-            "cluster_fuzzy_threshold": 0.5,
+            "cluster_fuzzy_threshold": 50,
             "dedup_enrich_fields": ["f1_incl", "f2_incl", "f3_excl"],
             "dedup_enrich_exclude_sources": ["source1 (id=1)"],
             "dedup_enrich_priority_sources": ["source1 (id=1)"],
@@ -178,21 +178,21 @@ class TestClusterConfigModel:
 
     def test_cluster_fuzzy_threshold_valid_range(self, params_working):
         # Le seuil doit être entre 0 et 1
-        params_working["cluster_fuzzy_threshold"] = 0.0
+        params_working["cluster_fuzzy_threshold"] = 0
         config = ClusterConfig(**params_working)
         assert config.cluster_fuzzy_threshold == 0.0
 
-        params_working["cluster_fuzzy_threshold"] = 1.0
+        params_working["cluster_fuzzy_threshold"] = 100
         config = ClusterConfig(**params_working)
         assert config.cluster_fuzzy_threshold == 1.0
 
-        params_working["cluster_fuzzy_threshold"] = 0.5
+        params_working["cluster_fuzzy_threshold"] = 50
         config = ClusterConfig(**params_working)
         assert config.cluster_fuzzy_threshold == 0.5
 
     def test_cluster_fuzzy_threshold_below_zero_is_rejected(self, params_working):
         # Pas de validation de range dans le modèle : on garde la valeur telle quelle
-        params_working["cluster_fuzzy_threshold"] = -0.1
+        params_working["cluster_fuzzy_threshold"] = -10
         with pytest.raises(
             ValueError,
             match=(
@@ -203,7 +203,7 @@ class TestClusterConfigModel:
 
     def test_cluster_fuzzy_threshold_above_one_is_rejected(self, params_working):
         # Pas de validation de range dans le modèle : on garde la valeur telle quelle
-        params_working["cluster_fuzzy_threshold"] = 1.1
+        params_working["cluster_fuzzy_threshold"] = 110
         with pytest.raises(
             ValueError,
             match=(


### PR DESCRIPTION
# Description succincte du problème résolu

Mattermost : https://mattermost.incubateur.net/betagouv/pl/53cki179htyddnq3yfsk3qaewc


**🗺️ contexte**: Airflow - Clustering

**💡 quoi**: Passer le paramètre `cluster_fuzzy_threshold` en entier car Airflow ne gère pas bien les float en UI

**🎯 pourquoi**: Bug Airflow

**🤔 comment**: Contourner le bug en passant le pramaètre cluster_fuzzy_threshold en entier de 0 à 100

- On le passe en entier
- On le convertit en float entre 0 et 1 pour ne pas modifier le comportement

**🤓 comment tester**: 

- Lancer un DAG de clustering avec un seuil cluster_fuzzy_threshold entre 0 et 100

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

