### PR TITLE
Correction de la synchro prod > preprod : restauration via DSN au lieu de Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,15 +213,15 @@ psql:
 
 .PHONY: dump-prod
 dump-prod:
-	sh scripts/infrastructure/backup-db.sh --env prod
+	bash scripts/infrastructure/backup-db.sh --env prod
 
 .PHONY: dump-preprod
 dump-preprod:
-	sh scripts/infrastructure/backup-db.sh --quiet --env preprod
+	bash scripts/infrastructure/backup-db.sh --quiet --env preprod
 
 .PHONY: dump-prod-quiet
 dump-prod-quiet:
-	sh scripts/infrastructure/backup-db.sh --quiet
+	bash scripts/infrastructure/backup-db.sh --quiet
 
 .PHONY: dump-sample
 dump-sample:
@@ -240,7 +240,7 @@ load-prod-dump:
 	@DUMP_FILE=$$(find tmpbackup-prod -type f -name "*.custom" -print -quit); \
 	psql -d '$(DB_URL)' -f scripts/sql/create_extensions.sql && \
 	psql -d '$(DB_URL)' -f $(WAGTAIL_FRENCH_SQL) && \
-	pg_restore -d '$(DB_URL)' --schema=public --clean --no-acl --no-owner --no-privileges "$$DUMP_FILE" || true
+	pg_restore -d '$(DB_URL)' --schema=public --clean --if-exists --no-acl --no-owner --no-privileges "$$DUMP_FILE"
 
 .SILENT:
 .PHONY: load-preprod-dump
@@ -286,8 +286,9 @@ db-restore-local-from-preprod:
 
 .PHONY: db-restore-preprod-from-prod
 db-restore-preprod-from-prod:
-	sh scripts/infrastructure/backup-db.sh --quiet
-	./scripts/db_restore.sh prod tmpbackup-prod
+	$(MAKE) dump-prod-quiet
+	$(MAKE) drop-all-tables
+	$(MAKE) load-prod-dump
 
 .PHONY: db-restore-local-from-sample
 db-restore-local-from-sample:


### PR DESCRIPTION
## Problème

Le workflow **Sync prod > preprod** échoue depuis #3089 ([run en échec](https://github.com/incubateur-ademe/quefairedemesobjets/actions/runs/28617132648/job/84863630838)) :

```
service "lvao-webapp-db" is not running
make: *** [Makefile:290: db-restore-preprod-from-prod] Error 1
```

La refactorisation des Makefile a fait pointer `db-restore-preprod-from-prod` vers `scripts/db_restore.sh`, qui restaure dans le conteneur Docker local `lvao-webapp-db`. Sur le runner CI, aucune stack docker compose ne tourne.

## Correctif

- `db-restore-preprod-from-prod` repasse par `drop-all-tables` + `load-prod-dump`, qui utilisent directement `DB_URL` (le DSN preprod passé par le workflow via `make -e`) — comportement d'avant #3089. `db_restore.sh` reste utilisé pour les restaurations locales.
- `backup-db.sh` est lancé avec `bash` : il utilise `[[`, ce qui provoquait des `[[: not found` silencieux sous `sh` (les gardes des lignes 9 et 49 étaient ignorées).
- `load-prod-dump` : suppression du `|| true` qui faisait passer le job au vert même si `pg_restore` échouait, et ajout de `--if-exists` pour éviter les erreurs bénignes de `DROP` avec `--clean`.

## Test

- `make -n db-restore-preprod-from-prod` résout bien vers `psql`/`pg_restore` sur `$(DB_URL)`, sans docker
- À vérifier après merge : relancer le workflow `sync_databases`