### PR TITLE
Corrige les script et permet des les passer par cohorte

### DIFF
--- a/webapp/data/management/commands/fix_cluster_point_suggestions.py
+++ b/webapp/data/management/commands/fix_cluster_point_suggestions.py
@@ -42,19 +42,32 @@ class Command(BaseCommand):
             action=argparse.BooleanOptionalAction,
             default=True,
         )
+        parser.add_argument(
+            "--suggestion-cohorte-id",
+            type=int,
+            help="Restrict the fix to suggestions from this cohort id",
+        )
 
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
         requeue = options["requeue"]
+        suggestion_cohorte_id = options["suggestion_cohorte_id"]
 
         suggestions = Suggestion.objects.filter(
             statut=SuggestionStatut.ERREUR,
             metadata__error__icontains=POINT_ERROR_MESSAGE,
         )
+        if suggestion_cohorte_id is not None:
+            suggestions = suggestions.filter(
+                suggestion_cohorte_id=suggestion_cohorte_id
+            )
 
         total = suggestions.count()
+        cohort_msg = (
+            f" (cohorte {suggestion_cohorte_id})" if suggestion_cohorte_id else ""
+        )
         self.stdout.write(
-            f"{total} suggestion(s) en erreur avec '{POINT_ERROR_MESSAGE}'"
+            f"{total} suggestion(s) en erreur avec '{POINT_ERROR_MESSAGE}'{cohort_msg}"
         )
 
         fixed_count = 0

--- a/webapp/data/management/commands/fix_recursion_suggestions.py
+++ b/webapp/data/management/commands/fix_recursion_suggestions.py
@@ -42,19 +42,33 @@ class Command(BaseCommand):
             action=argparse.BooleanOptionalAction,
             default=True,
         )
+        parser.add_argument(
+            "--suggestion-cohorte-id",
+            type=int,
+            help="Restrict the fix to suggestions from this cohort id",
+        )
 
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
         requeue = options["requeue"]
+        suggestion_cohorte_id = options["suggestion_cohorte_id"]
 
         suggestions = Suggestion.objects.filter(
             statut=SuggestionStatut.ERREUR,
             metadata__error__icontains=RECURSION_ERROR_MESSAGE,
         )
+        if suggestion_cohorte_id is not None:
+            suggestions = suggestions.filter(
+                suggestion_cohorte_id=suggestion_cohorte_id
+            )
 
         total = suggestions.count()
+        cohort_msg = (
+            f" (cohorte {suggestion_cohorte_id})" if suggestion_cohorte_id else ""
+        )
         self.stdout.write(
-            f"{total} suggestion(s) en erreur avec '{RECURSION_ERROR_MESSAGE}'"
+            f"{total} suggestion(s) en erreur avec "
+            f"'{RECURSION_ERROR_MESSAGE}'{cohort_msg}"
         )
 
         fixed_count = 0
@@ -127,9 +141,8 @@ class Command(BaseCommand):
             data = model_params.get("data")
             if not isinstance(data, dict):
                 continue
-            change_id = model_params.get("id")
             for key in ILLEGAL_PARENT_KEYS:
-                if key in data and data[key] == change_id:
+                if key in data:
                     del data[key]
                     removed += 1
         return removed


### PR DESCRIPTION
# Description succincte du problème résolu

Follow up : #3097


**🗺️ contexte**: Script de rattrappage

**💡 quoi**: Ajouter la notion de cohorte

**🎯 pourquoi**: pour choisir laquelle passer en premier car certaine cohorte ont les mêmes clusters

**🤔 comment**: paramètre suggestion-cohorte-id

**🤓 comment tester**: 

Lancer 

- `uv run python manage.py fix_cluster_point_suggestions --suggestion-cohorte-id=1019 --no-requeue`
- `uv run python manage.py fix_recursion_suggestions --suggestion-cohorte-id=922 --no-requeue`

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
