### PR TITLE
renommer 'En savoir plus sur ce site' en 'En savoir plus sur cet outil'

### DIFF
--- a/webapp/e2e_tests/iframe_navigation.spec.ts
+++ b/webapp/e2e_tests/iframe_navigation.spec.ts
@@ -16,12 +16,12 @@ const checkIframeUIIsPersisted = async (iframe: FrameLocator) => {
     iframe.locator('.fr-header:not([data-testid="header-iframe"])'),
   ).not.toBeVisible()
   await expect(
-    iframe.locator('button:has-text("En savoir plus sur ce site")'),
+    iframe.locator('button:has-text("En savoir plus sur cet outil")'),
   ).toBeVisible()
 
   // Check that iframe-specific button is present
   await expect(
-    iframe.locator('button:has-text("En savoir plus sur ce site")'),
+    iframe.locator('button:has-text("En savoir plus sur cet outil")'),
   ).toBeVisible()
 
   // Navigate using an external link on the product page to test internal navigation
@@ -115,7 +115,7 @@ test.describe("📄 Découpe du contenu de la fiche dans l'iframe", () => {
     const onclick = await lirePlus.getAttribute("onclick")
     expect(onclick).toContain("window.open")
     expect(onclick).toContain("_blank")
-    // It opens a fiche déchet URL, not the generic "En savoir plus sur ce site" target.
+    // It opens a fiche déchet URL, not the generic "En savoir plus sur cet outil" target.
     expect(onclick).toContain("/dechet/")
   })
 

--- a/webapp/templates/ui/components/footer/base.iframe.html
+++ b/webapp/templates/ui/components/footer/base.iframe.html
@@ -5,14 +5,14 @@
     This could be updated if django-dsfr adds support for link buttons in the future.
 
     Future alternative (doesn't display properly yet):
-    {% dsfr_link url="https://quefairedemesdechets.ademe.fr" label="En savoir plus sur ce site" is_external=True extra_classes="fr-btn fr-btn--tertiary" %}
+    {% dsfr_link url="https://quefairedemesdechets.ademe.fr" label="En savoir plus sur cet outil" is_external=True extra_classes="fr-btn fr-btn--tertiary" %}
     {% endcomment %}
     <div class="qf-flex qf-gap-2w md:qf-flex-row qf-flex-col">
         {% if footer_primary_button %}
             {% dsfr_button footer_primary_button %}
         {% endif %}
 
-        {% dsfr_button label="En savoir plus sur ce site" extra_classes="fr-btn--tertiary fr-btn--icon-left fr-icon-external-link-line" onclick="window.open('https://quefairedemesdechets.ademe.fr', '_blank', 'noopener,noreferrer')" %}
+        {% dsfr_button label="En savoir plus sur cet outil" extra_classes="fr-btn--tertiary fr-btn--icon-left fr-icon-external-link-line" onclick="window.open('https://quefairedemesdechets.ademe.fr', '_blank', 'noopener,noreferrer')" %}
     </div>
     <div class="qf-flex qf-gap-2w">
         {% include "ui/components/footer/combined_logos.html" %}


### PR DESCRIPTION
# Description succincte du problème résolu

https://app.notion.com/p/accelerateur-transition-ecologique-ademe/Assistant-en-cas-d-iframe-le-bouton-devrait-dire-En-savoir-plus-sur-cet-outil-pas-En-savoir-plu-33c6523d57d7805595b6c0871761e6a8?source=copy_link


**🗺️ contexte**: Aucun, mise à jour textuelle simple du footer iframe.

**💡 quoi**: Renommer le libellé du bouton en pied d’iframe : « En savoir plus sur ce site » devient « En savoir plus sur cet outil ».

**🎯 pourquoi**: Clarifier la distinction entre l’outil et le site général.

**🤔 comment**: 
- Mise à jour du template du footer iframe
- Mise à jour du test e2e concerné pour refléter le nouveau libellé

**🤓 comment tester**: 
- Vérifier dans l’iframe que le bouton affiche bien « En savoir plus sur cet outil »
- Lancer les tests e2e iframe : `poetry run pytest e2e_tests/iframe_navigation.spec.ts`

## Auto-review

- [x] J’ai bien relu mon code
- [x] La CI passe bien
- [ ] J’ai mis à jour le `.env.template` si nécessaire
- [ ] J’ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d’ajout de dépendance, j’ai bien respecté un cooldown de 7 jours

