### PR TITLE
ajout du header add X-Robots-Tag dans un autre bloc pour éviter qu'il soit ignoré

### DIFF
--- a/webapp/servers.conf.erb
+++ b/webapp/servers.conf.erb
@@ -69,6 +69,9 @@ server {
         proxy_cache_valid 200 301 302 10m;
         proxy_cache_valid 404 1m;
         add_header X-Cache-Status $upstream_cache_status always;
+<% if ENV["ENVIRONMENT"] != "production" %>
+        add_header X-Robots-Tag "noindex, nofollow" always;
+<% end %>
     }
 
     # PostHog proxy - keeps analytics traffic on our domain, bypasses ad-blockers
@@ -111,6 +114,9 @@ server {
         proxy_cache_use_stale error timeout updating;
         proxy_cache_background_update on;
         add_header X-Cache-Status $upstream_cache_status always;
+<% if ENV["ENVIRONMENT"] != "production" %>
+        add_header X-Robots-Tag "noindex, nofollow" always;
+<% end %>
     }
 
     location ~ ^/(favicon(?:-\d+)?.(?:jpe?g|png|ico))$ {


### PR DESCRIPTION
# Description succincte du problème résolu

**🗺️ contexte**: PR #3017 a ajouté un header `X-Robots-Tag` niveau serveur dans le bloc `server {}` de nginx pour empêcher l'indexation des environnements non-production.

**💡 quoi**: L'en-tête `X-Robots-Tag "noindex, nofollow"` est ajouté dans tous les blocs `location` qui définissent leur propre `add_header`, en particulier les blocs de cache et de proxy.

**🎯 pourquoi**: Nginx a un comportement particulier : quand un bloc `location` définit sa propre directive `add_header`, il hérite **uniquement** de `add_header` définis au niveau du bloc `location` parent (pas du `server`). Les en-têtes définis dans le `server {}` sont ignorés. Résultat : les routes mises en cache (proxy vers Django app, images statiques) n'avaient pas le header `X-Robots-Tag`, donc ces pages pouvaient être indexées par les moteurs de recherche.

**🤔 comment**:
- Ajout de `<% if ENV["ENVIRONMENT"] != "production" %> add_header X-Robots-Tag "noindex, nofollow" always; <% end %>` dans les deux blocs `location` de `webapp/servers.conf.erb` qui font du proxy_cache
- Ces blocs avaient déjà `add_header X-Cache-Status` — le `location` annulait donc le `X-Robots-Tag` du `server`

**🤓 comment tester**:
1. Déployer sur un environnement non-production (ex: staging, preview)
2. Vérifier avec `curl -I <url>` que la réponse d'une route en cache (ex: page d'accueil, image) contient bien l'en-tête `X-Robots-Tag: noindex, nofollow`
3. Vérifier que la production ne reçoit **pas** cet en-tête

## Exemple résultats / UI / Data

Avant (environnement non-production, route en cache) :
```
HTTP/2 200
...
X-Cache-Status: HIT
# X-Robots-Tag manquant
```

Après :
```
HTTP/2 200
...
X-Cache-Status: HIT
X-Robots-Tag: noindex, nofollow
```

## Auto-review

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)