### PR TITLE
ne supprimer les tables temporaires qu'après l'action principale

### DIFF
--- a/data-platform/dags/sources/config/tasks.py
+++ b/data-platform/dags/sources/config/tasks.py
@@ -3,6 +3,7 @@ import dataclasses
 
 @dataclasses.dataclass(frozen=True)
 class TASKS:
+    DB_CLEAN_TEMPORARY_TABLES: str = "db_clean_temporary_tables"
     DB_DATA_PREPARE: str = "db_data_prepare"
     DB_WRITE_TYPE_ACTION_SUGGESTIONS: str = "db_write_type_action_suggestions"
     KEEP_ACTEUR_CHANGED: str = "keep_acteur_changed"

--- a/data-platform/dags/sources/tasks/airflow_logic/db_clean_temporary_tables_task.py
+++ b/data-platform/dags/sources/tasks/airflow_logic/db_clean_temporary_tables_task.py
@@ -1,0 +1,27 @@
+import logging
+
+from airflow import DAG
+from airflow.providers.standard.operators.python import PythonOperator
+from sources.config.tasks import TASKS
+from sources.config.xcoms import XCOMS, xcom_pull
+from utils.db_tmp_tables import drop_temporary_table
+
+logger = logging.getLogger(__name__)
+
+
+def db_clean_temporary_tables_task(dag: DAG) -> PythonOperator:
+    return PythonOperator(
+        task_id=TASKS.DB_CLEAN_TEMPORARY_TABLES,
+        python_callable=db_clean_temporary_tables_wrapper,
+        dag=dag,
+    )
+
+
+def db_clean_temporary_tables_wrapper(ti) -> None:
+    table_name_create = xcom_pull(ti, XCOMS.TABLE_NAME_CREATE)
+    table_name_delete = xcom_pull(ti, XCOMS.TABLE_NAME_DELETE)
+    table_name_update = xcom_pull(ti, XCOMS.TABLE_NAME_UPDATE)
+
+    for table_name in (table_name_create, table_name_delete, table_name_update):
+        if table_name:
+            drop_temporary_table(table_name)

--- a/data-platform/dags/sources/tasks/airflow_logic/db_write_type_action_suggestions_task.py
+++ b/data-platform/dags/sources/tasks/airflow_logic/db_write_type_action_suggestions_task.py
@@ -9,7 +9,7 @@ from sources.tasks.business_logic.db_write_type_action_suggestions import (
     db_write_type_action_suggestions,
 )
 from utils import logging_utils as log
-from utils.db_tmp_tables import read_and_drop_temporary_table
+from utils.db_tmp_tables import drop_temporary_table, read_temporary_table
 
 logger = logging.getLogger(__name__)
 
@@ -34,9 +34,9 @@ def db_write_type_action_suggestions_wrapper(ti, dag, params) -> None:
     table_name_update = xcom_pull(ti, XCOMS.TABLE_NAME_UPDATE)
 
     # Load the DataFrames from the temporary tables
-    df_acteur_to_create = read_and_drop_temporary_table(table_name_create)
-    df_acteur_to_delete = read_and_drop_temporary_table(table_name_delete)
-    df_acteur_to_update = read_and_drop_temporary_table(table_name_update)
+    df_acteur_to_create = read_temporary_table(table_name_create)
+    df_acteur_to_delete = read_temporary_table(table_name_delete)
+    df_acteur_to_update = read_temporary_table(table_name_update)
 
     metadata_to_create = xcom_pull(ti, XCOMS.METADATA_TO_CREATE)
     metadata_to_update = xcom_pull(ti, XCOMS.METADATA_TO_UPDATE)
@@ -61,24 +61,30 @@ def db_write_type_action_suggestions_wrapper(ti, dag, params) -> None:
         and df_acteur_to_update.empty
     ):
         logger.warning("!!! Aucune suggestion à traiter pour cette source !!!")
+
         # set the task to airflow skip status
         xcom_push(ti, key=XCOMS.SKIP, value=True)
-        return
+    else:
 
-    db_write_type_action_suggestions(
-        dag_name=dag_name,
-        run_id=run_id,
-        df_acteur_to_create=df_acteur_to_create,
-        df_acteur_to_delete=df_acteur_to_delete,
-        df_acteur_to_update=df_acteur_to_update,
-        metadata_to_create={**metadata, **metadata_to_create},
-        metadata_to_update={
-            **metadata,
-            **metadata_to_update,
-            **metadata_columns_updated,
-        },
-        metadata_to_delete={**metadata, **metadata_to_delete},
-        df_log_error=df_log_error,
-        df_log_warning=df_log_warning,
-        use_legacy_suggestions=dag_config.use_legacy_suggestions,
-    )
+        db_write_type_action_suggestions(
+            dag_name=dag_name,
+            run_id=run_id,
+            df_acteur_to_create=df_acteur_to_create,
+            df_acteur_to_delete=df_acteur_to_delete,
+            df_acteur_to_update=df_acteur_to_update,
+            metadata_to_create={**metadata, **metadata_to_create},
+            metadata_to_update={
+                **metadata,
+                **metadata_to_update,
+                **metadata_columns_updated,
+            },
+            metadata_to_delete={**metadata, **metadata_to_delete},
+            df_log_error=df_log_error,
+            df_log_warning=df_log_warning,
+            use_legacy_suggestions=dag_config.use_legacy_suggestions,
+        )
+
+    # Load the DataFrames from the temporary tables
+    drop_temporary_table(table_name_create)
+    drop_temporary_table(table_name_delete)
+    drop_temporary_table(table_name_update)

--- a/data-platform/dags/sources/tasks/airflow_logic/db_write_type_action_suggestions_task.py
+++ b/data-platform/dags/sources/tasks/airflow_logic/db_write_type_action_suggestions_task.py
@@ -9,7 +9,7 @@ from sources.tasks.business_logic.db_write_type_action_suggestions import (
     db_write_type_action_suggestions,
 )
 from utils import logging_utils as log
-from utils.db_tmp_tables import drop_temporary_table, read_temporary_table
+from utils.db_tmp_tables import read_temporary_table
 
 logger = logging.getLogger(__name__)
 
@@ -64,27 +64,22 @@ def db_write_type_action_suggestions_wrapper(ti, dag, params) -> None:
 
         # set the task to airflow skip status
         xcom_push(ti, key=XCOMS.SKIP, value=True)
-    else:
+        return
 
-        db_write_type_action_suggestions(
-            dag_name=dag_name,
-            run_id=run_id,
-            df_acteur_to_create=df_acteur_to_create,
-            df_acteur_to_delete=df_acteur_to_delete,
-            df_acteur_to_update=df_acteur_to_update,
-            metadata_to_create={**metadata, **metadata_to_create},
-            metadata_to_update={
-                **metadata,
-                **metadata_to_update,
-                **metadata_columns_updated,
-            },
-            metadata_to_delete={**metadata, **metadata_to_delete},
-            df_log_error=df_log_error,
-            df_log_warning=df_log_warning,
-            use_legacy_suggestions=dag_config.use_legacy_suggestions,
-        )
-
-    # Load the DataFrames from the temporary tables
-    drop_temporary_table(table_name_create)
-    drop_temporary_table(table_name_delete)
-    drop_temporary_table(table_name_update)
+    db_write_type_action_suggestions(
+        dag_name=dag_name,
+        run_id=run_id,
+        df_acteur_to_create=df_acteur_to_create,
+        df_acteur_to_delete=df_acteur_to_delete,
+        df_acteur_to_update=df_acteur_to_update,
+        metadata_to_create={**metadata, **metadata_to_create},
+        metadata_to_update={
+            **metadata,
+            **metadata_to_update,
+            **metadata_columns_updated,
+        },
+        metadata_to_delete={**metadata, **metadata_to_delete},
+        df_log_error=df_log_error,
+        df_log_warning=df_log_warning,
+        use_legacy_suggestions=dag_config.use_legacy_suggestions,
+    )

--- a/data-platform/dags/sources/tasks/airflow_logic/operators.py
+++ b/data-platform/dags/sources/tasks/airflow_logic/operators.py
@@ -1,6 +1,9 @@
 from airflow import DAG
 from airflow.sdk.bases.operator import chain
 from shared.config.start_dates import START_DATES
+from sources.tasks.airflow_logic.db_clean_temporary_tables_task import (
+    db_clean_temporary_tables_task,
+)
 from sources.tasks.airflow_logic.db_data_prepare_task import db_data_prepare_task
 from sources.tasks.airflow_logic.db_write_type_action_suggestions_task import (
     db_write_type_action_suggestions_task,
@@ -29,12 +32,18 @@ default_params = {
 
 
 def eo_task_chain(dag: DAG) -> None:
+    db_data_prepare = db_data_prepare_task(dag).as_setup()
+    db_clean_temporary_tables = db_clean_temporary_tables_task(dag).as_teardown(
+        setups=db_data_prepare
+    )
+
     chain(
         source_config_validate_task(dag),
         source_data_download_task(dag),
         source_data_normalize_task(dag),
         source_data_validate_task(dag),
         keep_acteur_changed_task(dag),
-        db_data_prepare_task(dag),
+        db_data_prepare,
         db_write_type_action_suggestions_task(dag),
+        db_clean_temporary_tables,
     )

--- a/data-platform/dags/utils/db_tmp_tables.py
+++ b/data-platform/dags/utils/db_tmp_tables.py
@@ -93,9 +93,15 @@ def convert_json_columns_to_dict_list(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def read_and_drop_temporary_table(table_name: str) -> pd.DataFrame:
+    df = read_temporary_table(table_name)
+    drop_temporary_table(table_name)
+
+    return df
+
+
+def read_temporary_table(table_name: str) -> pd.DataFrame:
     """
     Read a temporary table from the database and convert JSON columns back to dict/list.
-    Drop the temporary table from the database.
     """
     engine = django_conn_to_sqlalchemy_engine(using=DJANGO_WH_CONNECTION_NAME)
 
@@ -107,8 +113,15 @@ def read_and_drop_temporary_table(table_name: str) -> pd.DataFrame:
 
     logger.info(f"Table temporaire lue: {table_name} avec {len(df)} lignes")
 
+    return df
+
+
+def drop_temporary_table(table_name: str):
+    """
+    Drop the temporary table from the database.
+    """
+    engine = django_conn_to_sqlalchemy_engine(using=DJANGO_WH_CONNECTION_NAME)
+
     with engine.begin() as conn:  # type: ignore
         conn.execute(text(f"DROP TABLE IF EXISTS {table_name}"))
     logger.info(f"Table temporaire supprimée: {table_name}")
-
-    return df


### PR DESCRIPTION
# Description succincte du problème résolu

Pour éviter le cas suivant :

- la plateforme a été déployée pendant une tache
- en temps normal le retry marche mais là, comme les données viennent d'une table temporaire qui a été supprimée en début de tache, il ne la retrouve pas
- le workaround est de redémarrer 2 taches plus tôt que celle qui a foirée
- solution : supprimer la table temporaire en fin de tache, le risque est d'avoir des relicat de table temporaire : c'est pas très grâve

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Airflow - Source

**💡 quoi**: utilisation de table temporaire : ne pas les supprimer trop tôt pour permettre au retry de fonctionner

**🎯 pourquoi**: On supprimait les tables temporaires avant de faire l'action principale, maintenant on attend la fin de la tache pour supprimer la table, si la tache fail (ex: déploiement, la tache se ré-exécute) alors on retrouve la table temporaire

**🤔 comment**: 

- création de 2 fonctions au lieu d'une : 
  - read_temporary_table
  - drop_temporary_table
- lecture en début de tache
- suppression en fin de tache

**🤓 comment tester**: 

Les DAG de type Source doivent continuer à tourner


## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
