### PR TITLE
serialiser et déserialiser les relations et locations dans les df partagées entre job d'un DAG

### DIFF
--- a/data-platform/dags/cluster/tasks/airflow_logic/cluster_acteurs_suggestions_prepare_task.py
+++ b/data-platform/dags/cluster/tasks/airflow_logic/cluster_acteurs_suggestions_prepare_task.py
@@ -38,6 +38,7 @@ def cluster_acteurs_suggestions_prepare_wrapper(ti) -> None:
     logger.info(task_info_get())
 
     df: pd.DataFrame = xcom_pull(ti, XCOMS.DF_PARENTS_CHOOSE_DATA)
+
     df = parent_data_new_deserialize(df)
 
     if df.empty:

--- a/data-platform/dags/cluster/tasks/airflow_logic/utils.py
+++ b/data-platform/dags/cluster/tasks/airflow_logic/utils.py
@@ -13,6 +13,7 @@ import json
 
 import pandas as pd
 from cluster.config.constants import COL_PARENT_DATA_NEW
+from utils.data_serialize_reconstruct import parent_data_dict_to_json_ready
 
 
 def parent_data_new_serialize(df: pd.DataFrame) -> pd.DataFrame:
@@ -21,7 +22,11 @@ def parent_data_new_serialize(df: pd.DataFrame) -> pd.DataFrame:
         return df
     df = df.copy()
     df[COL_PARENT_DATA_NEW] = df[COL_PARENT_DATA_NEW].map(
-        lambda v: None if v is None else json.dumps(v, default=str)
+        lambda v: (
+            None
+            if v is None
+            else json.dumps(parent_data_dict_to_json_ready(v), default=str)
+        )
     )
     return df
 

--- a/data-platform/dags/tests/cluster/tasks/business_logic/test_cluster_acteurs_parent_data_serde.py
+++ b/data-platform/dags/tests/cluster/tasks/business_logic/test_cluster_acteurs_parent_data_serde.py
@@ -1,11 +1,23 @@
 import pandas as pd
+import pytest
 from cluster.config.constants import COL_PARENT_DATA_NEW
 from cluster.tasks.airflow_logic.utils import (
     parent_data_new_deserialize,
     parent_data_new_serialize,
 )
+from cluster.tasks.business_logic.cluster_acteurs_suggestions.prepare import (
+    cluster_acteurs_suggestions_prepare,
+)
+from data.models.change import (
+    COL_CHANGE_MODEL_NAME,
+    COL_CHANGE_ORDER,
+    COL_CHANGE_REASON,
+)
+from django.contrib.gis.geos import Point
+from unit_tests.qfdmo.acteur_factory import ActeurTypeFactory
 
 
+@pytest.mark.django_db
 class TestParentDataNewSerde:
 
     def test_roundtrip_preserves_dicts_empty_and_none(self):
@@ -44,3 +56,61 @@ class TestParentDataNewSerde:
         df = pd.DataFrame({"identifiant_unique": ["p1"]})
         assert parent_data_new_serialize(df).equals(df)
         assert parent_data_new_deserialize(df).equals(df)
+
+    def test_roundtrip_preserves_point_location_as_coords(self):
+        df = pd.DataFrame(
+            {
+                COL_PARENT_DATA_NEW: [
+                    {"nom": "EPUR CENTRE", "location": Point(3.447635, 46.1413235)}
+                ]
+            }
+        )
+
+        serialized = parent_data_new_serialize(df)
+        assert serialized[COL_PARENT_DATA_NEW].iloc[0] == (
+            '{"nom": "EPUR CENTRE", "location": [3.447635, 46.1413235]}'
+        )
+
+        restored = parent_data_new_deserialize(serialized)
+        assert restored[COL_PARENT_DATA_NEW].iloc[0] == {
+            "nom": "EPUR CENTRE",
+            "location": [3.447635, 46.1413235],
+        }
+
+    def test_roundtrip_preserves_acteur_type_as_code(self):
+        acteur_type = ActeurTypeFactory(code="decheterie", libelle="déchèterie")
+        df = pd.DataFrame(
+            {
+                COL_PARENT_DATA_NEW: [{"acteur_type": acteur_type}],
+            }
+        )
+
+        restored = parent_data_new_deserialize(parent_data_new_serialize(df))
+        assert restored[COL_PARENT_DATA_NEW].iloc[0] == {"acteur_type": "decheterie"}
+
+    def test_xcom_roundtrip_acteur_type_survives_suggestions_prepare(self):
+        acteur_type = ActeurTypeFactory(code="decheterie", libelle="déchèterie")
+        df = pd.DataFrame(
+            [
+                {
+                    "cluster_id": "c1",
+                    "identifiant_unique": "new parent",
+                    COL_CHANGE_ORDER: 1,
+                    COL_CHANGE_REASON: "because",
+                    COL_CHANGE_MODEL_NAME: "acteur_create_as_parent",
+                    COL_PARENT_DATA_NEW: {
+                        "acteur_type": acteur_type,
+                        "location": Point(3.447635, 46.1413235),
+                    },
+                }
+            ]
+        )
+
+        df = parent_data_new_deserialize(parent_data_new_serialize(df))
+        working, failing = cluster_acteurs_suggestions_prepare(df)
+
+        assert failing == []
+        data = working[0]["changes"][0]["model_params"]["data"]
+        assert data["acteur_type"] == "decheterie"
+        assert data["longitude"] == 3.447635
+        assert data["latitude"] == 46.1413235

--- a/data-platform/dags/tests/cluster/tasks/business_logic/test_cluster_acteurs_suggestions_prepare.py
+++ b/data-platform/dags/tests/cluster/tasks/business_logic/test_cluster_acteurs_suggestions_prepare.py
@@ -23,7 +23,7 @@ from unit_tests.qfdmo.acteur_factory import (
     RevisionActeurFactory,
 )
 
-ACTEUR_TYPE_ID = 123456
+ACTEUR_TYPE_CODE = "at1"
 
 
 @pytest.mark.django_db
@@ -39,7 +39,7 @@ class TestClusterActeursSuggestionsDisplay:
         RevisionActeurFactory(identifiant_unique="revision to keep")
         ActeurFactory(identifiant_unique="update parent id")
         RevisionActeurFactory(identifiant_unique="update parent id")
-        at1 = ActeurTypeFactory(code="at1", id=ACTEUR_TYPE_ID)
+        at1 = ActeurTypeFactory(code=ACTEUR_TYPE_CODE, libelle="déchèterie")
 
         return pd.DataFrame(
             [
@@ -147,14 +147,18 @@ class TestClusterActeursSuggestionsDisplay:
         c1 = working[0]
         assert c1["changes"][0]["model_params"] == {
             "id": "new parent",
-            "data": {"acteur_type": ACTEUR_TYPE_ID, "longitude": 1.0, "latitude": 2.0},
+            "data": {
+                "acteur_type": ACTEUR_TYPE_CODE,
+                "longitude": 1.0,
+                "latitude": 2.0,
+            },
         }
         assert c1["changes"][1]["model_params"] == {"id": "parent to delete"}
 
         c2 = working[1]
         assert c2["changes"][0]["model_params"] == {
             "id": "parent to keep",
-            "data": {"acteur_type": ACTEUR_TYPE_ID},
+            "data": {"acteur_type": ACTEUR_TYPE_CODE},
         }
 
         c3 = working[2]

--- a/data-platform/dags/tests/utils/test_data_serialize_reconstruct.py
+++ b/data-platform/dags/tests/utils/test_data_serialize_reconstruct.py
@@ -8,7 +8,7 @@ from unit_tests.qfdmo.acteur_factory import (
     ActionFactory,
     SourceFactory,
 )
-from utils.data_serialize_reconstruct import data_serialize
+from utils.data_serialize_reconstruct import data_serialize, location_to_coords
 
 DATETIME = datetime(2023, 10, 1, 14, 30, 4)
 LONGITUDE, LATITUDE = 1, 2
@@ -98,3 +98,29 @@ class TestDataSerializeReconstruct:
         rec = data_reconstruct(RevisionActeur, ser)
         # The reconstruction should be in {field} format
         assert rec["source"].id == data_init["source"].id
+
+    def test_acteur_type_serialized_as_code_not_libelle(self, data_init):
+        acteur_type = data_init["acteur_type"]
+        acteur_type.libelle = "déchèterie"
+        acteur_type.save()
+        data = {"acteur_type": acteur_type}
+        serialized = data_serialize(RevisionActeur, data)
+        assert serialized["acteur_type"] == acteur_type.code
+        assert serialized["acteur_type"] != acteur_type.libelle
+
+        reconstructed = data_reconstruct(RevisionActeur, serialized)
+        assert reconstructed["acteur_type"] == acteur_type
+
+    def test_location_wkt_string_serialized(self):
+        wkt = "SRID=4326;POINT (3.447635 46.1413235)"
+        data = {"nom": "EPUR CENTRE", "location": wkt}
+        serialized = data_serialize(RevisionActeur, data)
+        assert serialized["longitude"] == pytest.approx(3.447635)
+        assert serialized["latitude"] == pytest.approx(46.1413235)
+        assert "location" not in serialized
+
+    def test_location_to_coords_wkt_string(self):
+        wkt = "SRID=4326;POINT (3.447635 46.1413235)"
+        longitude, latitude = location_to_coords(wkt)
+        assert longitude == pytest.approx(3.447635)
+        assert latitude == pytest.approx(46.1413235)

--- a/data-platform/dags/utils/data_serialize_reconstruct.py
+++ b/data-platform/dags/utils/data_serialize_reconstruct.py
@@ -4,13 +4,50 @@ to lose Python/Django objects"""
 
 import logging
 from datetime import datetime
+from typing import Any
 
-from django.db import models
+from utils.django import django_setup_full
 
 logger = logging.getLogger(__name__)
 
 
-def data_serialize(model: type[models.Model], data: dict) -> dict:
+def value_to_json_ready(key: str, value):
+    """Convert a parent_data_new value to a JSON-serializable form."""
+
+    django_setup_full()
+    from django.db import models
+    from qfdmo.models.utils import django_model_to_wire
+
+    if value is None:
+        return None
+    if key == "location" and hasattr(value, "x") and hasattr(value, "y"):
+        return [value.x, value.y]
+    if isinstance(value, models.Model):
+        return django_model_to_wire(value)
+    return value
+
+
+def parent_data_dict_to_json_ready(data: dict | None) -> dict | None:
+    if data is None or not isinstance(data, dict):
+        return data
+    return {key: value_to_json_ready(key, value) for key, value in data.items()}
+
+
+def location_to_coords(location) -> tuple:
+    """Extract (longitude, latitude) from common location representations."""
+    if hasattr(location, "x") and hasattr(location, "y"):
+        return location.x, location.y
+    if isinstance(location, (list, tuple)):
+        return location[0], location[1]
+    if isinstance(location, str):
+        from django.contrib.gis.geos import GEOSGeometry
+
+        point = GEOSGeometry(location)
+        return point.x, point.y
+    raise TypeError(f"Unsupported location type: {type(location)}")
+
+
+def data_serialize(model: type[Any], data: dict) -> dict:
     """
     Serialize a dictionary to match the Django model structure.
 
@@ -21,6 +58,10 @@ def data_serialize(model: type[models.Model], data: dict) -> dict:
     Returns:
     - A dictionary with values adjusted to match the model's requirements.
     """
+    django_setup_full()
+    from django.db import models
+    from qfdmo.models.utils import django_model_to_wire
+
     result = {}
 
     try:
@@ -44,12 +85,15 @@ def data_serialize(model: type[models.Model], data: dict) -> dict:
                     result[key] = value
                 elif isinstance(value, float):
                     result[key] = int(value)
+                elif isinstance(value, models.Model):
+                    result[key] = django_model_to_wire(value)
                 else:
                     logger.info(f"Serializing foreign key {key} with value {value}")
                     result[key] = value.pk
             elif key == "location":
-                result["longitude"] = data["location"][0]
-                result["latitude"] = data["location"][1]
+                longitude, latitude = location_to_coords(value)
+                result["longitude"] = longitude
+                result["latitude"] = latitude
             elif isinstance(value, datetime):
                 result[key] = value.isoformat()
             else:

--- a/webapp/data/models/changes/utils.py
+++ b/webapp/data/models/changes/utils.py
@@ -4,6 +4,7 @@ import logging
 
 from django.contrib.gis.geos import Point
 from django.db import models
+from qfdmo.models.utils import django_model_from_wire
 
 logger = logging.getLogger(__name__)
 
@@ -61,10 +62,7 @@ def data_reconstruct(model: type[models.Model], data_src: dict) -> dict:
                     pass
 
             # Retrieving the related instance if it's not already an instance
-            if not isinstance(value, field.related_model):  # type: ignore
-                value = field.related_model.objects.get(pk=value)  # type: ignore
-
-            result[key] = value
+            result[key] = django_model_from_wire(field.related_model, value)  # type: ignore
 
         else:
             result[key] = value

--- a/webapp/qfdmo/models/utils.py
+++ b/webapp/qfdmo/models/utils.py
@@ -22,6 +22,22 @@ class CodeAsNaturalKeyModel(models.Model):
         return getattr(self, "code")
 
 
+def django_model_to_wire(value: models.Model):
+    """Serialize a Django model instance for JSON / XCom transport."""
+    if isinstance(value, CodeAsNaturalKeyModel):
+        return value.code
+    return value.pk
+
+
+def django_model_from_wire(model_class: type[models.Model], value):
+    """Reconstruct a Django model instance from a wire-transport value."""
+    if isinstance(value, model_class):
+        return value
+    if issubclass(model_class, CodeAsNaturalKeyModel) and isinstance(value, str):
+        return model_class.objects.get(code=value)
+    return model_class.objects.get(pk=value)
+
+
 class NomAsNaturalKeyManager(models.Manager):
     def get_by_natural_key(self, nom: str) -> models.Model:
         return self.get(nom=nom)


### PR DESCRIPTION
# Description succincte du problème résolu

Notion : [[Clustering] Re-valider les 345 sugg’ qui ont fail pour cause de ‘Invalid parameters given for Point initialization’  + corriger le problème à la source](https://app.notion.com/p/accelerateur-transition-ecologique-ademe/Clustering-Re-valider-les-345-sugg-qui-ont-fail-pour-cause-de-Invalid-parameters-given-for-Point--3826523d57d78071a4a5cc51293f28ea)

**🗺️ contexte**: Airflow - Clusterisation

**💡 quoi**: Sérialisation et déserialisation des objets de type `localisation` et `CodeAsNaturalKeyModel`

**🎯 pourquoi**: car sinon, il prends le nom et ce n'est pas interprété correctement par la suite

**🤔 comment**: 

- location : via la fonction `location_to_coords` -> transforme en tuple x,y quelques soit le format reçu : str, GeoPoint, tuple
- CodeAsNaturalKeyModel : 
  - quand l'objet hérite de cette classe, on renvoie le code
  - quand on interprète une relation si elle hérite de cette classe, on va chercher via le code

**🤓 comment tester**: 

- Faire tourner un clustering avec création de parent
- Valider les suggestions
- observer qu'elles sont bien crées

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
