### PR TITLE
Garder 15 jours d'historique de DAG dans Airflow

### DIFF
--- a/data-platform/dags/tools/dags/airflow_cleanup_db.py
+++ b/data-platform/dags/tools/dags/airflow_cleanup_db.py
@@ -11,7 +11,7 @@ from shared.config.schedules import SCHEDULES
 from shared.config.start_dates import START_DATES
 from shared.config.tags import TAGS
 
-DAYS_TO_KEEP = 7
+DAYS_TO_KEEP = 15
 DEFAULT_BATCH_SIZE = 1000
 
 


### PR DESCRIPTION
# Description succincte du problème résolu

Discussion avec Christian
On n'a pas assez d'historique pour investiguer des soucis potentiel sur des DAGs en preprod et en prod

Passons de 7 à 15 jours de rétention

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Airflow

**💡 quoi**: Ajuster la fenêtre de cleanup des DAG Airflow

**🎯 pourquoi**: Garder plus d'historique

**🤔 comment**: Augmenter la variable `DAYS_TO_KEEP` de 7 à 15 dans le DAG `airflow_cleanup_db`

**🤓 comment tester**: Constater qu'on a 15 jours d'historique


## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
