### PR TITLE
accessibilité : légende et en-têtes du tableau mode liste (RGAA 5.4, 5.6)

### DIFF
--- a/webapp/core/templatetags/carte_tags.py
+++ b/webapp/core/templatetags/carte_tags.py
@@ -275,7 +275,8 @@ def acteurs_table(context, acteurs):
     As it must be rendered with a dict, we cannot easily render complex rows."""
     return {
         "table": {
-            "header": ["Nom du lieu", "Actions", "Distance", ""],
+            "caption": "Liste des lieux et solutions correspondant à votre recherche",
+            "header": ["Nom du lieu", "Actions", "Distance", "Fiche"],
             "content": [render_acteur_table_row(acteur, context) for acteur in acteurs],
             "extra_classes": "fr-table--mode-liste fr-table--multiline qf-w-full",
         }

--- a/webapp/e2e_tests/a11y_rgaa.spec.ts
+++ b/webapp/e2e_tests/a11y_rgaa.spec.ts
@@ -20,4 +20,26 @@ test.describe("♿ RGAA", () => {
       await expect(page.locator("h3", { hasText: "Adresse" })).toHaveCount(0)
     })
   })
+  test.describe("[Carte] 5.4 / 5.6 — Titre et en-têtes du tableau mode liste", () => {
+    test("Le tableau a une légende (<caption>) non vide", async ({ page }) => {
+      await navigateTo(
+        page,
+        "/lookbook/preview/accessibilite/A11Y_15_mode_liste_table_caption_et_entetes/",
+      )
+      const caption = page.locator("table caption")
+      await expect(caption).toBeAttached()
+      await expect(caption).not.toHaveText("")
+    })
+
+    test("La colonne « Voir la fiche » a un en-tête non vide", async ({ page }) => {
+      await navigateTo(
+        page,
+        "/lookbook/preview/accessibilite/A11Y_15_mode_liste_table_caption_et_entetes/",
+      )
+      const headers = page.locator("table thead th")
+      await expect(headers).toHaveCount(4)
+      const lastHeader = headers.last()
+      await expect(lastHeader).not.toHaveText("")
+    })
+  })
 })

--- a/webapp/previews/template_preview.py
+++ b/webapp/previews/template_preview.py
@@ -1214,6 +1214,30 @@ class AccessibilitePreview(LookbookPreview):
         ) + render_to_string(
             "ui/components/acteur/tabs/sections/services_disponibles.html", context
         )
+    def A11Y_15_mode_liste_table_caption_et_entetes(self, **kwargs):
+        """RGAA 5.4 / 5.6 — titre et en-têtes du tableau mode liste.
+
+        Le tableau des résultats en mode liste avait une balise
+        `<caption>` vide et un en-tête de colonne vide pour la colonne
+        « Voir la fiche ». Le tag `acteurs_table` (carte_tags.py)
+        fournit désormais un `caption` pertinent et un intitulé
+        « Fiche » pour cette colonne.
+        """
+        acteurs = DisplayedActeur.objects.all()[:2]
+        request = RequestFactory().get("/")
+        context = Context(
+            {
+                "acteurs": acteurs,
+                "map_container_id": DEFAULT_MAP_CONTAINER_ID,
+                "forms": {"legende": LegendeForm(), "filtres_form": None},
+                "request": request,
+            }
+        )
+        template = Template("""
+            {% load carte_tags %}
+            {% acteurs_table acteurs %}
+            """)
+        return template.render(context)
 
 
 class TestsPreview(LookbookPreview):


### PR DESCRIPTION
# Description succincte du problème résolu

Cartes Notion :
- [\[Carte\] - 5.4 - Titre du tableau correctement associé](https://app.notion.com/p/3986523d57d780278fc2ec11c855760e)
- [\[Carte\] - 5.6 - En-têtes de colonnes/lignes des tableaux correctement déclarés](https://app.notion.com/p/3986523d57d7808d82eacfe1e678fb19)

**N'oublier pas de taguer** : `accessibility`

**🗺️ contexte**: Audit RGAA de la carte interactive — critères 5.4 (titre de tableau) et 5.6 (en-têtes de colonnes/lignes).

**💡 quoi**: Le tableau des résultats en mode liste avait une balise `<caption>` vide et un en-tête de colonne vide pour la colonne « Voir la fiche ».

**🎯 pourquoi**: Le composant `dsfr_table` de django-dsfr rend systématiquement `<caption>{{ self.caption }}</caption>` et un `<th scope="col">` par colonne déclarée. Le tag `acteurs_table` (`carte_tags.py`) ne fournissait ni `caption`, ni de texte pour le dernier en-tête, résultant en une légende vide et une colonne d'action sans intitulé pour les technologies d'assistance.

**🤔 comment**:
- `core/templatetags/carte_tags.py` : ajout d'une `caption` pertinente et remplacement de l'en-tête vide de la 4ᵉ colonne par « Fiche »
- Ajout d'une preview Lookbook `A11Y_15_mode_liste_table_caption_et_entetes` rendant directement le tag `acteurs_table`
- Ajout de deux tests e2e vérifiant la présence d'une légende non vide et d'un en-tête non vide sur la dernière colonne

**🤓 comment tester**:
```bash
cd webapp && npx playwright test --reporter=list ./e2e_tests/a11y_rgaa.spec.ts
```
Ou visuellement : `/lookbook/preview/accessibilite/A11Y_15_mode_liste_table_caption_et_entetes/`

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] Aucun

## 📆 A faire (prochaine PR)

- [ ] Aucun
