### PR TITLE
Garder la connexion à la DB pour ne pas timeout

### DIFF
--- a/data-platform/dbt/profiles.yml
+++ b/data-platform/dbt/profiles.yml
@@ -9,3 +9,8 @@ default:
       password: "{{ env_var('POSTGRES_PASSWORD', 'warehouse') }}"
       dbname: "{{ env_var('POSTGRES_DB', 'warehouse') }}"
       schema: "{{ env_var('POSTGRES_SCHEMA', 'public') }}"
+      # Keepalive TCP : during a long query (ex. int_acteur ~120s),
+      # the socket remains silent and a NAT/load-balancer Scaleway cuts the
+      # inactive connection after ~100s -> "SSL connection has been closed
+      # unexpectedly". Keepalive probes maintain the tunnel open.
+      keepalives_idle: 30


### PR DESCRIPTION
# Description succincte du problème résolu

Mattermost : https://mattermost.incubateur.net/betagouv/pl/7u3xgroon3ymjp6zhdoadxhwdh

cf. https://docs.getdbt.com/docs/local/connect-data-platform/postgres-setup?version=2.0&name=Fusion

**🗺️ contexte**: DBT - DB

**💡 quoi**: erreur "SSL connection has been closed unexpectedly"

**🎯 pourquoi**: l'erreur apparait après entre 100 et 110 s de requête, je soupsonne un timeout

**🤔 comment**: Ajout du paramètre keepalive_idle à la connexion entretenue par DBT

**🤓 comment tester**: 

Lancer le refraichissement des Acteurs en preprod

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)
