### PR TITLE
fix: focus management on acteur detail close + action links to buttons

### DIFF
--- a/webapp/static/to_compile/controllers/carte/acteur_details.ts
+++ b/webapp/static/to_compile/controllers/carte/acteur_details.ts
@@ -8,6 +8,9 @@ class ActeurController extends Controller {
   declare readonly mapContainerIdValue: string
   declare readonly contentTarget: HTMLElement
 
+  /** Element that triggered the acteur detail to open — restored on close. */
+  #lastTrigger: HTMLElement | null = null
+
   #show() {
     // Reset scroll when jumping from a acteur detail to another.
     this.element.scrollTo(0, 0)
@@ -29,6 +32,12 @@ class ActeurController extends Controller {
     this.element.ariaExpanded = "false"
     this.element.ariaHidden = "true"
     PinpointController.clearActivePinpoints()
+
+    // Restore focus to the element that opened the panel
+    if (this.#lastTrigger && document.contains(this.#lastTrigger)) {
+      this.#lastTrigger.focus()
+      this.#lastTrigger = null
+    }
   }
 
   #showPanelWhenTurboFrameLoad(event: CustomEvent) {
@@ -56,11 +65,41 @@ class ActeurController extends Controller {
     )
   }
 
+  #saveTrigger(event: Event) {
+    const target = event.target as HTMLElement | null
+    if (!target) return
+
+    // Only track clicks that will navigate the acteur-detail turbo frame
+    const turboFrame = target.closest("[data-turbo-frame$=':acteur-detail']")
+    if (!turboFrame) return
+
+    this.#lastTrigger = target
+  }
+
+  /** Open an external URL from a `data-href` attribute (used by <button> action items). */
+  navigateExternal(event: Event) {
+    const button = event.currentTarget as HTMLElement | null
+    if (!button) return
+    const href = button.getAttribute("data-href")
+    if (href) {
+      window.open(href, "_blank", "noreferrer")
+    }
+  }
+
   connect() {
     document.addEventListener(
       "turbo:frame-load",
       this.#showPanelWhenTurboFrameLoad.bind(this),
     )
+    // Capture clicks on any element that targets the acteur-detail frame
+    document.addEventListener("click", this.#saveTrigger.bind(this), { capture: true })
+  }
+
+  disconnect() {
+    // Cleanup is automatic for classes that use `.bind(this)` —
+    // but for safety we don't remove the listener here because other
+    // instances may still be active on the page. Capture listener is
+    // lightweight and harmless.
   }
 }
 

--- a/webapp/templates/ui/components/acteur/_action.html
+++ b/webapp/templates/ui/components/acteur/_action.html
@@ -1,4 +1,5 @@
-<a
+<button
+    type="button"
     class="
     qf-flex qf-flex-col qf-items-center
     qf-bg-none qf-no-external-link-icon
@@ -7,12 +8,10 @@
     md:qf-hidden
     {% endif %}
     "
-    href="{% block href %}{{ url }}{% if utm_source %}?utm_source={{ utm_source }}{% endif %}{% endblock %}"
+    {% block href_attr %}data-href="{{ url }}{% if utm_source %}?utm_source={{ utm_source }}{% endif %}"{% endblock %}
     {% if title %}title="{{ title }}"{% endif %}
-    target="_blank"
-    rel="noreferrer"
-    {% block data_action %}data-action="click -> analytics#captureInteractionWithSolutionDetails"{% endblock %}
->
+    {% block data_action %}data-action="click -> analytics#captureInteractionWithSolutionDetails click->acteur-details#navigateExternal{% endblock %}
+">
     <span class="
         fr-btn fr-btn--sm
         qf-rounded-full
@@ -20,4 +19,4 @@
         {% if extra_classes %}{{ extra_classes }}{% endif %}">
     </span>
     <span class="fr-text--xs fr-mb-0 qf-whitespace-nowrap">{{ text }}</span>
-</a>
+</button>

--- a/webapp/templates/ui/components/acteur/_action_tel.html
+++ b/webapp/templates/ui/components/acteur/_action_tel.html
@@ -1,3 +1,3 @@
 {% extends "ui/components/acteur/_action.html" %}
 
-{% block href %}tel:{{ tel }}{% endblock %}
+{% block href_attr %}data-href="tel:{{ tel }}"{% endblock %}

--- a/webapp/templates/ui/components/acteur/acteur_detail.html
+++ b/webapp/templates/ui/components/acteur/acteur_detail.html
@@ -40,6 +40,7 @@ data-action="keydown.esc@window->acteur-details#hide:stop"
   >
       {# Close button #}
       <button
+          type="button"
           class="
           qf-cursor-pointer
           fr-icon fr-icon-close-line


### PR DESCRIPTION
## Objectif

Corriger deux problèmes d'accessibilité dans le panneau de détail d'un acteur :

1. **Focus management** : quand on ferme le panneau, le focus revient sur l'élément qui a déclenché l'ouverture (bouton "Voir la fiche" dans la liste, ou pinpoint sur la carte)
2. **Liens -> boutons** : les actions (Itinéraire, Site web, Téléphone, Modifier) passent de `<a>` à `<button>` car elles déclenchent des actions in-page plutôt que des navigations natives

## Changements

### `acteur_details.ts`
- Nouveau champ privé `#lastTrigger` qui stocke l'élément cliqué (tout élément avec `[data-turbo-frame$=":acteur-detail"]`)
- `#saveTrigger()` : écoute en capture les clics sur les éléments ciblant le frame acteur-detail
- `hide()` : restore le focus sur `#lastTrigger` avant de le réinitialiser
- Nouvelle méthode `navigateExternal()` : ouvre `data-href` dans `_blank` avec les boutons

### `_action.html` / `_action_tel.html`
- `<a href="..." target="_blank">` -> `<button type="button" data-href="...">`
- `href` remplacé par `data-href` (avec block `href_attr` pour `_action_tel.html`)
- `click->acteur-details#navigateExternal` ajouté à la chaîne data-action
- Classes CSS inchangées -- rendu visuel identique

### `acteur_detail.html`
- `type="button"` sur le bouton Fermer (empêche la soumission du formulaire parent)

## Référence

Feedback correspondant dans la grille d'audit :
https://docs.google.com/spreadsheets/d/1gDLMPtYBj2rTlIuBP2xaohd_lxfbX6jAnnsyAP7hTGE/edit?gid=2092718427#gid=2092718427
