### PR TITLE
Command pour réparer les Suggestions avec des mauvaise lat, long et type

### DIFF
--- a/webapp/data/management/commands/fix_cluster_point_suggestions.py
+++ b/webapp/data/management/commands/fix_cluster_point_suggestions.py
@@ -1,0 +1,184 @@
+import argparse
+
+from data.models.changes import (
+    ChangeActeurCreateAsParent,
+    ChangeActeurKeepAsParent,
+    ChangeActeurUpdateParentId,
+)
+from data.models.suggestion import Suggestion, SuggestionStatut
+from django.core.management.base import BaseCommand
+from qfdmo.models.acteur import DEFAULT_SOURCE_CODE, VueActeur
+
+# Message stored in Suggestion.metadata["error"] when a CLUSTERING suggestion
+# failed because the parent's location could not be rebuilt.
+POINT_ERROR_MESSAGE = "Invalid parameters given for Point initialization"
+
+# Change models that describe the parent acteur (the one carrying the broken
+# location / acteur_type data).
+PARENT_CHANGE_MODEL_NAMES = [
+    ChangeActeurKeepAsParent.name(),
+    ChangeActeurCreateAsParent.name(),
+]
+
+
+class Command(BaseCommand):
+    help = (
+        "Fix CLUSTERING suggestions that ended in error with "
+        f"'{POINT_ERROR_MESSAGE}' by rebuilding the parent's longitude / latitude "
+        "and acteur_type from its children (preferring the "
+        f"'{DEFAULT_SOURCE_CODE}' source), then re-queue them for processing."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            help="Run command without writing changes to the database",
+            action=argparse.BooleanOptionalAction,
+            default=False,
+        )
+        parser.add_argument(
+            "--requeue",
+            help="Reset fixed suggestions to ATRAITER so the DAG reprocesses them",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        requeue = options["requeue"]
+
+        suggestions = Suggestion.objects.filter(
+            statut=SuggestionStatut.ERREUR,
+            metadata__error__icontains=POINT_ERROR_MESSAGE,
+        )
+
+        total = suggestions.count()
+        self.stdout.write(
+            f"{total} suggestion(s) en erreur avec '{POINT_ERROR_MESSAGE}'"
+        )
+
+        fixed_count = 0
+        for suggestion in suggestions:
+            changes = self._extract_changes(suggestion)
+            if changes is None:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"  Suggestion {suggestion.id}: pas de 'changes' "
+                        "exploitable, ignorée"
+                    )
+                )
+                continue
+
+            parent_change = self._find_parent_change(changes)
+            if parent_change is None:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"  Suggestion {suggestion.id}: pas de changement parent, "
+                        "ignorée"
+                    )
+                )
+                continue
+
+            child = self._pick_child(changes)
+            if child is None:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"  Suggestion {suggestion.id}: aucun enfant avec une "
+                        "localisation exploitable, à inspecter manuellement"
+                    )
+                )
+                continue
+
+            data = parent_change["model_params"]["data"]
+            self._apply_child_data(data, child)
+
+            fixed_count += 1
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"  Suggestion {suggestion.id}: corrigée depuis l'enfant "
+                    f"{child.identifiant_unique} (source "
+                    f"{child.source.code if child.source else '?'})"
+                )
+            )
+
+            if not dry_run:
+                suggestion.suggestion["changes"] = changes
+                if requeue:
+                    suggestion.statut = SuggestionStatut.ATRAITER
+                    suggestion.metadata = None
+                suggestion.save()
+
+        prefix = "[dry-run] " if dry_run else ""
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{prefix}{fixed_count}/{total} suggestion(s) corrigée(s)"
+                + (" et remises à ATRAITER" if requeue and not dry_run else "")
+            )
+        )
+
+    def _extract_changes(self, suggestion) -> list | None:
+        suggestion_data = suggestion.suggestion
+        if not isinstance(suggestion_data, dict):
+            return None
+        changes = suggestion_data.get("changes")
+        if not isinstance(changes, list):
+            return None
+        return changes
+
+    def _find_parent_change(self, changes: list) -> dict | None:
+        for change in changes:
+            if not isinstance(change, dict):
+                continue
+            if change.get("model_name") not in PARENT_CHANGE_MODEL_NAMES:
+                continue
+            model_params = change.get("model_params")
+            if isinstance(model_params, dict) and isinstance(
+                model_params.get("data"), dict
+            ):
+                return change
+        return None
+
+    def _child_ids(self, changes: list) -> list[str]:
+        """Children are the acteurs re-pointed to the new parent, in order."""
+        ids = []
+        for change in changes:
+            if not isinstance(change, dict):
+                continue
+            if change.get("model_name") != ChangeActeurUpdateParentId.name():
+                continue
+            child_id = (change.get("model_params") or {}).get("id")
+            if child_id is not None:
+                ids.append(child_id)
+        return ids
+
+    def _pick_child(self, changes: list) -> VueActeur | None:
+        """Return the first child carrying a usable location, prioritizing the
+        'communautelvao' source, then the order they appear in the suggestion."""
+        child_ids = self._child_ids(changes)
+        if not child_ids:
+            return None
+
+        acteurs = VueActeur.objects.filter(
+            identifiant_unique__in=child_ids
+        ).select_related("acteur_type", "source")
+        by_id = {a.identifiant_unique: a for a in acteurs}
+
+        # Keep the suggestion order, but move communautelvao children first
+        ordered = [by_id[cid] for cid in child_ids if cid in by_id]
+        ordered.sort(
+            key=lambda a: 0 if a.source and a.source.code == DEFAULT_SOURCE_CODE else 1
+        )
+
+        for acteur in ordered:
+            if acteur.location is not None:
+                return acteur
+        return None
+
+    def _apply_child_data(self, data: dict, child: VueActeur) -> None:
+        # A serialized location is split into longitude / latitude (no Point over
+        # JSON), so we never keep a raw `location` key around.
+        data.pop("location", None)
+        data["longitude"] = child.location.x
+        data["latitude"] = child.location.y
+        if child.acteur_type is not None:
+            data["acteur_type"] = child.acteur_type.code

--- a/webapp/data/management/commands/fix_recursion_suggestions.py
+++ b/webapp/data/management/commands/fix_recursion_suggestions.py
@@ -1,0 +1,135 @@
+import argparse
+import copy
+
+from data.models.changes import ChangeActeurCreateAsParent, ChangeActeurKeepAsParent
+from data.models.suggestion import Suggestion, SuggestionStatut
+from django.core.management.base import BaseCommand
+
+# Message stored in Suggestion.metadata["error"] when a suggestion failed with a
+# RecursionError. The root cause is a parent acteur whose change data carries a
+# `parent` / `parent_id` pointing to itself: applying it makes the parent FK
+# self-referential and any later load recurse infinitely through
+# RevisionActeur.__init__.
+RECURSION_ERROR_MESSAGE = "maximum recursion depth exceeded"
+
+# A parent acteur must never have a parent: these keys are illegal in the data of
+# a "keep/create as parent" change and are what triggered the recursion.
+ILLEGAL_PARENT_KEYS = ["parent", "parent_id"]
+
+PARENT_CHANGE_MODEL_NAMES = [
+    ChangeActeurKeepAsParent.name(),
+    ChangeActeurCreateAsParent.name(),
+]
+
+
+class Command(BaseCommand):
+    help = (
+        "Fix CLUSTERING suggestions that ended in error with "
+        f"'{RECURSION_ERROR_MESSAGE}' by removing the self-referential parent "
+        "from their parent changes, then re-queue them for processing."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            help="Run command without writing changes to the database",
+            action=argparse.BooleanOptionalAction,
+            default=False,
+        )
+        parser.add_argument(
+            "--requeue",
+            help="Reset fixed suggestions to ATRAITER so the DAG reprocesses them",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        requeue = options["requeue"]
+
+        suggestions = Suggestion.objects.filter(
+            statut=SuggestionStatut.ERREUR,
+            metadata__error__icontains=RECURSION_ERROR_MESSAGE,
+        )
+
+        total = suggestions.count()
+        self.stdout.write(
+            f"{total} suggestion(s) en erreur avec '{RECURSION_ERROR_MESSAGE}'"
+        )
+
+        fixed_count = 0
+        for suggestion in suggestions:
+            changes = self._extract_changes(suggestion)
+            if changes is None:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"  Suggestion {suggestion.id}: pas de 'changes' "
+                        "exploitable, ignorée"
+                    )
+                )
+                continue
+
+            new_changes = copy.deepcopy(changes)
+            removed = self._strip_illegal_parents(suggestion.id, new_changes)
+
+            if not removed:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"  Suggestion {suggestion.id}: aucune clé parent "
+                        "auto-référente trouvée, à inspecter manuellement"
+                    )
+                )
+                continue
+
+            fixed_count += 1
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"  Suggestion {suggestion.id}: {removed} clé(s) parent "
+                    "supprimée(s)"
+                )
+            )
+
+            if not dry_run:
+                suggestion.suggestion["changes"] = new_changes
+                if requeue:
+                    suggestion.statut = SuggestionStatut.ATRAITER
+                    suggestion.metadata = None
+                suggestion.save()
+
+        prefix = "[dry-run] " if dry_run else ""
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{prefix}{fixed_count}/{total} suggestion(s) corrigée(s)"
+                + (" et remises à ATRAITER" if requeue and not dry_run else "")
+            )
+        )
+
+    def _extract_changes(self, suggestion) -> list | None:
+        suggestion_data = suggestion.suggestion
+        if not isinstance(suggestion_data, dict):
+            return None
+        changes = suggestion_data.get("changes")
+        if not isinstance(changes, list):
+            return None
+        return changes
+
+    def _strip_illegal_parents(self, suggestion_id, changes: list) -> int:
+        """Remove self-referential parent keys from parent changes in place.
+
+        Returns the number of keys removed."""
+        removed = 0
+        for change in changes:
+            if not isinstance(change, dict):
+                continue
+            if change.get("model_name") not in PARENT_CHANGE_MODEL_NAMES:
+                continue
+            model_params = change.get("model_params") or {}
+            data = model_params.get("data")
+            if not isinstance(data, dict):
+                continue
+            change_id = model_params.get("id")
+            for key in ILLEGAL_PARENT_KEYS:
+                if key in data and data[key] == change_id:
+                    del data[key]
+                    removed += 1
+        return removed

--- a/webapp/qfdmo/models/acteur.py
+++ b/webapp/qfdmo/models/acteur.py
@@ -1010,9 +1010,17 @@ class RevisionActeur(BaseActeur, LatLngPropertiesMixin, DisplayedActeurLinkMixin
         pointent vers l'identifiant_unique de cet acteur"""
         return parents_cache_get()["nombre_enfants"].get(self.identifiant_unique, 0)
 
+    def clean(self):
+        super().clean()
+        # An acteur can't be its own parent
+        if self.parent_id and self.parent_id == self.identifiant_unique:
+            raise ValidationError(
+                {"parent": "Un acteur ne peut pas être son propre parent."}
+            )
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._original_parent = self.parent
+        self._original_parent_id = self.parent_id
 
     def save(self, *args, **kwargs):
         # OPTIMIZE: if we need to validate the main action in the service propositions
@@ -1048,9 +1056,12 @@ class RevisionActeur(BaseActeur, LatLngPropertiesMixin, DisplayedActeurLinkMixin
                     valeur=perimetre_adomicile.valeur,
                 )
 
-        if self.parent != self._original_parent and self._original_parent:
-            if not self._original_parent.is_parent:
-                self._original_parent.delete()
+        if self.parent_id != self._original_parent_id and self._original_parent_id:
+            original_parent = RevisionActeur.objects.filter(
+                pk=self._original_parent_id
+            ).first()
+            if original_parent and not original_parent.is_parent:
+                original_parent.delete()
 
         # Dès qu'on fait des changements de révisions, quels qu'ils soient,
         # on force le recalcul du nombre d'enfants

--- a/webapp/unit_tests/qfdmo/test_acteur.py
+++ b/webapp/unit_tests/qfdmo/test_acteur.py
@@ -556,6 +556,27 @@ class TestRevisionActeurRemoveParentWithoutChildren:
 
 
 @pytest.mark.django_db
+class TestRevisionActeurSelfParent:
+    def test_cant_be_its_own_parent(self):
+        revision_acteur = RevisionActeurFactory()
+        revision_acteur.parent_id = revision_acteur.identifiant_unique
+        with pytest.raises(ValidationError):
+            revision_acteur.save()
+
+    def test_load_self_referential_parent_does_not_recurse(self):
+        """A self-referential parent already in DB must not crash on load:
+        __init__ keeps only the parent id and does not chase the parent FK."""
+        revision_acteur = RevisionActeurFactory()
+        # Bypass validation to simulate corrupted data already in DB
+        RevisionActeur.objects.filter(pk=revision_acteur.pk).update(
+            parent_id=revision_acteur.identifiant_unique
+        )
+        # Would raise RecursionError before the lazy __init__ fix
+        reloaded = RevisionActeur.objects.get(pk=revision_acteur.pk)
+        assert reloaded._original_parent_id == revision_acteur.identifiant_unique
+
+
+@pytest.mark.django_db
 class TestActeurService:
     def test_acteur_services_basic(self, displayed_acteur):
         displayed_acteur.acteur_services.add(


### PR DESCRIPTION
# Description succincte du problème résolu

[[Clustering] Revalider les 76 sugg’ finies en erreur : maximum recursion depth exceeded + corriger le problème à la source](https://app.notion.com/p/accelerateur-transition-ecologique-ademe/Clustering-Revalider-les-76-sugg-finies-en-erreur-maximum-recursion-depth-exceeded-corriger-le-3866523d57d780c3a07af7b7b671c02d?source=copy_link)
[[Clustering] Re-valider les 345 sugg’ qui ont fail pour cause de ‘Invalid parameters given for Point initialization’  + corriger le problème à la source](https://app.notion.com/p/accelerateur-transition-ecologique-ademe/Clustering-Re-valider-les-345-sugg-qui-ont-fail-pour-cause-de-Invalid-parameters-given-for-Point--3826523d57d78071a4a5cc51293f28ea?source=copy_link)

**🗺️ contexte**: Airflow

**💡 quoi**: Script de rattrapage des suggestions 

**🎯 pourquoi**: Erreurs d'application de suggestion

**🤔 comment**: command django pour corriger les suggestion et les retraiter

**🤓 comment tester**: 

Récuperer la DB de prod et passer les 2 scripts :

- uv run python manage.py fix_cluster_point_suggestions
- uv run python manage.py fix_recursion_suggestions

les suggestions en erreur doivent passer avec succès


## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
