### PR TITLE
Au déplacement et nouvelle recherche dans la zone, l'adresse initiale n'est plus conservée

### DIFF
--- a/webapp/qfdmo/views/adresses.py
+++ b/webapp/qfdmo/views/adresses.py
@@ -24,6 +24,7 @@ from qfdmo.constants import MAP_FORM_PREFIX
 from qfdmo.forms import MapForm, generate_form_prefix
 from qfdmo.geo_api import retrieve_epci_geojson_from_api_or_cache
 from qfdmo.map_utils import (
+    center_from_frontend_bbox,
     sanitize_frontend_bbox,
 )
 from qfdmo.models import Acteur, ActeurStatus, DisplayedActeur, RevisionActeur
@@ -228,6 +229,11 @@ class AbstractSearchActeursView(
             acteurs_in_bbox = acteurs.in_bbox(bbox)
 
             if acteurs_in_bbox.exists():
+                center = center_from_frontend_bbox(custom_bbox)
+                if center[0] and center[1]:
+                    self.location = json.dumps(
+                        {"longitude": center[0], "latitude": center[1]}
+                    )
                 return custom_bbox, acteurs_in_bbox
 
         # At the beginning, there is no bounding box.

--- a/webapp/static/to_compile/js/solution_map.ts
+++ b/webapp/static/to_compile/js/solution_map.ts
@@ -22,7 +22,6 @@ export class SolutionMap {
   #useOsm: boolean
   bboxValue?: Array<Number>
   points: Array<Array<Number>>
-  #homePoint: Array<Number> | null = null
   mapPadding: number = 50
   initialZoom: number = DEFAULT_INITIAL_ZOOM
 
@@ -91,9 +90,6 @@ export class SolutionMap {
           new maplibregl.Popup().setHTML("<p><strong>Vous êtes ici !</strong></p>"),
         )
         .addTo(this.map)
-
-      // Store home point for inclusion in fitBounds
-      this.#homePoint = [this.#location.latitude, this.#location.longitude]
     }
   }
 
@@ -169,13 +165,11 @@ export class SolutionMap {
         fitBoundsOptions,
       )
     } else {
-      // Include home point (user location) in bounds calculation
-      const allPoints = this.#homePoint ? [...points, this.#homePoint] : points
-
-      if (allPoints.length > 0) {
+      // ponytail: le pinpoint home est volontairement exclu du fitBounds (cf. PR #2755)
+      if (points.length > 0) {
         // Compute bbox from points
-        const lngs = allPoints.map((point) => point[1])
-        const lats = allPoints.map((point) => point[0])
+        const lngs = points.map((point) => point[1])
+        const lats = points.map((point) => point[0])
         const bounds: LngLatBoundsLike = [
           [Math.min(...lngs), Math.min(...lats)], // South-west
           [Math.max(...lngs), Math.max(...lats)], // North-east


### PR DESCRIPTION
## Problème

Fixes #3131

Quand l'utilisateur effectue une recherche par adresse puis déplace la carte et clique sur « Nouvelle recherche dans cette zone » :
- Le pin rouge restait positionné à l'adresse initiale
- La carte zoomait trop loin pour englober à la fois l'ancien pin et les nouveaux résultats

## Solution

Dans `_bbox_and_acteurs_from_location_or_epci()`, quand une bbox produit des résultats, `self.location` est maintenant mis à jour avec le centre de la bbox plutôt que de conserver les coordonnées de l'adresse initiale. Le pin rouge se déplace donc au centre de la nouvelle zone de recherche.

## Tâches frontend

- [ ] Vérifier que le comportement du pin rouge est correct dans les scénarios suivants :
  - Recherche par adresse → déplacement → « Nouvelle recherche dans cette zone »
  - Recherche « Autour de moi » → déplacement → « Nouvelle recherche dans cette zone »
  - Recherche par adresse sans déplacement (comportement inchangé)
- [ ] Vérifier que le `fitBounds` zoome correctement sur la nouvelle zone

## Preview

<!-- Ajouter le lien de preview ici -->