### PR TITLE
Suppression des espaces autour des emails

### DIFF
--- a/webapp/qfdmo/management/commands/trim_emails.py
+++ b/webapp/qfdmo/management/commands/trim_emails.py
@@ -1,0 +1,44 @@
+import argparse
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.db.models import Q
+from django.db.models.functions import Trim
+from qfdmo.models.acteur import Acteur, RevisionActeur
+
+
+class Command(BaseCommand):
+    help = "Strip leading and trailing whitespace from acteur emails"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            help="Run command without writing changes to the database",
+            action=argparse.BooleanOptionalAction,
+            default=False,
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        email_to_strip = Q(email__startswith=" ") | Q(email__endswith=" ")
+
+        with transaction.atomic():
+            results = []
+            for model in (Acteur, RevisionActeur):
+                qs = model.objects.filter(email_to_strip)
+                emails = qs.values_list("email", flat=True)
+                if dry_run:
+                    count = qs.count()
+                else:
+                    count = qs.update(email=Trim("email"))
+                results.append((model.__name__, count, emails))
+
+        prefix = "[DRY-RUN] " if dry_run else ""
+        for name, count, emails in results:
+            self.stdout.write(
+                self.style.SUCCESS(f"{prefix}{name}: {count} email(s) cleaned")
+            )
+            if emails:
+                self.stdout.write(
+                    self.style.SUCCESS(f"Emails: `{('`, `').join(list(emails))}`")
+                )


### PR DESCRIPTION
# Description succincte du problème résolu

Mattermost : https://mattermost.incubateur.net/betagouv/pl/5o64qjkxwfbrffryjhaw9uayca

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Data en DB

**💡 quoi**: Certains email finissent par un espace, du coup, il ne passent pas la validation

**🎯 pourquoi**: Vieille data enregistrées avant la mise en place de la validation

**🤔 comment**: Command Django

**🤓 comment tester**:

- lancer la commande `uv run python manage.py trim_emails`
- chercher en DB si il reste des emails avec des espaces en début ou fin d'email

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
