### PR TITLE
accessibilité : niveau de titre h4 pour les sections de la fiche acteur (RGAA 9.1)

### DIFF
--- a/webapp/e2e_tests/a11y_rgaa.spec.ts
+++ b/webapp/e2e_tests/a11y_rgaa.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "@playwright/test"
+import { navigateTo } from "./helpers"
+
+/**
+ * E2E tests for the RGAA audit fixes (contre-audit accessibilité, carte).
+ * Each describe block maps to one Notion "Suivi des tâches" card.
+ */
+test.describe("♿ RGAA", () => {
+  test.describe("[Carte] 9.1 — Niveau de titre des sections de la fiche acteur", () => {
+    test("Les titres « Adresse » et « Services disponibles » sont des <h4>", async ({
+      page,
+    }) => {
+      await navigateTo(
+        page,
+        "/lookbook/preview/accessibilite/A11Y_14_acteur_section_heading_level/",
+      )
+      const headings = page.locator("h4")
+      await expect(headings.filter({ hasText: "Adresse" })).toBeAttached()
+      await expect(headings.filter({ hasText: "Services disponibles" })).toBeAttached()
+      await expect(page.locator("h3", { hasText: "Adresse" })).toHaveCount(0)
+    })
+  })
+})

--- a/webapp/previews/template_preview.py
+++ b/webapp/previews/template_preview.py
@@ -1198,6 +1198,23 @@ class AccessibilitePreview(LookbookPreview):
             "ui/components/accessibilite/liens_explicites_demo.html",
         )
 
+    def A11Y_14_acteur_section_heading_level(self, **kwargs):
+        """RGAA 9.1 — niveau de titre cohérent dans la fiche acteur.
+
+        Le titre de la fiche acteur (`object.libelle`) est rendu en
+        `<h3>` en contexte Turbo (panneau de détail). Les titres de
+        section (« Adresse », « Services disponibles », etc.) étaient
+        eux aussi en `<h3>`, cassant la hiérarchie de titres. Ils
+        passent en `<h4>`.
+        """
+        acteur = DisplayedActeur.objects.first()
+        context = {"object": acteur}
+        return render_to_string(
+            "ui/components/acteur/tabs/sections/adresse.html", context
+        ) + render_to_string(
+            "ui/components/acteur/tabs/sections/services_disponibles.html", context
+        )
+
 
 class TestsPreview(LookbookPreview):
     """

--- a/webapp/templates/ui/components/acteur/tabs/_section.html
+++ b/webapp/templates/ui/components/acteur/tabs/_section.html
@@ -1,8 +1,8 @@
 <div {% block wrapper_attrs %}{% endblock %}>
-    <h3 class="qf-text-base qf-mb-1w {% block title_classes %}{% endblock %}">
+    <h4 class="qf-text-base qf-mb-1w {% block title_classes %}{% endblock %}">
         {% block title %}
         {% endblock title %}
-    </h3>
+    </h4>
 
     <div class="qf-text-sm qf-space-y-1w">
         {% block content %}


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [\[Carte\] - 9.1 - L'information est-elle structurée par l'utilisation appropriée de titres ?](https://app.notion.com/p/3986523d57d780edb75eff0efd46986c)

**N'oublier pas de taguer** : `accessibility`

**🗺️ contexte**: Audit RGAA de la carte interactive — critère 9.1 (structuration par titres).

**💡 quoi**: Les titres de section de la fiche acteur (« Adresse », « Services disponibles », « Horaires », etc.) sont en `<h4>` au lieu de `<h3>`.

**🎯 pourquoi**: Le titre de la fiche acteur (`object.libelle`) est rendu en `<h3>` en contexte Turbo (panneau de détail sur la carte). Les titres de section, également en `<h3>`, se retrouvaient donc au même niveau que le titre de la fiche elle-même, cassant la hiérarchie de titres attendue par les technologies d'assistance.

**🤔 comment**:
- `_section.html` (template de base commun à toutes les sections de la fiche acteur) : `<h3>` → `<h4>`
- Ajout d'une preview Lookbook `A11Y_14_acteur_section_heading_level` démontrant le rendu des sections « Adresse » et « Services disponibles »
- Ajout d'un test e2e vérifiant que ces titres sont bien des `<h4>`

**🤓 comment tester**:
```bash
cd webapp && npx playwright test --reporter=list ./e2e_tests/a11y_rgaa.spec.ts
```
Ou visuellement : `/lookbook/preview/accessibilite/A11Y_14_acteur_section_heading_level/`

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] Vérifier qu'aucun sélecteur CSS ne cible spécifiquement `h3` dans ce contexte (vérifié en amont, rien trouvé)

## 📆 A faire (prochaine PR)

- [ ] Aucun
