### PR TITLE
Les parametres de DAG dry_run et use_legacy doivent être à Faux par défaut

### DIFF
--- a/data-platform/dags/cluster/dags/cluster_acteur_suggestions.py
+++ b/data-platform/dags/cluster/dags/cluster_acteur_suggestions.py
@@ -59,7 +59,7 @@ exclus_string = "  \n".join([", ".join(chunck) for chunck in fields_enrich_exclu
 DAG_ID = "cluster_acteur_suggestions"
 PARAMS = {
     "dry_run": Param(
-        True,
+        False,
         type="boolean",
         description_md=f"""
             🚱 Si coché, aucune tâche d'écriture ne sera effectuée.

--- a/data-platform/dags/crawl/dags/crawl_urls.py
+++ b/data-platform/dags/crawl/dags/crawl_urls.py
@@ -48,7 +48,7 @@ with DAG(
     tags=[TAGS.ENRICH, TAGS.CRAWL, TAGS.ACTEURS, TAGS.URL, TAGS.SUGGESTIONS],
     params={
         "dry_run": Param(
-            True,
+            False,
             type="boolean",
             description_md=f"""🚱 Si coché, les URLs seront parcourues
             mais les suggestions pas écrites en base.

--- a/data-platform/dags/sources/dags/source_aliapur.py
+++ b/data-platform/dags/sources/dags/source_aliapur.py
@@ -36,7 +36,7 @@ with DAG(
             ),
             "validate_address_with_ban": False,
             "product_mapping": get_mapping_config(),
-            "use_legacy_suggestions": True,
+            "use_legacy_suggestions": False,
         }
     ),
 ) as dag:

--- a/data-platform/dags/sources/dags/source_batribox.py
+++ b/data-platform/dags/sources/dags/source_batribox.py
@@ -44,7 +44,7 @@ with DAG(
             ),
             "validate_address_with_ban": False,
             "product_mapping": get_mapping_config("sous_categories"),
-            "use_legacy_suggestions": True,
+            "use_legacy_suggestions": False,
         }
     ),
 ) as dag:

--- a/data-platform/dags/sources/dags/source_citeo.py
+++ b/data-platform/dags/sources/dags/source_citeo.py
@@ -52,7 +52,7 @@ with DAG(
             On y associera alors le geste `donner`.
             """,
             ),
-            "use_legacy_suggestions": True,
+            "use_legacy_suggestions": False,
         }
     ),
 ) as dag:

--- a/data-platform/dags/sources/dags/source_cma.py
+++ b/data-platform/dags/sources/dags/source_cma.py
@@ -2,12 +2,11 @@ import json
 
 from airflow import DAG
 from airflow.sdk.definitions.param import ParamsDict
+from qfdmo.models.acteur import ActeurPublicAccueilli, ActeurStatus
 from shared.config.airflow import DEFAULT_ARGS
 from shared.config.tags import TAGS
 from sources.config.airflow_params import get_mapping_config
 from sources.tasks.airflow_logic.operators import default_params, eo_task_chain
-
-from qfdmo.models.acteur import ActeurPublicAccueilli, ActeurStatus
 
 with DAG(
     dag_id="cma",
@@ -176,7 +175,7 @@ with DAG(
             "endpoint": ("https://apiopendata.artisanat.fr/reparacteur"),
             "validate_address_with_ban": False,
             "product_mapping": get_mapping_config(mapping_key="sous_categories_cma"),
-            "use_legacy_suggestions": True,
+            "use_legacy_suggestions": False,
         }
     ),
 ) as dag:

--- a/data-platform/dags/sources/dags/source_corepile.py
+++ b/data-platform/dags/sources/dags/source_corepile.py
@@ -36,7 +36,7 @@ with DAG(
             ),
             "validate_address_with_ban": False,
             "product_mapping": get_mapping_config(),
-            "use_legacy_suggestions": True,
+            "use_legacy_suggestions": False,
         }
     ),
 ) as dag:

--- a/data-platform/dags/sources/dags/source_cyclevia.py
+++ b/data-platform/dags/sources/dags/source_cyclevia.py
@@ -36,7 +36,7 @@ with DAG(
             ),
             "validate_address_with_ban": False,
             "product_mapping": get_mapping_config(),
-            "use_legacy_suggestions": True,
+            "use_legacy_suggestions": False,
         }
     ),
 ) as dag:

--- a/data-platform/dags/sources/dags/source_ecodds.py
+++ b/data-platform/dags/sources/dags/source_ecodds.py
@@ -37,7 +37,7 @@ with DAG(
             ),
             "validate_address_with_ban": False,
             "product_mapping": get_mapping_config(),
-            "use_legacy_suggestions": True,
+            "use_legacy_suggestions": False,
         }
     ),
 ) as dag:

--- a/data-platform/dags/sources/dags/source_ecologic.py
+++ b/data-platform/dags/sources/dags/source_ecologic.py
@@ -38,7 +38,7 @@ with DAG(
             ),
             "validate_address_with_ban": False,
             "product_mapping": get_mapping_config(mapping_key="sous_categories_3eee"),
-            "use_legacy_suggestions": True,
+            "use_legacy_suggestions": False,
         }
     ),
 ) as dag:

--- a/data-platform/dags/sources/dags/source_ecomaison.py
+++ b/data-platform/dags/sources/dags/source_ecomaison.py
@@ -39,7 +39,7 @@ with DAG(
             ),
             "validate_address_with_ban": False,
             "product_mapping": get_mapping_config(),
-            "use_legacy_suggestions": True,
+            "use_legacy_suggestions": False,
         }
     ),
 ) as dag:

--- a/data-platform/dags/sources/dags/source_ecopae.py
+++ b/data-platform/dags/sources/dags/source_ecopae.py
@@ -36,7 +36,7 @@ with DAG(
             ),
             "validate_address_with_ban": False,
             "product_mapping": get_mapping_config(),
-            "use_legacy_suggestions": True,
+            "use_legacy_suggestions": False,
         }
     ),
 ) as dag:

--- a/data-platform/dags/sources/dags/source_ecosystem.py
+++ b/data-platform/dags/sources/dags/source_ecosystem.py
@@ -36,7 +36,7 @@ with DAG(
             ),
             "validate_address_with_ban": False,
             "product_mapping": get_mapping_config(mapping_key="sous_categories_3eee"),
-            "use_legacy_suggestions": True,
+            "use_legacy_suggestions": False,
         }
     ),
 ) as dag:

--- a/data-platform/dags/sources/dags/source_generic.py
+++ b/data-platform/dags/sources/dags/source_generic.py
@@ -148,7 +148,7 @@ with DAG(
             "metadata_endpoint": "https://<URL>/schema",
             "validate_address_with_ban": False,
             "product_mapping": get_mapping_config(),
-            "use_legacy_suggestions": True,
+            "use_legacy_suggestions": False,
         }
     ),
 ) as dag:

--- a/data-platform/dags/sources/dags/source_ocab.py
+++ b/data-platform/dags/sources/dags/source_ocab.py
@@ -40,7 +40,7 @@ with DAG(
             },
             "validate_address_with_ban": False,
             "product_mapping": get_mapping_config(),
-            "use_legacy_suggestions": True,
+            "use_legacy_suggestions": False,
         }
     ),
 ) as dag:

--- a/data-platform/dags/sources/dags/source_ocad3e.py
+++ b/data-platform/dags/sources/dags/source_ocad3e.py
@@ -39,7 +39,7 @@ with DAG(
             "product_mapping": get_mapping_config(
                 mapping_key="sous_categories_qualirepar"
             ),
-            "use_legacy_suggestions": True,
+            "use_legacy_suggestions": False,
         }
     ),
 ) as dag:

--- a/data-platform/dags/sources/dags/source_pharmacies.py
+++ b/data-platform/dags/sources/dags/source_pharmacies.py
@@ -2,12 +2,11 @@ import json
 
 from airflow import DAG
 from airflow.sdk.definitions.param import ParamsDict
+from qfdmo.models.acteur import ActeurPublicAccueilli, ActeurStatus
 from shared.config.airflow import DEFAULT_ARGS
 from shared.config.tags import TAGS
 from sources.config.airflow_params import get_mapping_config
 from sources.tasks.airflow_logic.operators import default_params, eo_task_chain
-
-from qfdmo.models.acteur import ActeurPublicAccueilli, ActeurStatus
 
 with DAG(
     dag_id="pharmacies",
@@ -125,7 +124,7 @@ with DAG(
             "endpoint": "https://www.ordre.pharmacien.fr/download/annuaire_csv.zip",
             "validate_address_with_ban": False,
             "product_mapping": get_mapping_config(),
-            "use_legacy_suggestions": True,
+            "use_legacy_suggestions": False,
         }
     ),
 ) as dag:

--- a/data-platform/dags/sources/dags/source_pyreo.py
+++ b/data-platform/dags/sources/dags/source_pyreo.py
@@ -36,7 +36,7 @@ with DAG(
             ),
             "validate_address_with_ban": False,
             "product_mapping": get_mapping_config(),
-            "use_legacy_suggestions": True,
+            "use_legacy_suggestions": False,
         }
     ),
 ) as dag:

--- a/data-platform/dags/sources/dags/source_refashion.py
+++ b/data-platform/dags/sources/dags/source_refashion.py
@@ -37,7 +37,7 @@ with DAG(
             "validate_address_with_ban": False,
             "label_bonus_reparation": "refashion",
             "product_mapping": get_mapping_config(),
-            "use_legacy_suggestions": True,
+            "use_legacy_suggestions": False,
         }
     ),
 ) as dag:

--- a/data-platform/dags/sources/dags/source_s3.py
+++ b/data-platform/dags/sources/dags/source_s3.py
@@ -165,7 +165,7 @@ with DAG(
             ),
             "validate_address_with_ban": False,
             "product_mapping": get_souscategorie_mapping_from_db(),
-            "use_legacy_suggestions": True,
+            "use_legacy_suggestions": False,
         }
     ),
 ) as dag:

--- a/data-platform/dags/sources/dags/source_sinoe.py
+++ b/data-platform/dags/sources/dags/source_sinoe.py
@@ -1,16 +1,15 @@
 import json
 
 from airflow import DAG
+from airflow.sdk.definitions.param import ParamsDict
+from qfdmo.models.acteur import ActeurStatus
 from shared.config.airflow import DEFAULT_ARGS_NO_RETRIES
 from shared.config.tags import TAGS
-from airflow.sdk.definitions.param import ParamsDict
 from sources.config.airflow_params import (
     get_mapping_config,
     source_sinoe_dechet_mapping_get,
 )
 from sources.tasks.airflow_logic.operators import default_params, eo_task_chain
-
-from qfdmo.models.acteur import ActeurStatus
 
 with DAG(
     dag_id="source_sinoe",
@@ -171,7 +170,7 @@ with DAG(
             "dechet_mapping": source_sinoe_dechet_mapping_get(),
             "validate_address_with_ban": False,
             "product_mapping": get_mapping_config("sous_categories_sinoe"),
-            "use_legacy_suggestions": True,
+            "use_legacy_suggestions": False,
         }
     ),
 ) as dag:

--- a/data-platform/dags/sources/dags/source_soren.py
+++ b/data-platform/dags/sources/dags/source_soren.py
@@ -36,7 +36,7 @@ with DAG(
             ),
             "validate_address_with_ban": False,
             "product_mapping": get_mapping_config(),
-            "use_legacy_suggestions": True,
+            "use_legacy_suggestions": False,
         }
     ),
 ) as dag:

--- a/data-platform/dags/sources/dags/source_valdelia.py
+++ b/data-platform/dags/sources/dags/source_valdelia.py
@@ -36,7 +36,7 @@ with DAG(
             ),
             "validate_address_with_ban": False,
             "product_mapping": get_mapping_config(),
-            "use_legacy_suggestions": True,
+            "use_legacy_suggestions": False,
         }
     ),
 ) as dag:

--- a/data-platform/dags/tests/cluster/config/test_model.py
+++ b/data-platform/dags/tests/cluster/config/test_model.py
@@ -8,7 +8,7 @@ class TestClusterConfigModel:
     def params_working(self) -> dict:
         # Paramètres pour créer une config qui fonctionne
         return {
-            "dry_run": True,
+            "dry_run": False,
             "include_sources": ["source1 (id=1)", "source3 (id=3)"],
             "apply_include_sources_to_parents": True,
             "include_acteur_types": ["atype2 (id=2)", "atype3 (id=3)"],

--- a/data-platform/dags/tests/cluster/helpers/configs.py
+++ b/data-platform/dags/tests/cluster/helpers/configs.py
@@ -7,7 +7,7 @@ We represent the confs in dict format because:
 """
 
 CONF_BASE_DICT = {
-    "dry_run": True,
+    "dry_run": False,
     "include_sources": ["ecopae (id=252)", "cyclevia (id=90)"],
     "apply_include_sources_to_parents": False,
     "include_acteur_types": ["decheterie (id=7)"],

--- a/data-platform/dags/tools/dags/airflow_cleanup_db.py
+++ b/data-platform/dags/tools/dags/airflow_cleanup_db.py
@@ -34,7 +34,7 @@ DEFAULT_BATCH_SIZE = 1000
     ],
     params={
         "dry_run": Param(
-            default=False,
+            False,
             type="boolean",
             description="🚱 Si coché: on affiche de l'info mais pas de nettoyage",
         ),


### PR DESCRIPTION
# Description succincte du problème résolu

Demande de Christian, c'est plus pratique car c'est ce qu'il utilise le plus souvent : dry-run = Faux et use_legacy_suggestions = Faux

**🗺️ contexte**: Airflow DAG

**💡 quoi**: mettre les paramètres de DAG `dry_run` et `use_legacy_suggestions`

**🎯 pourquoi**: réduire le nombre de clique de Christian

**🤔 comment**: mettre les valeur par défaut à `False` partout où elle sont utilisées

**🤓 comment tester**: 

- Lancer la stack Airflow : `docker compose --profile lvao --profile airflow up -d`
- se connecter : `http://localhost:8080/dags`
- lancer des DAG et vérifier que les flags `dry_run` et `use_legacy_suggestions` sont à Faux par défaut


## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
