### PR TITLE
Augmenter la durée de rétention des backups de la webapp

### DIFF
--- a/infrastructure/modules/database/main.tf
+++ b/infrastructure/modules/database/main.tf
@@ -10,7 +10,7 @@ resource "scaleway_rdb_instance" "webapp" {
   password                  = var.webapp_db_password
   tags                      = ["${var.environment}", "postgresql", "qfdmo"]
   backup_schedule_frequency = 24
-  backup_schedule_retention = 7
+  backup_schedule_retention = 30
   backup_same_region        = false
   volume_size_in_gb         = var.webapp_volume_size
   volume_type               = "sbs_15k"


### PR DESCRIPTION
# Description succincte du problème résolu


**🗺️ contexte**: infra

**💡 quoi**: augmentation de la durée de rétention des backups

**🎯 pourquoi**: car 7j c'est trop peu quand on réalise trop tard qu'on a perdu des données

**🤔 comment**: modif opentofu + console scaleway

**🤓 comment tester**: vérifier dans la ui scaleway 


## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
