### PR TITLE
utiliser la fonction chain au lieu de l'operateur >>

### DIFF
--- a/data-platform/dags/acteurs/dags/compute_acteur.py
+++ b/data-platform/dags/acteurs/dags/compute_acteur.py
@@ -6,6 +6,7 @@ from acteurs.tasks.airflow_logic.replace_acteur_table_task import (
 )
 from airflow import DAG
 from airflow.providers.standard.operators.bash import BashOperator
+from airflow.sdk.bases.operator import chain
 from shared.config.airflow import DEFAULT_ARGS
 from shared.config.dbt_commands import DBT_RUN, DBT_TEST
 from shared.config.schedules import SCHEDULES
@@ -139,41 +140,44 @@ with DAG(
     )
 
     # Définir la séquence principale
-    (
-        dbt_run_base_acteurs
-        >> dbt_test_base_acteurs
-        >> dbt_run_intermediate_acteurs
-        >> dbt_test_intermediate_acteurs
-        >> dbt_run_marts_acteurs_carte
-        >> dbt_test_marts_acteurs_carte
-        >> dbt_run_exposure_acteurs_carte
-        >> dbt_test_exposure_acteurs_carte
-        >> dbt_run_marts_acteurs_opendata
-        >> dbt_test_marts_acteurs_opendata
-        >> dbt_run_exposure_acteurs_opendata
-        >> dbt_test_exposure_acteurs_opendata
-        >> dbt_run_marts_acteurs_exhaustive
-        >> dbt_test_marts_acteurs_exhaustive
-        >> dbt_run_exposure_acteurs_exhaustive
-        >> dbt_test_exposure_acteurs_exhaustive
+    chain(
+        dbt_run_base_acteurs,
+        dbt_test_base_acteurs,
+        dbt_run_intermediate_acteurs,
+        dbt_test_intermediate_acteurs,
+        dbt_run_marts_acteurs_carte,
+        dbt_test_marts_acteurs_carte,
+        dbt_run_exposure_acteurs_carte,
+        dbt_test_exposure_acteurs_carte,
+        dbt_run_marts_acteurs_opendata,
+        dbt_test_marts_acteurs_opendata,
+        dbt_run_exposure_acteurs_opendata,
+        dbt_test_exposure_acteurs_opendata,
+        dbt_run_marts_acteurs_exhaustive,
+        dbt_test_marts_acteurs_exhaustive,
+        dbt_run_exposure_acteurs_exhaustive,
+        dbt_test_exposure_acteurs_exhaustive,
     )
     # Définir la séquence de vérification en parallèle
-    (
-        dbt_test_exposure_acteurs_carte
-        >> check_model_table_epci_task
-        >> replace_epci_table_task
+    # EPCI
+    chain(
+        dbt_test_exposure_acteurs_carte,
+        check_model_table_epci_task,
+        replace_epci_table_task,
     )
-    (
-        dbt_test_exposure_acteurs_carte
-        >> check_model_table_displayedacteur_task
-        >> check_model_table_displayedpropositionservice_task
-        >> check_model_table_displayedperimetreadomicile_task
-        >> replace_displayedacteur_table_task
+    # DisplayedActeur
+    chain(
+        dbt_test_exposure_acteurs_carte,
+        check_model_table_displayedacteur_task,
+        check_model_table_displayedpropositionservice_task,
+        check_model_table_displayedperimetreadomicile_task,
+        replace_displayedacteur_table_task,
     )
-    (
-        dbt_test_exposure_acteurs_exhaustive
-        >> check_model_table_vueacteur_task
-        >> check_model_table_vuepropositionservice_task
-        >> check_model_table_vueperimetreadomicile_task
-        >> replace_vueacteur_table_task
+    # VueActeur
+    chain(
+        dbt_test_exposure_acteurs_exhaustive,
+        check_model_table_vueacteur_task,
+        check_model_table_vuepropositionservice_task,
+        check_model_table_vueperimetreadomicile_task,
+        replace_vueacteur_table_task,
     )

--- a/data-platform/dags/acteurs/dags/export_opendata.py
+++ b/data-platform/dags/acteurs/dags/export_opendata.py
@@ -5,6 +5,7 @@ from acteurs.tasks.airflow_logic.remove_old_s3_opendata_csv_task import (
     remove_old_s3_opendata_csv_task,
 )
 from airflow import DAG
+from airflow.sdk.bases.operator import chain
 from decouple import config
 from shared.config.airflow import DEFAULT_ARGS
 from shared.config.schedules import SCHEDULES
@@ -34,4 +35,7 @@ with DAG(
     max_active_runs=1,
 ) as dag:
 
-    export_opendata_csv_to_s3_task(dag=dag) >> remove_old_s3_opendata_csv_task(dag=dag)
+    chain(
+        export_opendata_csv_to_s3_task(dag=dag),
+        remove_old_s3_opendata_csv_task(dag=dag),
+    )

--- a/data-platform/dags/crawl/dags/crawl_urls.py
+++ b/data-platform/dags/crawl/dags/crawl_urls.py
@@ -1,5 +1,6 @@
 from airflow import DAG
 from airflow.sdk import Param
+from airflow.sdk.bases.operator import chain
 from crawl.tasks.airflow_logic.crawl_urls_check_crawl_task import (
     crawl_urls_check_crawl_task,
 )
@@ -90,8 +91,8 @@ with DAG(
     suggest_diff_other = crawl_urls_suggest_crawl_diff_other_task(dag)
 
     # Always reading and checking syntax
-    read >> check_syntax >> suggest_syntax  # type: ignore
+    chain(read, check_syntax, suggest_syntax)
     # DNS depends on syntax
-    check_syntax >> check_dns >> suggest_dns  # type: ignore
+    chain(check_syntax, check_dns, suggest_dns)
     # Crawl depends on DNS
-    check_dns >> check_crawl >> [suggest_diff_standard, suggest_diff_other]  # type: ignore
+    chain(check_dns, check_crawl, [suggest_diff_standard, suggest_diff_other])

--- a/data-platform/dags/enrich/dags/enrich_acteurs_closed.py
+++ b/data-platform/dags/enrich/dags/enrich_acteurs_closed.py
@@ -4,6 +4,7 @@ contains people from Annuaire Entreprise (AE)
 """
 
 from airflow import DAG
+from airflow.sdk.bases.operator import chain
 from enrich.config.cohorts import COHORTS
 from enrich.config.dbt import DBT
 from enrich.config.models import EnrichActeursClosedConfig
@@ -88,9 +89,14 @@ with DAG(
     )
 
     # Graph
-    config >> dbt_refresh  # type: ignore
-    dbt_refresh >> dbt_test  # type: ignore
-    dbt_test >> suggest_not_replaced_unite  # type: ignore
-    dbt_test >> suggest_not_replaced_etablissement  # type: ignore
-    dbt_test >> suggest_other_siren  # type: ignore
-    dbt_test >> suggest_same_siren  # type: ignore
+    chain(
+        config,
+        dbt_refresh,
+        dbt_test,
+        [
+            suggest_not_replaced_unite,
+            suggest_not_replaced_etablissement,
+            suggest_other_siren,
+            suggest_same_siren,
+        ],
+    )

--- a/data-platform/dags/enrich/dags/enrich_acteurs_normalize_codepostal.py
+++ b/data-platform/dags/enrich/dags/enrich_acteurs_normalize_codepostal.py
@@ -1,4 +1,5 @@
 from airflow import DAG
+from airflow.sdk.bases.operator import chain
 from enrich.tasks.airflow_logic.db_read_acteur_cp_task import db_read_acteur_cp_task
 from enrich.tasks.airflow_logic.db_write_cp_suggestions_task import (
     db_write_cp_suggestions_task,
@@ -23,4 +24,4 @@ with DAG(
     db_read_acteur_cp = db_read_acteur_cp_task(dag)
     acteur_cp_normalize = normalize_acteur_cp_task(dag)
     db_write_cp_suggestions = db_write_cp_suggestions_task(dag)
-    db_read_acteur_cp >> acteur_cp_normalize >> db_write_cp_suggestions  # type: ignore
+    chain(db_read_acteur_cp, acteur_cp_normalize, db_write_cp_suggestions)

--- a/data-platform/dags/enrich/dags/enrich_acteurs_rgpd.py
+++ b/data-platform/dags/enrich/dags/enrich_acteurs_rgpd.py
@@ -1,6 +1,7 @@
 """DAG to anonymize QFDMO acteurs for RGPD"""
 
 from airflow import DAG
+from airflow.sdk.bases.operator import chain
 from enrich.config.cohorts import COHORTS
 from enrich.config.dbt import DBT
 from enrich.config.models import EnrichActeursRGPDConfig
@@ -45,4 +46,4 @@ with DAG(
         cohort=COHORTS.RGPD,
         dbt_model_name=DBT.MARTS_ENRICH_RGPD_SUGGESTIONS,
     )
-    config >> dbt_refresh >> dbt_test >> suggest_rgpd  # type: ignore
+    chain(config, dbt_refresh, dbt_test, suggest_rgpd)

--- a/data-platform/dags/enrich/dags/enrich_acteurs_villes.py
+++ b/data-platform/dags/enrich/dags/enrich_acteurs_villes.py
@@ -1,6 +1,7 @@
 """DAG to suggestion city corrections based on BAN data"""
 
 from airflow import DAG
+from airflow.sdk.bases.operator import chain
 from enrich.config.cohorts import COHORTS
 from enrich.config.dbt import DBT
 from enrich.config.models import EnrichActeursVillesConfig
@@ -57,7 +58,4 @@ with DAG(
         cohort=COHORTS.VILLES_NEW,
         dbt_model_name=DBT.MARTS_ENRICH_VILLES_NEW,
     )
-    config >> dbt_refresh  # type: ignore
-    dbt_refresh >> dbt_test  # type: ignore
-    dbt_test >> suggest_typo  # type: ignore
-    dbt_test >> suggest_new  # type: ignore
+    chain(config, dbt_refresh, dbt_test, [suggest_typo, suggest_new])

--- a/data-platform/dags/enrich/dags/enrich_siret_siren.py
+++ b/data-platform/dags/enrich/dags/enrich_siret_siren.py
@@ -10,6 +10,7 @@ crawl_urls does with `use_legacy_suggestions=False`.
 """
 
 from airflow import DAG
+from airflow.sdk.bases.operator import chain
 from enrich.config.cohorts import COHORTS
 from enrich.config.dbt import DBT
 from enrich.config.models import EnrichActeursSiretSirenConfig
@@ -82,7 +83,8 @@ with DAG(
         suggest_field="siren",
     )
 
-    # Graph
-    dbt_refresh >> dbt_test  # type: ignore
-    dbt_test >> suggest_siret_from_siren  # type: ignore
-    dbt_test >> suggest_siren_from_siret  # type: ignore
+    chain(
+        dbt_refresh,
+        dbt_test,
+        [suggest_siret_from_siren, suggest_siren_from_siret],
+    )

--- a/data-platform/dags/tools/dags/airflow_cleanup_db.py
+++ b/data-platform/dags/tools/dags/airflow_cleanup_db.py
@@ -2,17 +2,20 @@
 - Originally developped by Astronomer: https://www.astronomer.io/docs/learn/cleanup-dag-tutorial
 - Modified to fit our needs"""
 
+import shlex
 from datetime import UTC, datetime, timedelta
 
 from airflow.cli.commands.db_command import all_tables
 from airflow.providers.standard.operators.bash import BashOperator
 from airflow.sdk import Param, dag
+from airflow.sdk.bases.operator import chain
 from shared.config.schedules import SCHEDULES
 from shared.config.start_dates import START_DATES
 from shared.config.tags import TAGS
 
 DAYS_TO_KEEP = 15
 DEFAULT_BATCH_SIZE = 1000
+DB_CLEANUP_SCRIPT = "/opt/airflow/scripts/db_cleanup.sh"
 
 
 @dag(
@@ -60,22 +63,44 @@ DEFAULT_BATCH_SIZE = 1000
     },
 )
 def airflow_cleanup_db():
+    def db_cleanup_command(params: dict) -> str:
+        cmd = [
+            DB_CLEANUP_SCRIPT,
+            "db",
+            "clean",
+            "--clean-before-timestamp",
+            params["clean_before_timestamp"],
+            "--batch-size",
+            str(params["batch_size"]),
+            "--skip-archive",
+            "--verbose",
+            "--yes",
+        ]
+        if params["dry_run"]:
+            cmd.append("--dry-run")
+        if params["tables"]:
+            cmd.extend(["--tables", ",".join(params["tables"])])
+        return " ".join(shlex.quote(arg) for arg in cmd)
+
+    def db_archive_cleanup_command(params: dict) -> str:
+        cmd = [
+            DB_CLEANUP_SCRIPT,
+            "db",
+            "drop-archived",
+            "--yes",
+        ]
+        if params["tables"]:
+            cmd.extend(["--tables", ",".join(params["tables"])])
+        return " ".join(shlex.quote(arg) for arg in cmd)
+
+    # Trailing space prevents Airflow from interpreting the command as a
+    # path to a Jinja template file (BashOperator.template_ext = ('.sh',)).
+    db_cleanup_bash_command = "{{ db_cleanup_command(params) }} "
+    db_archive_cleanup_bash_command = "{{ db_archive_cleanup_command(params) }} "
+
     db_cleanup = BashOperator(
         task_id="db_cleanup",
-        bash_command="""\
-            /opt/airflow/scripts/db_cleanup.sh db clean \
-             --clean-before-timestamp '{{ params.clean_before_timestamp }}' \
-             --batch-size {{ params.batch_size }} \
-             --skip-archive \
-        {% if params.dry_run -%}
-             --dry-run \
-        {% endif -%}
-        {% if params.tables -%}
-             --tables '{{ params.tables|join(',') }}' \
-        {% endif -%}
-             --verbose \
-             --yes \
-        """,
+        bash_command=db_cleanup_bash_command,
         do_xcom_push=False,
     )
 
@@ -83,18 +108,18 @@ def airflow_cleanup_db():
     # (before --skip-archive was used) or by partial failures.
     db_archive_cleanup = BashOperator(
         task_id="clean_archive_tables",
-        bash_command="""\
-            /opt/airflow/scripts/db_cleanup.sh db drop-archived \
-        {% if params.tables -%}
-             --tables {{ params.tables|join(',') }} \
-        {% endif -%}
-             --yes \
-        """,
+        bash_command=db_archive_cleanup_bash_command,
         do_xcom_push=False,
         trigger_rule="all_done",
     )
 
-    db_cleanup >> db_archive_cleanup
+    db_cleanup.dag.user_defined_macros = {
+        **(db_cleanup.dag.user_defined_macros or {}),
+        "db_cleanup_command": db_cleanup_command,
+        "db_archive_cleanup_command": db_archive_cleanup_command,
+    }
+
+    chain(db_cleanup, db_archive_cleanup)
 
 
 airflow_cleanup_db()


### PR DESCRIPTION
# Description succincte du problème résolu

## ⚠️ PR au dessus de #3177

4 PR qui s'enchainent : #3169 > #3170 > #3177 > #3178

Technique
en lieu et place de l'opérateur `>>` mal intéerprété par les linters, on utilise la fonction `chain`

+ refacto de `airflow_cleanup_db`

**🗺️ contexte**: Airflow

**💡 quoi**: ☝️ 

**🎯 pourquoi**: simplification

**🤔 comment**: ☝️ 

**🤓 comment tester**: tous les DAGs continue à fonctionner, en particulier `airflow_cleanup_db`

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
