### PR TITLE
Vérifier si le DAG refresh_geo_models n'est pas stacké avant d'en lancer un autre

### DIFF
--- a/data-platform/dags/clone/tasks/airflow_logic/chain_tasks.py
+++ b/data-platform/dags/clone/tasks/airflow_logic/chain_tasks.py
@@ -12,7 +12,10 @@ from clone.tasks.airflow_logic.clone_view_in_use_switch_task import (
     clone_view_in_use_switch_task,
 )
 from shared.config.dag_names import REFRESH_GEO_MODELS_DAG_ID
-from shared.tasks.airflow_logic.trigger_dag_task import trigger_dag_task
+from shared.tasks.airflow_logic.trigger_dag_task import (
+    should_trigger_dag_task,
+    trigger_dag_task,
+)
 
 
 def chain_tasks(dag: DAG) -> None:
@@ -22,6 +25,10 @@ def chain_tasks(dag: DAG) -> None:
         clone_table_validate_task(dag),
         clone_view_in_use_switch_task(dag),
         clone_old_tables_remove_task(dag),
+        should_trigger_dag_task(
+            task_id="check_refresh_geo_models_dag_state",
+            target_dag=REFRESH_GEO_MODELS_DAG_ID,
+        ),
         trigger_dag_task(
             task_id="launch_refresh_geo_models",
             target_dag=REFRESH_GEO_MODELS_DAG_ID,


### PR DESCRIPTION
# Description succincte du problème résolu

## ⚠️ Cette PR sera caduque si on merge #3169

Technique
Le DAG refresh_geo_models est lancer après chaque synchro des table de type geo, pour éviter d'empiler les rafraichissement des modèle geo via DBT, on vérifie qu'il n'y a pas déjà un DAG en attente d'exécution


**🗺️ contexte**: Airflow

**💡 quoi**: Ne pas demander des rafraichissement de modèle géo via DBT à la chaine alors que c'est inutil

**🎯 pourquoi**: Optimiser, ne pas lancer des commande qui vont refaire ce qui a déjà été fait

**🤔 comment**: Même fonction que pour le rafraichissement des acteurs : `should_trigger_dag_task`

**🤓 comment tester**: Lancer plusieurs clone de contours à la suite, on devrait ne pas lancer de refresh DBT quand il y en a déjà des stacké


## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
