### PR TITLE
Réduction des marges sur le fil d'ariane des pages produit

### DIFF
--- a/webapp/static/to_compile/styles/dsfr-overrides.css
+++ b/webapp/static/to_compile/styles/dsfr-overrides.css
@@ -253,3 +253,10 @@ https://github.com/GouvernementFR/dsfr/blob/6a2bbfe02e396d8d77c50efee9638ab78c7b
     }
   }
 }
+
+/** breadcrumb does not plays well with our page produit design.
+we reduce its margin in order to prevent the produit page hero
+to be too tall */
+.produit-page .fr-breadcrumb {
+  margin-bottom: 0;
+}

--- a/webapp/templates/ui/pages/produit_page.html
+++ b/webapp/templates/ui/pages/produit_page.html
@@ -4,6 +4,8 @@
 
 {% block analytics_action %}produitPageView{% endblock %}
 
+{% block body_classes %}produit-page{% endblock %}
+
 {% block main %}
 <div
     class="qf-flex qf-flex-col


### PR DESCRIPTION
# Description succincte du problème résolu

https://app.notion.com/p/accelerateur-transition-ecologique-ademe/Fil-d-ariane-Probl-me-de-hauteur-avec-bcp-de-blanc-3726523d57d7803a8914cfd2ecfd6d6a?source=copy_link


**🗺️ contexte**: fil d'ariane sur fiches produit

**💡 quoi**: le fil d'ariane des fiches produit affiche une marge trop importante

**🎯 pourquoi**: car on a tenté de respecter le dsfr, mais il faut faire du custom

**🤔 comment**:

- ajout d'une classe sur les pages produit
- ajout d'un override explicite dans le fichier css dédié

**🤓 comment tester**:

- chercher bout de canapé sur la home 
- cliquer sur le résultat correspondant
- vérifier que le breadcrumb s'affiche comme sur la créa https://www.figma.com/design/8lTOjFETVvT3pAz5rebxhE/%F0%9F%AA%91-Que-faire---Espace-de-travail?node-id=29854-21145&t=NPmgwSardAHLiGYB-0

## Exemple résultats / UI / Data

<img width="1182" height="805" alt="image" src="https://github.com/user-attachments/assets/00616f56-60c7-40fa-a669-0de90853d091" />


## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
