### PR TITLE
Ajout d'un paramètre pour corriger les datasets de la BAN

### DIFF
--- a/data-platform/dags/clone/config/models.py
+++ b/data-platform/dags/clone/config/models.py
@@ -4,7 +4,8 @@ import re
 from pathlib import Path
 from typing import Literal
 
-from pydantic import AnyUrl, BaseModel, computed_field
+from clone.tasks.business_logic.fix_corrupted_utf8 import validate_sed_substitutions
+from pydantic import AnyUrl, BaseModel, computed_field, model_validator
 
 DIR_CURRENT = Path(__file__).resolve()
 DIR_SQL_CREATION = DIR_CURRENT.parent / "sql" / "creation"
@@ -12,6 +13,16 @@ DIR_SQL_VALIDATION = DIR_CURRENT.parent / "sql" / "validation"
 
 PREFIX_ALL = "clone"
 SUFFIX_VIEW_IN_USE = "in_use"
+
+FIX_CORRUPTED_UTF8_SED_SUBSTITUTION_DESCRIPTION = """
+🔧 Liste d'expressions sed limitées au format 's/motif/remplacement/'
+(remplacement littéral de bytes sur tout le fichier, pas une commande shell).
+Ajouter '/g' pour remplacer toutes les occurrences. Seules les séquences '\\xHH'
+sont autorisées comme échappements.
+
+**Exemples :**
+- s/\\xef\\xbf\\xbd\\xa9/é/ : remplace le caractère Unicode 'U+FFFD' par 'é'
+"""
 
 
 class CloneConfig(BaseModel):
@@ -26,6 +37,18 @@ class CloneConfig(BaseModel):
     delimiter: str = ","
     run_timestamp: str
     convert_downloaded_file_to_utf8: bool = False
+    fix_corrupted_utf8_sed_substitutions: list[str] = []
+
+    @model_validator(mode="after")
+    def validate_fix_corrupted_utf8(self) -> "CloneConfig":
+        substitutions = [
+            item.strip()
+            for item in self.fix_corrupted_utf8_sed_substitutions
+            if item.strip()
+        ]
+        if substitutions:
+            validate_sed_substitutions(substitutions)
+        return self
 
     @computed_field
     @property

--- a/data-platform/dags/clone/dags/clone_ban_adresses.py
+++ b/data-platform/dags/clone/dags/clone_ban_adresses.py
@@ -6,6 +6,7 @@ running into DB table name length limits.
 
 from airflow import DAG
 from airflow.sdk import Param
+from clone.config.models import FIX_CORRUPTED_UTF8_SED_SUBSTITUTION_DESCRIPTION
 from clone.tasks.airflow_logic.chain_tasks import chain_tasks
 from clone.tasks.airflow_logic.clone_dbt_task import clone_dbt_params
 from shared.config.airflow import DEFAULT_ARGS_NO_RETRIES
@@ -62,6 +63,11 @@ with DAG(
             ";",
             type="string",
             description_md="🔤 Délimiteur utilisé dans le fichier",
+        ),
+        "fix_corrupted_utf8_sed_substitutions": Param(
+            [],
+            type="array",
+            description_md=FIX_CORRUPTED_UTF8_SED_SUBSTITUTION_DESCRIPTION,
         ),
         **clone_dbt_params(dbt_select="tag:ban,tag:normalisation"),
     },

--- a/data-platform/dags/clone/dags/clone_ban_lieux_dits.py
+++ b/data-platform/dags/clone/dags/clone_ban_lieux_dits.py
@@ -6,6 +6,7 @@ running into DB table name length limits.
 
 from airflow import DAG
 from airflow.sdk import Param
+from clone.config.models import FIX_CORRUPTED_UTF8_SED_SUBSTITUTION_DESCRIPTION
 from clone.tasks.airflow_logic.chain_tasks import chain_tasks
 from shared.config.airflow import DEFAULT_ARGS_NO_RETRIES
 from shared.config.schedules import SCHEDULES
@@ -61,6 +62,11 @@ with DAG(
             ";",
             type="string",
             description_md="🔤 Délimiteur utilisé dans le fichier",
+        ),
+        "fix_corrupted_utf8_sed_substitutions": Param(
+            [],
+            type="array",
+            description_md=FIX_CORRUPTED_UTF8_SED_SUBSTITUTION_DESCRIPTION,
         ),
     },
 ) as dag:

--- a/data-platform/dags/clone/tasks/airflow_logic/clone_table_create_task.py
+++ b/data-platform/dags/clone/tasks/airflow_logic/clone_table_create_task.py
@@ -45,6 +45,7 @@ def clone_table_create_wrapper(ti) -> None:
         table_name=config.table_name,
         table_schema_file_path=config.table_schema_file_path,
         convert_downloaded_file_to_utf8=config.convert_downloaded_file_to_utf8,
+        fix_corrupted_utf8_sed_substitutions=config.fix_corrupted_utf8_sed_substitutions,
         dry_run=config.dry_run,
     )
 

--- a/data-platform/dags/clone/tasks/business_logic/clone_table_create.py
+++ b/data-platform/dags/clone/tasks/business_logic/clone_table_create.py
@@ -4,6 +4,7 @@ import logging
 import tempfile
 from pathlib import Path
 
+from clone.tasks.business_logic.fix_corrupted_utf8 import fix_corrupted_utf8_file
 from pydantic import AnyUrl
 from shared.config.airflow import TMP_FOLDER
 from utils import logging_utils as log
@@ -139,6 +140,7 @@ def commands_download_to_disk_first(
     delimiter: str,
     table_name: str,
     convert_downloaded_file_to_utf8: bool,
+    fix_corrupted_utf8_sed_substitutions: list[str],
     dry_run: bool,
 ):
     """Commands to create table while first dowloading to disk"""
@@ -175,6 +177,18 @@ def commands_download_to_disk_first(
             )
             file_unpacked = file_converted
 
+        if fix_corrupted_utf8_sed_substitutions:
+            file_path = Path(folder) / file_unpacked
+            logger.info(
+                "Correction UTF-8 dans %s avec %r",
+                file_path,
+                fix_corrupted_utf8_sed_substitutions,
+            )
+            fix_corrupted_utf8_file(
+                file_path=file_path,
+                sed_substitutions=fix_corrupted_utf8_sed_substitutions,
+            )
+
         # Load into DB
         if file_unpacked.endswith(".csv"):
             cmd_psql = command_psql_copy_from_csv(
@@ -200,6 +214,7 @@ def clone_table_create(
     table_name: str,
     table_schema_file_path: Path,
     convert_downloaded_file_to_utf8: bool,
+    fix_corrupted_utf8_sed_substitutions: list[str],
     dry_run: bool,
 ) -> None:
     django_setup_full()
@@ -232,6 +247,7 @@ def clone_table_create(
                 delimiter=delimiter,
                 table_name=table_name,
                 convert_downloaded_file_to_utf8=convert_downloaded_file_to_utf8,
+                fix_corrupted_utf8_sed_substitutions=fix_corrupted_utf8_sed_substitutions,
                 dry_run=dry_run,
             )
         elif clone_method == "stream_directly":

--- a/data-platform/dags/clone/tasks/business_logic/fix_corrupted_utf8.py
+++ b/data-platform/dags/clone/tasks/business_logic/fix_corrupted_utf8.py
@@ -1,0 +1,66 @@
+"""Safe UTF-8 fix on a CSV file before PostgreSQL import."""
+
+import logging
+import re
+import shlex
+from pathlib import Path
+
+from utils.cmd import cmd_run
+
+logger = logging.getLogger(__name__)
+
+# Literal s/pattern/replacement/ expression (optional trailing g).
+SED_SUBSTITUTION_RE = re.compile(
+    r"^s/"
+    r"(?P<pattern>(?:[^/\\]|\\.|\\x[0-9a-fA-F]{2})+)"
+    r"/"
+    r"(?P<replacement>(?:[^/\\]|\\.|\\x[0-9a-fA-F]{2})+)"
+    r"/"
+    r"(?P<flags>g)?$"
+)
+
+FORBIDDEN_CHARACTERS = set("\n\r;|`&<>()${}'")
+
+
+class UnsafeSedSubstitutionError(ValueError):
+    """Raised when a sed substitution expression is rejected."""
+
+
+def validate_sed_substitutions(sed_substitutions: list[str]) -> None:
+    """Validate one or more sed-like s/pattern/replacement/ expressions."""
+    for sed_substitution in sed_substitutions:
+        if any(char in sed_substitution for char in FORBIDDEN_CHARACTERS):
+            raise UnsafeSedSubstitutionError(
+                "L'expression contient des caractères interdits"
+            )
+
+        match = SED_SUBSTITUTION_RE.fullmatch(sed_substitution)
+        if match is None:
+            raise UnsafeSedSubstitutionError(
+                "Format attendu : s/motif/remplacement/ "
+                "(remplacement littéral, pas regex)"
+            )
+
+
+def fix_corrupted_utf8_file(
+    file_path: Path,
+    sed_substitutions: list[str],
+) -> None:
+    """Apply validated sed substitutions on a file via the sed shell command."""
+    substitutions = [item.strip() for item in sed_substitutions if item.strip()]
+    if not substitutions:
+        return
+
+    validate_sed_substitutions(substitutions)
+
+    for sed_substitution in substitutions:
+
+        cmd_run(
+            f"sed -i {shlex.quote(sed_substitution)} {shlex.quote(str(file_path))}",
+            dry_run=False,
+        )
+
+    logger.info(
+        "Correction UTF-8 appliquée sur %s",
+        file_path,
+    )

--- a/data-platform/dags/tests/clone/tasks/business_logic/test_clone_table_create.py
+++ b/data-platform/dags/tests/clone/tasks/business_logic/test_clone_table_create.py
@@ -60,6 +60,7 @@ class TestCommands:
                 file_unpacked="StockUniteLegale_utf8.csv",
                 delimiter=",",
                 convert_downloaded_file_to_utf8=False,
+                fix_corrupted_utf8_sed_substitutions=[],
                 table_name="my_table",
                 dry_run=True,
             )
@@ -83,6 +84,7 @@ class TestCommands:
                 file_unpacked="adresses-france.csv",
                 delimiter=";",
                 convert_downloaded_file_to_utf8=False,
+                fix_corrupted_utf8_sed_substitutions=[],
                 table_name="my_table",
                 dry_run=True,
             )
@@ -91,3 +93,31 @@ class TestCommands:
             assert "zcat" in mock_cmd_run.call_args_list[1][0][0]
             assert "wc" in mock_cmd_run.call_args_list[2][0][0]
             assert "psql" in mock_cmd_run.call_args_list[3][0][0]
+
+    def test_download_gz_with_fix_corrupted_utf8(self):
+        substitutions = [
+            r"s/entr\xef\xbf\xbd\xa9e/entrée/",
+            r"s/foo/bar/g",
+        ]
+        with (
+            patch(
+                "clone.tasks.business_logic.clone_table_create.cmd_run"
+            ) as mock_cmd_run,
+            patch(
+                "clone.tasks.business_logic.clone_table_create.fix_corrupted_utf8_file"
+            ) as mock_fix,
+            patch("clone.tasks.business_logic.clone_table_create.TMP_FOLDER", "/tmp"),
+        ):
+            commands_download_to_disk_first(
+                data_endpoint=AnyUrl(url="https://example.com/adresses-france.csv.gz"),
+                file_downloaded="adresses-france.csv.gz",
+                file_unpacked="adresses-france.csv",
+                delimiter=";",
+                convert_downloaded_file_to_utf8=False,
+                fix_corrupted_utf8_sed_substitutions=substitutions,
+                table_name="my_table",
+                dry_run=True,
+            )
+            assert len(mock_cmd_run.call_args_list) == 4
+            mock_fix.assert_called_once()
+            assert mock_fix.call_args.kwargs["sed_substitutions"] == substitutions

--- a/data-platform/dags/tests/clone/tasks/business_logic/test_fix_corrupted_utf8.py
+++ b/data-platform/dags/tests/clone/tasks/business_logic/test_fix_corrupted_utf8.py
@@ -1,0 +1,114 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from clone.config.models import CloneConfig
+from clone.tasks.business_logic.fix_corrupted_utf8 import (
+    UnsafeSedSubstitutionError,
+    fix_corrupted_utf8_file,
+    validate_sed_substitutions,
+)
+from pydantic import ValidationError
+
+
+class TestValidateSedSubstitution:
+
+    @pytest.mark.parametrize(
+        "expression",
+        [
+            ["s/entr\xef\xbf\xbd\xa9e/entrée/"],
+            ["s/foo/bar/"],
+            ["s/foo/bar/g"],
+            ["s/entr\xef\xbf\xbd\xa9e/entrée/", "s/foo/bar/g"],
+        ],
+    )
+    def test_accepts_safe_expressions(self, expression):
+        validate_sed_substitutions(expression)
+
+    @pytest.mark.parametrize(
+        "expression",
+        [
+            [""],
+            ["s/foo/bar"],
+            ["s/foo/bar/; rm -rf /"],
+            ["s/foo/bar/e"],
+            ["s/foo/bar/w /etc/passwd"],
+            ["s/$(whoami)/bar/"],
+            ["12086494s/entr\xef\xbf\xbd\xa9e/entrée/"],
+            ["s/a'b/bar/"],
+            ["s/a/b/", "s/foo/bar"],
+        ],
+    )
+    def test_rejects_unsafe_expressions(self, expression):
+        with pytest.raises(UnsafeSedSubstitutionError):
+            validate_sed_substitutions(expression)
+
+
+class TestFixCorruptedUtf8File:
+
+    def test_quotes_sed_expression_for_shell(self, tmp_path: Path):
+        csv_file = tmp_path / "sample.csv"
+        csv_file.write_bytes(b"content\n")
+
+        with patch(
+            "clone.tasks.business_logic.fix_corrupted_utf8.cmd_run"
+        ) as mock_cmd_run:
+            fix_corrupted_utf8_file(
+                file_path=csv_file,
+                sed_substitutions=[r"s/\xef\xbf\xbd\xa9/é/"],
+            )
+
+        mock_cmd_run.assert_called_once_with(
+            f"sed -i 's/\\xef\\xbf\\xbd\\xa9/é/' {csv_file}",
+            dry_run=False,
+        )
+
+    def test_ignores_empty_substitutions(self, tmp_path: Path):
+        csv_file = tmp_path / "sample.csv"
+        csv_file.write_bytes(b"content\n")
+
+        with patch(
+            "clone.tasks.business_logic.fix_corrupted_utf8.cmd_run"
+        ) as mock_cmd_run:
+            fix_corrupted_utf8_file(
+                file_path=csv_file,
+                sed_substitutions=["", "  "],
+            )
+
+        mock_cmd_run.assert_not_called()
+
+
+class TestCloneConfigValidation:
+
+    def test_allows_empty_substitutions(self):
+        config = CloneConfig(
+            dry_run=False,
+            table_kind="my_table",
+            data_endpoint="https://example.org/data.csv",  # type: ignore
+            run_timestamp="20220305120000",
+            fix_corrupted_utf8_sed_substitutions=[],
+        )
+        assert config.fix_corrupted_utf8_sed_substitutions == []
+
+    def test_validates_each_substitution(self):
+        config = CloneConfig(
+            dry_run=False,
+            table_kind="my_table",
+            data_endpoint="https://example.org/data.csv",  # type: ignore
+            run_timestamp="20220305120000",
+            fix_corrupted_utf8_sed_substitutions=[
+                r"s/entr\xef\xbf\xbd\xa9e/entrée/g",
+                r"s/foo/bar/",
+            ],
+        )
+        assert len(config.fix_corrupted_utf8_sed_substitutions) == 2
+
+    def test_rejects_unsafe_substitution(self):
+        with pytest.raises(ValidationError):
+            CloneConfig(
+                dry_run=False,
+                table_kind="my_table",
+                data_endpoint="https://example.org/data.csv",  # type: ignore
+                run_timestamp="20220305120000",
+                fix_corrupted_utf8_sed_substitutions=["s/a/b/; rm -rf /"],
+            )


### PR DESCRIPTION
# Description succincte du problème résolu

Bug du aux datasets de la BAN

Cela fait 2 fois que le clonage de la BAN ne passe pas car un caractère UTF-8 traine dans le jeu de donnée
du coup je permets d'exécuter une commande `sed` de correction appliqué au jeu de donnée

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: Airflow - clone BAN

**💡 quoi**: permettre de faire un sed pour remplacer les caatère mal encodé

**🎯 pourquoi**: Parce quele jeu de données n'est pas très stable

**🤔 comment**: 

- On configure uniquement le remplacemet car c'est plus simple à sécuriser, ne pas permettre n'importe quelle commande

**🤓 comment tester**: 

Lancer le clone des adresses avec le sed donné en exemple


## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)
