### PR TITLE
[DBT] Ne pas utiliser de source dans les models autre que ceux de base

### DIFF
--- a/data-platform/dbt/dbt_project.yml
+++ b/data-platform/dbt/dbt_project.yml
@@ -35,3 +35,4 @@ clean-targets:
 
 models:
   +unlogged: true
+  +materialized: table

--- a/data-platform/dbt/models/base/acteurs/base_acteurservice.sql
+++ b/data-platform/dbt/models/base/acteurs/base_acteurservice.sql
@@ -1,0 +1,1 @@
+select * from {{ source('qfdmo', 'qfdmo_acteurservice') }}

--- a/data-platform/dbt/models/base/acteurs/base_displayedacteur.sql
+++ b/data-platform/dbt/models/base/acteurs/base_displayedacteur.sql
@@ -1,0 +1,1 @@
+select * from {{ source('qfdmo', 'qfdmo_displayedacteur') }}

--- a/data-platform/dbt/models/base/acteurs/base_displayedacteur_acteur_services.sql
+++ b/data-platform/dbt/models/base/acteurs/base_displayedacteur_acteur_services.sql
@@ -1,0 +1,1 @@
+select * from {{ source('qfdmo', 'qfdmo_displayedacteur_acteur_services') }}

--- a/data-platform/dbt/models/base/acteurs/base_displayedacteur_labels.sql
+++ b/data-platform/dbt/models/base/acteurs/base_displayedacteur_labels.sql
@@ -1,0 +1,1 @@
+select * from {{ source('qfdmo', 'qfdmo_displayedacteur_labels') }}

--- a/data-platform/dbt/models/base/acteurs/base_displayedacteur_sources.sql
+++ b/data-platform/dbt/models/base/acteurs/base_displayedacteur_sources.sql
@@ -1,0 +1,1 @@
+select * from {{ source('qfdmo', 'qfdmo_displayedacteur_sources') }}

--- a/data-platform/dbt/models/base/acteurs/base_displayedperimetreadomicile.sql
+++ b/data-platform/dbt/models/base/acteurs/base_displayedperimetreadomicile.sql
@@ -1,0 +1,1 @@
+select * from {{ source('qfdmo', 'qfdmo_displayedperimetreadomicile') }}

--- a/data-platform/dbt/models/base/acteurs/base_displayedpropositionservice.sql
+++ b/data-platform/dbt/models/base/acteurs/base_displayedpropositionservice.sql
@@ -1,0 +1,1 @@
+select * from {{ source('qfdmo', 'qfdmo_displayedpropositionservice') }}

--- a/data-platform/dbt/models/base/acteurs/base_displayedpropositionservice_sous_categories.sql
+++ b/data-platform/dbt/models/base/acteurs/base_displayedpropositionservice_sous_categories.sql
@@ -1,0 +1,1 @@
+select * from {{ source('qfdmo', 'qfdmo_displayedpropositionservice_sous_categories') }}

--- a/data-platform/dbt/models/base/acteurs/base_epci.sql
+++ b/data-platform/dbt/models/base/acteurs/base_epci.sql
@@ -1,0 +1,1 @@
+select * from {{ source('qfdmo', 'qfdmo_epci') }}

--- a/data-platform/dbt/models/base/acteurs/base_labelqualite.sql
+++ b/data-platform/dbt/models/base/acteurs/base_labelqualite.sql
@@ -1,0 +1,1 @@
+select * from {{ source('qfdmo', 'qfdmo_labelqualite') }}

--- a/data-platform/dbt/models/base/acteurs/base_souscategorieobjet.sql
+++ b/data-platform/dbt/models/base/acteurs/base_souscategorieobjet.sql
@@ -1,0 +1,1 @@
+select * from {{ source('qfdmo', 'qfdmo_souscategorieobjet') }}

--- a/data-platform/dbt/models/base/stats/base_vueacteur.sql
+++ b/data-platform/dbt/models/base/stats/base_vueacteur.sql
@@ -1,0 +1,3 @@
+
+SELECT *
+FROM {{ source('stats_qfdmo', 'qfdmo_vueacteur') }}

--- a/data-platform/dbt/models/base/stats/schema.yml
+++ b/data-platform/dbt/models/base/stats/schema.yml
@@ -83,6 +83,19 @@ models:
         - base
         - acteurs
         - visible
+  - name: base_vueacteur
+    description: "Acteurs (vue complète, non filtrée)"
+    columns:
+      - name: identifiant_unique
+        description: "L'identifiant unique de l'acteur"
+        data_tests:
+          - not_null
+          - unique
+    config:
+      tags:
+        - stats
+        - base
+        - acteurs
   - name: base_vuepropositionservice
     description: "Propositions de services"
     columns:

--- a/data-platform/dbt/models/exposure/acteurs/opendata/exposure_opendata_acteur.sql
+++ b/data-platform/dbt/models/exposure/acteurs/opendata/exposure_opendata_acteur.sql
@@ -7,7 +7,7 @@ WITH deduplicated_opened_sources AS (
   FROM {{ ref('marts_opendata_acteur') }}  AS da
   LEFT JOIN {{ ref('marts_opendata_acteur_sources') }} AS das
     ON da.identifiant_unique = das.acteur_id
-  LEFT JOIN {{ source('qfdmo', 'qfdmo_source') }} AS source
+  LEFT JOIN {{ ref('base_source') }} AS source
     ON das.source_id = source.id
   GROUP BY da.uuid
 ),
@@ -20,14 +20,14 @@ proposition_services AS (
         'sous_categories', (
           SELECT jsonb_agg(sco.code)
           FROM {{ ref('marts_opendata_propositionservice_sous_categories') }}  AS pssc
-          JOIN {{ source('qfdmo', 'qfdmo_souscategorieobjet') }} AS sco ON pssc.souscategorieobjet_id = sco.id
+          JOIN {{ ref('base_souscategorieobjet') }} AS sco ON pssc.souscategorieobjet_id = sco.id
           WHERE pssc.propositionservice_id = ps.id
         )
       )
     ) as services
   FROM {{ ref('marts_opendata_acteur') }} AS da
   JOIN {{ ref('marts_opendata_propositionservice') }}  AS ps ON ps.acteur_id = da.identifiant_unique
-  JOIN {{ source('qfdmo', 'qfdmo_action') }} AS a ON ps.action_id = a.id
+  JOIN {{ ref('base_action') }} AS a ON ps.action_id = a.id
   GROUP BY da.uuid
 ),
 acteur_labels AS (
@@ -37,7 +37,7 @@ acteur_labels AS (
   FROM {{ ref('marts_opendata_acteur') }}  AS da
   LEFT JOIN {{ ref('marts_opendata_acteur_labels') }} AS dal
     ON da.identifiant_unique = dal.acteur_id
-  LEFT JOIN {{ source('qfdmo', 'qfdmo_labelqualite') }} AS lq ON dal.labelqualite_id = lq.id
+  LEFT JOIN {{ ref('base_labelqualite') }} AS lq ON dal.labelqualite_id = lq.id
   GROUP BY da.uuid
 ),
 acteur_services AS (
@@ -47,7 +47,7 @@ acteur_services AS (
   FROM {{ ref('marts_opendata_acteur') }}  AS da
   LEFT JOIN {{ ref('marts_opendata_acteur_acteur_services') }} AS daas
     ON da.identifiant_unique = daas.acteur_id
-  LEFT JOIN {{ source('qfdmo', 'qfdmo_acteurservice') }} AS as2 ON daas.acteurservice_id = as2.id
+  LEFT JOIN {{ ref('base_acteurservice') }} AS as2 ON daas.acteurservice_id = as2.id
   GROUP BY da.uuid
 ),
 perimetreadomicile AS (
@@ -84,7 +84,7 @@ SELECT
     WHEN EXISTS (
       SELECT 1
       FROM {{ ref('marts_opendata_acteur_sources') }} das2
-      JOIN {{ source('qfdmo', 'qfdmo_source') }} s ON das2.source_id = s.id
+      JOIN {{ ref('base_source') }} s ON das2.source_id = s.id
       WHERE das2.acteur_id = da.identifiant_unique
       AND s.code = 'carteco'
     ) THEN NULL
@@ -125,7 +125,7 @@ SELECT
   {{ sscat_from_action('ps.services', 'rapporter') }} as "rapporter",
   to_char(da.modifie_le, 'YYYY-MM-DD') as "date_de_derniere_modification"
 FROM {{ ref('marts_opendata_acteur') }}  AS da
-LEFT JOIN {{ source('qfdmo', 'qfdmo_acteurtype') }} AS at ON da.acteur_type_id = at.id
+LEFT JOIN {{ ref('base_acteur_type') }} AS at ON da.acteur_type_id = at.id
 -- INNER JOIN : Only open lisense
 INNER JOIN deduplicated_opened_sources AS ds ON da.uuid = ds.uuid
 LEFT JOIN proposition_services AS ps ON da.uuid = ps.uuid

--- a/data-platform/dbt/models/exposure/stats/exposure_stats_proposionservice_only_on_acteur.sql
+++ b/data-platform/dbt/models/exposure/stats/exposure_stats_proposionservice_only_on_acteur.sql
@@ -13,8 +13,8 @@ more_props_agg AS (
         a.code AS action_code,
         jsonb_agg(sco.code ORDER BY sco.code) AS sous_categories
     FROM {{ ref('marts_acteur_vs_revision_propositon_services') }} AS m
-    INNER JOIN {{ source('qfdmo', 'qfdmo_action') }} AS a ON m.action_id = a.id
-    INNER JOIN {{ source('qfdmo', 'qfdmo_souscategorieobjet') }} AS sco ON m.souscategorieobjet_id = sco.id
+    INNER JOIN {{ ref('base_action') }} AS a ON m.action_id = a.id
+    INNER JOIN {{ ref('base_souscategorieobjet') }} AS sco ON m.souscategorieobjet_id = sco.id
     WHERE m.source = 'acteur'
     GROUP BY m.identifiant_unique, a.code
 ),
@@ -35,8 +35,8 @@ acteur_props_agg AS (
     FROM {{ ref('int_propositonservices_with_revision') }} AS ps
     INNER JOIN {{ ref('int_propositionservice_sous_categories_with_revision') }} AS psc
         ON ps.id = psc.propositionservice_id
-    INNER JOIN {{ source('qfdmo', 'qfdmo_action') }} AS a ON ps.action_id = a.id
-    INNER JOIN {{ source('qfdmo', 'qfdmo_souscategorieobjet') }} AS sco
+    INNER JOIN {{ ref('base_action') }} AS a ON ps.action_id = a.id
+    INNER JOIN {{ ref('base_souscategorieobjet') }} AS sco
         ON psc.souscategorieobjet_id = sco.id
     WHERE ps.acteur_id IN (SELECT identifiant_unique FROM acteurs)
     GROUP BY ps.acteur_id, a.code

--- a/data-platform/dbt/models/exposure/stats/exposure_stats_proposionservice_only_on_revision.sql
+++ b/data-platform/dbt/models/exposure/stats/exposure_stats_proposionservice_only_on_revision.sql
@@ -13,8 +13,8 @@ more_props_agg AS (
         a.code AS action_code,
         jsonb_agg(sco.code ORDER BY sco.code) AS sous_categories
     FROM {{ ref('marts_acteur_vs_revision_propositon_services') }} AS m
-    INNER JOIN {{ source('qfdmo', 'qfdmo_action') }} AS a ON m.action_id = a.id
-    INNER JOIN {{ source('qfdmo', 'qfdmo_souscategorieobjet') }} AS sco ON m.souscategorieobjet_id = sco.id
+    INNER JOIN {{ ref('base_action') }} AS a ON m.action_id = a.id
+    INNER JOIN {{ ref('base_souscategorieobjet') }} AS sco ON m.souscategorieobjet_id = sco.id
     WHERE m.source = 'revision'
     GROUP BY m.identifiant_unique, a.code
 ),
@@ -35,8 +35,8 @@ revision_props_agg AS (
     FROM {{ ref('int_revisionpropositonservices_with_acteur') }} AS rps
     INNER JOIN {{ ref('int_revisionpropositonservice_sous_categories_with_acteur') }} AS rpsc
         ON rps.id = rpsc.revisionpropositionservice_id
-    INNER JOIN {{ source('qfdmo', 'qfdmo_action') }} AS a ON rps.action_id = a.id
-    INNER JOIN {{ source('qfdmo', 'qfdmo_souscategorieobjet') }} AS sco
+    INNER JOIN {{ ref('base_action') }} AS a ON rps.action_id = a.id
+    INNER JOIN {{ ref('base_souscategorieobjet') }} AS sco
         ON rpsc.souscategorieobjet_id = sco.id
     WHERE rps.acteur_id IN (SELECT identifiant_unique FROM revisions)
     GROUP BY rps.acteur_id, a.code

--- a/data-platform/dbt/models/intermediate/stats/int_ae_siren_in_acteur.sql
+++ b/data-platform/dbt/models/intermediate/stats/int_ae_siren_in_acteur.sql
@@ -1,5 +1,5 @@
 
 SELECT ae.siren, ae.etat_administratif
-FROM {{ source('stats_clone', 'clone_ae_unite_legale_in_use') }} AS ae
+FROM {{ ref('base_ae_unite_legale') }} AS ae
 INNER JOIN {{ ref('int_acteur_with_siren') }} AS av ON ae.siren = av.siren
 GROUP BY ae.siren, ae.etat_administratif

--- a/data-platform/dbt/models/intermediate/stats/int_ae_siret_in_acteur.sql
+++ b/data-platform/dbt/models/intermediate/stats/int_ae_siret_in_acteur.sql
@@ -1,5 +1,5 @@
 
 SELECT ae.siret, ae.etat_administratif
-FROM {{ source('stats_clone', 'clone_ae_etablissement_in_use') }} AS ae
+FROM {{ ref('base_ae_etablissement') }} AS ae
 INNER JOIN {{ ref('int_acteur_with_siret') }} AS av ON ae.siret = av.siret
 GROUP BY ae.siret, ae.etat_administratif

--- a/data-platform/dbt/models/marts/acteurs/exhaustive/marts_exhaustive_acteur.sql
+++ b/data-platform/dbt/models/marts/acteurs/exhaustive/marts_exhaustive_acteur.sql
@@ -26,5 +26,5 @@ LEFT JOIN {{ ref('marts_opendata_acteur') }} AS oa
   ON a.identifiant_unique = oa.identifiant_unique
 LEFT JOIN {{ ref('marts_exhaustive_acteur_epci') }} AS cae
   ON a.identifiant_unique = cae.identifiant_unique
-LEFT JOIN {{ source('qfdmo','qfdmo_epci') }} AS epci
+LEFT JOIN {{ ref('base_epci') }} AS epci
   ON cae.code_epci = epci.code

--- a/data-platform/dbt/models/marts/acteurs/sample/marts_sample_displayedacteur.sql
+++ b/data-platform/dbt/models/marts/acteurs/sample/marts_sample_displayedacteur.sql
@@ -1,6 +1,6 @@
-SELECT displayedacteur.* FROM {{ source('qfdmo', 'qfdmo_displayedacteur') }} AS displayedacteur
-LEFT JOIN {{ source('qfdmo','qfdmo_epci') }} AS epci ON displayedacteur.epci_id = epci.id
-LEFT JOIN {{ source('qfdmo','qfdmo_acteurtype') }} AS acteur_type ON displayedacteur.acteur_type_id = acteur_type.id
+SELECT displayedacteur.* FROM {{ ref('base_displayedacteur') }} AS displayedacteur
+LEFT JOIN {{ ref('base_epci') }} AS epci ON displayedacteur.epci_id = epci.id
+LEFT JOIN {{ ref('base_acteur_type') }} AS acteur_type ON displayedacteur.acteur_type_id = acteur_type.id
 WHERE
     epci.code IN (
         '200043123', /* CC Auray Quiberon Terre Atlantique */

--- a/data-platform/dbt/models/marts/acteurs/sample/marts_sample_displayedacteur_acteur_services.sql
+++ b/data-platform/dbt/models/marts/acteurs/sample/marts_sample_displayedacteur_acteur_services.sql
@@ -1,2 +1,2 @@
-SELECT * FROM {{ source('qfdmo', 'qfdmo_displayedacteur_acteur_services') }}
+SELECT * FROM {{ ref('base_displayedacteur_acteur_services') }}
 WHERE displayedacteur_id IN (SELECT identifiant_unique FROM {{ ref('marts_sample_displayedacteur') }})

--- a/data-platform/dbt/models/marts/acteurs/sample/marts_sample_displayedacteur_labels.sql
+++ b/data-platform/dbt/models/marts/acteurs/sample/marts_sample_displayedacteur_labels.sql
@@ -1,2 +1,2 @@
-SELECT * FROM {{ source('qfdmo', 'qfdmo_displayedacteur_labels') }}
+SELECT * FROM {{ ref('base_displayedacteur_labels') }}
 WHERE displayedacteur_id IN (SELECT identifiant_unique FROM {{ ref('marts_sample_displayedacteur') }})

--- a/data-platform/dbt/models/marts/acteurs/sample/marts_sample_displayedacteur_sources.sql
+++ b/data-platform/dbt/models/marts/acteurs/sample/marts_sample_displayedacteur_sources.sql
@@ -1,2 +1,2 @@
-SELECT * FROM {{ source('qfdmo', 'qfdmo_displayedacteur_sources') }}
+SELECT * FROM {{ ref('base_displayedacteur_sources') }}
 WHERE displayedacteur_id IN (SELECT identifiant_unique FROM {{ ref('marts_sample_displayedacteur') }})

--- a/data-platform/dbt/models/marts/acteurs/sample/marts_sample_displayedperimetreadomicile.sql
+++ b/data-platform/dbt/models/marts/acteurs/sample/marts_sample_displayedperimetreadomicile.sql
@@ -1,2 +1,2 @@
-SELECT * FROM {{ source('qfdmo', 'qfdmo_displayedperimetreadomicile') }}
+SELECT * FROM {{ ref('base_displayedperimetreadomicile') }}
 WHERE acteur_id IN (SELECT identifiant_unique FROM {{ ref('marts_sample_displayedacteur') }})

--- a/data-platform/dbt/models/marts/acteurs/sample/marts_sample_displayedpropositionservice.sql
+++ b/data-platform/dbt/models/marts/acteurs/sample/marts_sample_displayedpropositionservice.sql
@@ -1,2 +1,2 @@
-SELECT * FROM {{ source('qfdmo', 'qfdmo_displayedpropositionservice') }}
+SELECT * FROM {{ ref('base_displayedpropositionservice') }}
 WHERE acteur_id IN (SELECT identifiant_unique FROM {{ ref('marts_sample_displayedacteur') }})

--- a/data-platform/dbt/models/marts/acteurs/sample/marts_sample_displayedpropositionservice_sous_categories.sql
+++ b/data-platform/dbt/models/marts/acteurs/sample/marts_sample_displayedpropositionservice_sous_categories.sql
@@ -1,2 +1,2 @@
-SELECT * FROM {{ source('qfdmo', 'qfdmo_displayedpropositionservice_sous_categories') }}
+SELECT * FROM {{ ref('base_displayedpropositionservice_sous_categories') }}
 WHERE displayedpropositionservice_id IN (SELECT id FROM {{ ref('marts_sample_displayedpropositionservice') }})

--- a/data-platform/dbt/models/marts/enrich/marts_enrich_acteurs_closed_candidates.sql
+++ b/data-platform/dbt/models/marts/enrich/marts_enrich_acteurs_closed_candidates.sql
@@ -30,7 +30,7 @@ WITH acteurs_with_siret AS (
 		ville AS acteur_ville,
 		location AS acteur_location
 
-	FROM {{ source('enrich', 'qfdmo_vueacteur') }} AS acteurs
+	FROM {{ ref('base_vueacteur') }} AS acteurs
 	WHERE siret IS NOT NULL AND siret != '' AND LENGTH(siret) = 14
 	AND statut = 'ACTIF'
 	AND (est_dans_carte IS TRUE OR est_dans_opendata IS TRUE)

--- a/data-platform/dbt/models/marts/enrich/marts_enrich_acteurs_rgpd_suggest.sql
+++ b/data-platform/dbt/models/marts/enrich/marts_enrich_acteurs_rgpd_suggest.sql
@@ -28,7 +28,7 @@ WITH acteurs_with_siren AS (
 		{{ target.schema }}.udf_normalize_string_for_match(CONCAT(nom || ' ' || nom_officiel || ' ' || nom_commercial)) AS noms_normalises,
 		commentaires,
 		statut
-	FROM {{ source('enrich', 'qfdmo_vueacteur') }} AS acteurs
+	FROM {{ ref('base_vueacteur') }} AS acteurs
 	/*
 	We have normalization issues with our SIREN field in our DB
 	and we obtain better matching by reconstructing SIREN via SIRET

--- a/data-platform/dbt/models/marts/enrich/marts_enrich_acteurs_villes_candidates.sql
+++ b/data-platform/dbt/models/marts/enrich/marts_enrich_acteurs_villes_candidates.sql
@@ -17,7 +17,7 @@ SELECT
   ban.ville AS ban_ville,
   ban.code_postal AS ban_code_postal,
   ban.ville AS suggest_ville
-FROM {{ source('enrich', 'qfdmo_vueacteur') }} AS acteurs
+FROM {{ ref('base_vueacteur') }} AS acteurs
 JOIN {{ ref('int_ban_villes') }} AS ban ON ban.code_postal = acteurs.code_postal
 WHERE acteurs.statut = 'ACTIF'
 AND acteurs.code_postal IS NOT NULL and acteurs.code_postal != '' and LENGTH(acteurs.code_postal) = 5

--- a/data-platform/dbt/models/marts/stats/marts_ae_lien_succession_resolved_vueacteur.sql
+++ b/data-platform/dbt/models/marts/stats/marts_ae_lien_succession_resolved_vueacteur.sql
@@ -9,7 +9,7 @@ SELECT
     transfert_siege,
     continuite_economique
 FROM {{ ref('int_ae_lien_succession_resolved') }}
-INNER JOIN {{ source('stats_qfdmo', 'qfdmo_vueacteur') }} AS vueacteur
+INNER JOIN {{ ref('base_vueacteur') }} AS vueacteur
 ON vueacteur.siret = siret_predecesseur
 AND (vueacteur.est_dans_carte IS TRUE OR vueacteur.est_dans_opendata IS TRUE)
 WHERE etat_administratif_successeur = 'A'


### PR DESCRIPTION
# Description succincte du problème résolu

Pour éviter les jointures sur des tables qui ne sont pas dans le même schema

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: DBT

**💡 quoi**: Ne pas utiliser les `sources` dans les 

**🎯 pourquoi**: Règle sanitaire, comme les sources peuvent venit d'un schema en remote : webapp_public, copier les sources dans un modèle base évite par la suite de faire des jointures sur un serveur PG distant

**🤔 comment**: Pour chaque source, on crée un modèle base matérialisé comme une table

**🤓 comment tester**: tous les modèle DBT doivent continuer à fonctionner

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
