### PR TITLE
Désactivation temporaire de la comparaison visuelle e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -89,6 +89,9 @@ jobs:
 
   e2e-compare:
     name: Compare (main)
+    # Temporarily disabled: remove this condition to re-enable
+    # the visual comparison against main.
+    if: ${{ false }}
     needs: e2e
     uses: ./.github/workflows/_e2e.yml
     with:


### PR DESCRIPTION
# Désactivation temporaire de la comparaison visuelle e2e


**🗺️ contexte**: Stabilisation des tests e2e

**💡 quoi**: Désactivation temporaire du job `e2e-compare` (comparaison visuelle avec `main`) 

**🎯 pourquoi**: La comparaison visuelle est instable et génère du bruit

**🤔 comment**:

le diff est explicite

**🤓 comment tester**: Sur cette PR (ou toute PR taguée `frontend`), vérifier dans l'onglet Actions que les jobs baseline tournent et que `Compare (main)` est skippé.

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [x] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template` (N/A)
- [x] J'ai ajouté des tests qui couvrent le nouveau code (N/A — config CI)
- [x] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html) (N/A)
