### PR TITLE
Correction des DAGs CMA et Généric

### DIFF
--- a/data-platform/dags/sources/dags/source_cma.py
+++ b/data-platform/dags/sources/dags/source_cma.py
@@ -67,6 +67,31 @@ with DAG(
                         "transformation": "clean_sous_categorie_codes",
                         "destination": "sous_categorie_codes",
                     },
+                    {
+                        "origin": "email",
+                        "transformation": "clean_email",
+                        "destination": "email",
+                    },
+                    {
+                        "origin": "nom",
+                        "transformation": "strip_string",
+                        "destination": "nom",
+                    },
+                    {
+                        "origin": "adresse",
+                        "transformation": "strip_string",
+                        "destination": "adresse",
+                    },
+                    {
+                        "origin": "description",
+                        "transformation": "strip_string",
+                        "destination": "description",
+                    },
+                    {
+                        "origin": "ville",
+                        "transformation": "strip_string",
+                        "destination": "ville",
+                    },
                     # 3. Ajout des colonnes avec une valeur par défaut
                     {
                         "column": "statut",
@@ -168,11 +193,6 @@ with DAG(
                     {"remove": "techsource"},
                     {"remove": "website"},
                     # 6. Colonnes à garder (rien à faire, utilisé pour le controle)
-                    {"keep": "nom"},
-                    {"keep": "adresse"},
-                    {"keep": "description"},
-                    {"keep": "email"},
-                    {"keep": "ville"},
                 ]
             ),
             "endpoint": ("https://apiopendata.artisanat.fr/reparacteur"),

--- a/data-platform/dags/sources/dags/source_generic.py
+++ b/data-platform/dags/sources/dags/source_generic.py
@@ -43,6 +43,31 @@ def default_normalization_rules() -> list[dict]:
             "transformation": "clean_sous_categorie_codes",
             "destination": "sous_categorie_codes",
         },
+        {
+            "origin": "email",
+            "transformation": "clean_email",
+            "destination": "email",
+        },
+        {
+            "origin": "nom",
+            "transformation": "strip_string",
+            "destination": "nom",
+        },
+        {
+            "origin": "adresse",
+            "transformation": "strip_string",
+            "destination": "adresse",
+        },
+        {
+            "origin": "description",
+            "transformation": "strip_string",
+            "destination": "description",
+        },
+        {
+            "origin": "ville",
+            "transformation": "strip_string",
+            "destination": "ville",
+        },
         # 3. Ajout des colonnes avec une valeur par défaut
         {
             "column": "statut",
@@ -117,11 +142,6 @@ def default_normalization_rules() -> list[dict]:
         {"remove": "categorie"},
         {"remove": "website"},
         # 6. Colonnes à garder (rien à faire, utilisé pour le controle)
-        {"keep": "nom"},
-        {"keep": "adresse"},
-        {"keep": "description"},
-        {"keep": "email"},
-        {"keep": "ville"},
     ]
 
 


### PR DESCRIPTION
# Description succincte du problème résolu

Mattermost : [pb email](https://mattermost.incubateur.net/betagouv/pl/5o64qjkxwfbrffryjhaw9uayca)


**🗺️ contexte**: Airflow - Source

**💡 quoi**: Pour le DAG source généric et CMA, la fonction de transformation des emails n'était pas OK

**🎯 pourquoi**: pas de traitement de validation des format d'email

**🤔 comment**:

- utilisation de clean_email comme fonction de normalisation
- on en profitepour utiliser la fonction de normalisation string_strip sur les champs de type adresse ou description

**🤓 comment tester**: Faire tourner et valider le DAG de la CMA, il devrait y avoir moins d'email

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
