### PR TITLE
récupérer des pages produit supprimées

### DIFF
--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -197,3 +197,33 @@ extract-dsfr:
 	$(PYTHON) ./dsfr_hacks/extract_dsfr_colors.py
 	$(PYTHON) ./dsfr_hacks/extract_used_colors.py
 	$(PYTHON) ./dsfr_hacks/extract_used_icons.py
+
+# ProduitPage recovery — recover pages deleted by mistake, from a DB backup.
+# 1. Drop a .custom dump (e.g. a Scalingo backup) into ../tmpbackup-recover/
+# 2. make db-restore-recover
+# 3. make export-produit-pages slugs="mon-produit" [output=recovered.json]
+# 4. make recreate-produit-pages [fixture=recovered.json] [args=--dry-run]
+#    (or run recreate_produit_pages on prod via a Scalingo one-off container)
+RECOVER_DB_URL := postgres://webapp:webapp@localhost:6543/recover# pragma: allowlist secret
+RECOVER_DUMP_DIR := ../tmpbackup-recover
+
+.PHONY: db-restore-recover
+db-restore-recover:
+	@mkdir -p $(RECOVER_DUMP_DIR); \
+	DUMP_FILE=$$(find $(RECOVER_DUMP_DIR) -type f -name "*.custom" -print -quit); \
+	[ -n "$$DUMP_FILE" ] || { echo "No .custom dump found in $(RECOVER_DUMP_DIR)/"; exit 1; }; \
+	echo "Restoring $$DUMP_FILE into 'recover' database..."; \
+	psql -d '$(DB_URL)' -c "DROP DATABASE IF EXISTS recover;" && \
+	psql -d '$(DB_URL)' -c "CREATE DATABASE recover;" && \
+	psql -d '$(RECOVER_DB_URL)' -f ../scripts/sql/create_extensions.sql && \
+	psql -d '$(RECOVER_DB_URL)' -f qfdmd/migrations/sql/create_wagtail_french_config.sql && \
+	pg_restore -d '$(RECOVER_DB_URL)' --schema=public --no-acl --no-owner --no-privileges --verbose --jobs=4 "$$DUMP_FILE" || true
+
+.PHONY: export-produit-pages
+export-produit-pages:
+	@[ -n "$(slugs)" ] || { echo "Usage: make export-produit-pages slugs='slug1 slug2' [output=recovered.json]"; exit 1; }
+	DATABASE_URL='$(RECOVER_DB_URL)' $(DJANGO_ADMIN) export_produit_pages $(slugs) --output $(or $(output),recovered.json)
+
+.PHONY: recreate-produit-pages
+recreate-produit-pages:
+	$(DJANGO_ADMIN) recreate_produit_pages $(or $(fixture),recovered.json) $(args)

--- a/webapp/qfdmd/management/commands/export_produit_pages.py
+++ b/webapp/qfdmd/management/commands/export_produit_pages.py
@@ -1,0 +1,110 @@
+import json
+import sys
+
+from django.core.management.base import BaseCommand
+
+from qfdmd.models import ProduitPage
+
+
+class Command(BaseCommand):
+    help = (
+        "Export ProduitPage instances to the JSON fixture format consumed by "
+        "recreate_produit_pages. Run against a DB where the page still exists "
+        "(restored backup, staging) to recover a deleted page."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "slugs",
+            nargs="+",
+            help="Slugs of the ProduitPages to export.",
+        )
+        parser.add_argument(
+            "--output",
+            type=str,
+            default=None,
+            help="Write JSON to this file instead of stdout.",
+        )
+
+    def handle(self, *args, **options):
+        exported = []
+        for slug in options["slugs"]:
+            try:
+                page = ProduitPage.objects.get(slug=slug)
+            except ProduitPage.DoesNotExist:
+                self.stderr.write(f"ProduitPage with slug='{slug}' not found.")
+                sys.exit(1)
+            except ProduitPage.MultipleObjectsReturned:
+                self.stderr.write(
+                    f"Multiple ProduitPages with slug='{slug}', export by hand."
+                )
+                sys.exit(1)
+            exported.append((page, self._export_page(page)))
+            self.stderr.write(f"Exported '{page.title}' (id={page.pk})")
+
+        # Sort parents before children (Wagtail materialized path) and, when a
+        # page's parent is part of this export, reference it by _key so the
+        # fixture replays on a DB where the original page ids no longer exist.
+        exported.sort(key=lambda item: item[0].path)
+        keys = {page_def["key"] for _, page_def in exported}
+        pages = []
+        for _, page_def in exported:
+            parent_slug = page_def["parent_page_lookup"].get("slug")
+            if parent_slug in keys:
+                page_def["parent_page_lookup"] = {"_key": parent_slug}
+            pages.append(page_def)
+
+        fixture = {
+            "description": "Exported by export_produit_pages",
+            "pages": pages,
+        }
+        output = json.dumps(fixture, indent=2, ensure_ascii=False)
+
+        if options["output"]:
+            with open(options["output"], "w") as f:
+                f.write(output)
+            self.stderr.write(f"Wrote {options['output']}")
+        else:
+            self.stdout.write(output)
+
+    def _export_page(self, page):
+        parent = page.get_parent()
+        return {
+            "key": page.slug,
+            # ponytail: id wins in recreate's lookup; slug kept as a
+            # human-readable hint and cross-env fallback
+            "parent_page_lookup": {"id": parent.pk, "slug": parent.slug},
+            "page_type": "produitpage",
+            "title": page.title,
+            "slug": page.slug,
+            "seo_title": page.seo_title,
+            "search_description": page.search_description,
+            "live": page.live,
+            "show_in_menus": page.show_in_menus,
+            "genre": page.genre,
+            "nombre": page.nombre,
+            "est_famille": page.est_famille,
+            "titre_phrase": page.titre_phrase,
+            "usage_unique": page.usage_unique,
+            "ab_test_carte_default_view": page.ab_test_carte_default_view,
+            "migree_depuis_synonymes_legacy": page.migree_depuis_synonymes_legacy,
+            "commentaire": page.commentaire,
+            "go_live_at": page.go_live_at.isoformat() if page.go_live_at else None,
+            "expire_at": page.expire_at.isoformat() if page.expire_at else None,
+            "legacy_produit_noms": sorted(
+                rel.produit.nom for rel in page.legacy_produit.all()
+            ),
+            "legacy_synonyme_noms": sorted(
+                rel.synonyme.nom for rel in page.legacy_synonymes.all()
+            ),
+            "legacy_synonyme_exclusion_noms": sorted(
+                rel.synonyme.nom for rel in page.legacy_synonymes_to_exclude.all()
+            ),
+            "tag_names": sorted(t.name for t in page.tags.all()),
+            "search_tag_names": sorted(t.name for t in page.search_tags.all()),
+            "sous_categorie_objet_codes": sorted(
+                sc.code for sc in page.sous_categorie_objet.all()
+            ),
+            "infotri": list(page.infotri.raw_data) if page.infotri else [],
+            "body": list(page.body.raw_data) if page.body else [],
+        }

--- a/webapp/qfdmd/management/commands/recreate_produit_pages.py
+++ b/webapp/qfdmd/management/commands/recreate_produit_pages.py
@@ -1,0 +1,308 @@
+import json
+import sys
+from pathlib import Path
+
+from django.core.management.base import BaseCommand
+from django.utils.dateparse import parse_datetime
+from taggit.models import Tag
+from wagtail.models import Page
+
+from qfdmd.models import (
+    LegacyIntermediateProduitPage,
+    LegacyIntermediateProduitPageSynonymeExclusion,
+    LegacyIntermediateSynonymePage,
+    Produit,
+    ProduitPage,
+    SearchTag,
+    Synonyme,
+)
+from qfdmo.models import SousCategorieObjet
+
+
+class Command(BaseCommand):
+    help = "Recreate ProduitPage instances from a JSON fixture using add_child()."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "fixture",
+            type=str,
+            help="Path to the JSON fixture file.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Validate and show what would be created without saving.",
+        )
+        parser.add_argument(
+            "--parent-page-id",
+            type=int,
+            default=None,
+            help="Override the parent page ID for the first page in the fixture.",
+        )
+
+    def handle(self, *args, **options):
+        fixture_path = Path(options["fixture"])
+        dry_run = options["dry_run"]
+        parent_page_id_override = options["parent_page_id"]
+
+        if not fixture_path.exists():
+            self.stderr.write(f"Fixture file not found: {fixture_path}")
+            sys.exit(1)
+
+        with open(fixture_path) as f:
+            data = json.load(f)
+
+        pages = data.get("pages", [])
+        if not pages:
+            self.stderr.write("No pages found in fixture.")
+            return
+
+        if parent_page_id_override is not None and pages:
+            pages[0]["parent_page_lookup"] = {"id": parent_page_id_override}
+            self.stdout.write(
+                f"Overriding first page parent to id={parent_page_id_override}"
+            )
+
+        created_pages = {}
+        for i, page_def in enumerate(pages):
+            self.stdout.write(f"\n--- Page {i + 1}/{len(pages)} ---")
+            created = self._create_page(page_def, created_pages, dry_run)
+            if created:
+                created_pages[page_def.get("key", page_def["slug"])] = created
+
+        if created_pages:
+            self.stdout.write(
+                self.style.SUCCESS(f"\nCreated {len(created_pages)} page(s).")
+            )
+
+    def _find_parent(self, page_def, created_pages):
+        parent_lookup = page_def.get("parent_page_lookup")
+        if not parent_lookup:
+            self.stderr.write("  Missing parent_page_lookup.")
+            return None
+
+        parent_key = parent_lookup.get("_key")
+        if parent_key:
+            parent = created_pages.get(parent_key)
+            if parent:
+                return parent
+            self.stderr.write(
+                f"  Parent key '{parent_key}' not found in created pages "
+                "(must be defined before child)."
+            )
+            return None
+
+        parent_id = parent_lookup.get("id")
+        parent_slug = parent_lookup.get("slug")
+        if parent_id:
+            try:
+                return Page.objects.get(id=parent_id).specific
+            except Page.DoesNotExist:
+                if not parent_slug:
+                    self.stderr.write(f"  Parent page with id={parent_id} not found.")
+                    return None
+                self.stdout.write(
+                    f"  Parent page with id={parent_id} not found, "
+                    f"falling back to slug='{parent_slug}'."
+                )
+
+        if parent_slug:
+            try:
+                return Page.objects.get(slug=parent_slug).specific
+            except Page.DoesNotExist:
+                self.stderr.write(f"  Parent page with slug='{parent_slug}' not found.")
+                return None
+            except Page.MultipleObjectsReturned:
+                self.stderr.write(
+                    f"  Multiple pages found with slug='{parent_slug}'. Use id instead."
+                )
+                return None
+
+        self.stderr.write("  parent_page_lookup must contain one of: id, slug, _key.")
+        return None
+
+    def _create_page(self, page_def, created_pages, dry_run):
+        parent = self._find_parent(page_def, created_pages)
+        if parent is None:
+            return None
+
+        page_type = page_def.get("page_type", "produitpage")
+        if page_type != "produitpage":
+            self.stderr.write(f"  Unsupported page_type: {page_type}")
+            return None
+
+        title = page_def.get("title", "")
+        slug_value = page_def.get("slug", "")
+        self.stdout.write(
+            f"  Creating '{title}' under '{parent.title}' (parent id={parent.pk})"
+        )
+
+        if dry_run:
+            self._dry_run_report(page_def)
+            return None
+
+        page = ProduitPage(
+            title=title,
+            slug=slug_value,
+            live=page_def.get("live", True),
+            show_in_menus=page_def.get("show_in_menus", False),
+            seo_title=page_def.get("seo_title", ""),
+            search_description=page_def.get("search_description", ""),
+            genre=page_def.get("genre", ""),
+            nombre=page_def.get("nombre"),
+            est_famille=page_def.get("est_famille", False),
+            titre_phrase=page_def.get("titre_phrase", ""),
+            usage_unique=page_def.get("usage_unique", False),
+            ab_test_carte_default_view=page_def.get(
+                "ab_test_carte_default_view", False
+            ),
+            migree_depuis_synonymes_legacy=page_def.get(
+                "migree_depuis_synonymes_legacy", False
+            ),
+            commentaire=page_def.get("commentaire", ""),
+        )
+
+        go_live_at = page_def.get("go_live_at")
+        if go_live_at:
+            page.go_live_at = parse_datetime(go_live_at)
+        expire_at = page_def.get("expire_at")
+        if expire_at:
+            page.expire_at = parse_datetime(expire_at)
+
+        parent.add_child(instance=page)
+
+        body = page_def.get("body")
+        if body is not None:
+            page.body = body
+
+        infotri = page_def.get("infotri")
+        if infotri is not None:
+            page.infotri = infotri
+
+        page.save()
+
+        self._attach_tags(page, page_def)
+        self._attach_search_tags(page, page_def)
+        self._attach_sous_categories(page, page_def)
+        self._attach_legacy_redirects(page, page_def)
+
+        revision = page.save_revision()
+        if page_def.get("live", True):
+            revision.publish()
+
+        self.stdout.write(
+            self.style.SUCCESS(f"  Created page id={page.pk}, slug='{page.slug}'")
+        )
+
+        return page
+
+    def _attach_tags(self, page, page_def):
+        tag_names = page_def.get("tag_names", [])
+        for name in tag_names:
+            tag, created = Tag.objects.get_or_create(name=name)
+            page.tags.add(tag)
+            if created:
+                self.stdout.write(f"    Created tag: '{name}'")
+
+        tag_slugs = page_def.get("tag_slugs", [])
+        for slug in tag_slugs:
+            try:
+                tag = Tag.objects.get(slug=slug)
+                page.tags.add(tag)
+            except Tag.DoesNotExist:
+                self.stderr.write(f"    Tag with slug='{slug}' not found, skipping.")
+
+    def _attach_search_tags(self, page, page_def):
+        search_tag_names = page_def.get("search_tag_names", [])
+        for name in search_tag_names:
+            tag, created = SearchTag.objects.get_or_create(name=name)
+            page.search_tags.add(tag)
+            if created:
+                self.stdout.write(f"    Created search tag: '{name}'")
+
+    def _attach_sous_categories(self, page, page_def):
+        codes = page_def.get("sous_categorie_objet_codes", [])
+        for code in codes:
+            try:
+                sc = SousCategorieObjet.objects.get(code=code)
+                page.sous_categorie_objet.add(sc)
+            except SousCategorieObjet.DoesNotExist:
+                self.stderr.write(
+                    f"    SousCategorieObjet with code='{code}' not found, skipping."
+                )
+
+    def _attach_legacy_redirects(self, page, page_def):
+        """Recreate the legacy Django → Wagtail redirect relations.
+
+        The intermediate rows are deleted in cascade with the page, but the
+        Produit/Synonyme objects survive, so they are looked up by nom.
+        """
+        for nom in page_def.get("legacy_produit_noms", []):
+            try:
+                produit = Produit.objects.get(nom=nom)
+                LegacyIntermediateProduitPage.objects.create(page=page, produit=produit)
+            except Produit.DoesNotExist:
+                self.stderr.write(f"    Produit '{nom}' not found, skipping.")
+            except Exception as e:
+                self.stderr.write(f"    Could not redirect produit '{nom}': {e}")
+
+        for nom in page_def.get("legacy_synonyme_noms", []):
+            try:
+                synonyme = Synonyme.objects.get(nom=nom)
+                LegacyIntermediateSynonymePage.objects.create(
+                    page=page, synonyme=synonyme
+                )
+            except Synonyme.DoesNotExist:
+                self.stderr.write(f"    Synonyme '{nom}' not found, skipping.")
+            except Exception as e:
+                self.stderr.write(f"    Could not redirect synonyme '{nom}': {e}")
+
+        for nom in page_def.get("legacy_synonyme_exclusion_noms", []):
+            try:
+                synonyme = Synonyme.objects.get(nom=nom)
+                LegacyIntermediateProduitPageSynonymeExclusion.objects.create(
+                    page=page, synonyme=synonyme
+                )
+            except Synonyme.DoesNotExist:
+                self.stderr.write(
+                    f"    Synonyme (exclusion) '{nom}' not found, skipping."
+                )
+            except Exception as e:
+                self.stderr.write(f"    Could not exclude synonyme '{nom}': {e}")
+
+    def _dry_run_report(self, page_def):
+        tag_names = page_def.get("tag_names", [])
+        search_tag_names = page_def.get("search_tag_names", [])
+        sc_codes = page_def.get("sous_categorie_objet_codes", [])
+
+        self.stdout.write(f"    genre: {page_def.get('genre', '')}")
+        self.stdout.write(f"    nombre: {page_def.get('nombre')}")
+        self.stdout.write(f"    est_famille: {page_def.get('est_famille', False)}")
+        self.stdout.write(f"    titre_phrase: {page_def.get('titre_phrase', '')}")
+        self.stdout.write(f"    usage_unique: {page_def.get('usage_unique', False)}")
+        self.stdout.write(
+            f"    ab_test_carte_default_view: "
+            f"{page_def.get('ab_test_carte_default_view', False)}"
+        )
+        self.stdout.write(
+            f"    migree_depuis_synonymes_legacy: "
+            f"{page_def.get('migree_depuis_synonymes_legacy', False)}"
+        )
+        self.stdout.write(f"    body blocks: {len(page_def.get('body', []))}")
+        self.stdout.write(f"    infotri blocks: {len(page_def.get('infotri', []))}")
+        self.stdout.write(f"    tag_names: {tag_names}")
+        self.stdout.write(f"    search_tag_names: {search_tag_names}")
+        self.stdout.write(f"    sous_categorie_objet_codes: {sc_codes}")
+        self.stdout.write(f"    go_live_at: {page_def.get('go_live_at')}")
+        self.stdout.write(f"    expire_at: {page_def.get('expire_at')}")
+        self.stdout.write(
+            f"    legacy_produit_noms: {page_def.get('legacy_produit_noms', [])}"
+        )
+        self.stdout.write(
+            f"    legacy_synonyme_noms: {page_def.get('legacy_synonyme_noms', [])}"
+        )
+        self.stdout.write(
+            f"    legacy_synonyme_exclusion_noms: "
+            f"{page_def.get('legacy_synonyme_exclusion_noms', [])}"
+        )
+        self.stdout.write("  [DRY RUN] Would create page (not saved).")


### PR DESCRIPTION
# Description succincte du problème résolu

Des ProduitPages supprimées par erreur (`articles-sport`, `velo`) devaient être récupérées depuis un backup de la base de production.

**💡 quoi**: une commande `export_produit_pages` (export d'une ProduitPage au format fixture JSON) et des cibles Makefile pour restaurer un dump `.custom` dans une base `recover` jetable.

**🎯 pourquoi**: Wagtail supprime définitivement les pages (pas de corbeille) ; la seule source de récupération est un backup.

**🤔 comment**:

- `export_produit_pages` : exporte tous les champs éditables (body, infotri, tags, synonymes de recherche, sous-catégories, redirections legacy, planification) au format consommé par `recreate_produit_pages`
- `recreate_produit_pages` : complété (redirections legacy, go_live_at/expire_at, fallback id → slug pour le parent)
- `webapp/Makefile` : `db-restore-recover`, `export-produit-pages`, `recreate-produit-pages`

**🤓 comment tester**:

1. déposer un backup `.custom` dans `tmpbackup-recover/`
2. `make db-restore-recover`
3. `make export-produit-pages slugs="articles-sport velo"`
4. `make recreate-produit-pages args=--dry-run`

## Auto-review

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] J'ai ajouté des tests qui couvrent le nouveau code