### PR TITLE
accessibilité : correction du lien d'évitement sur Firefox (RGAA 12.7)

### DIFF
--- a/webapp/e2e_tests/a11y_rgaa.spec.ts
+++ b/webapp/e2e_tests/a11y_rgaa.spec.ts
@@ -42,4 +42,26 @@ test.describe("♿ RGAA", () => {
       await expect(lastHeader).not.toHaveText("")
     })
   })
+  test.describe("[Site Que faire] 12.7 — Lien d'évitement fonctionnel (bug Firefox)", () => {
+    for (const path of ["/", "/carte"]) {
+      test(`Le <main id="content"> de ${path} porte tabindex="-1"`, async ({
+        page,
+      }) => {
+        await navigateTo(page, path)
+        const main = page.locator("main#content")
+        await expect(main).toHaveAttribute("tabindex", "-1")
+      })
+    }
+
+    test('Le <nav id="fr-navigation"> porte tabindex="-1" quand il est rendu', async ({
+      page,
+    }) => {
+      await navigateTo(page, "/")
+      const nav = page.locator("nav#fr-navigation")
+      const count = await nav.count()
+      if (count > 0) {
+        await expect(nav).toHaveAttribute("tabindex", "-1")
+      }
+    })
+  })
 })

--- a/webapp/previews/template_preview.py
+++ b/webapp/previews/template_preview.py
@@ -1139,6 +1139,11 @@ class AccessibilitePreview(LookbookPreview):
         infotri). Le `<main>` du layout porte `id="content"` et
         `role="main"`, ce qui correspond à la cible définie dans le
         context processor global.
+
+        `tabindex="-1"` a été ajouté sur `<main id="content">` (et sur
+        `<nav id="fr-navigation">` dans `header_menu.html`) : un bug
+        connu de Firefox empêche le focus de se déplacer via un lien
+        d'ancrage si la cible n'est pas programmatiquement focusable.
         """
         return render_to_string(
             "ui/components/accessibilite/skip_link_demo.html",

--- a/webapp/templates/ui/components/accessibilite/skip_link_demo.html
+++ b/webapp/templates/ui/components/accessibilite/skip_link_demo.html
@@ -10,7 +10,7 @@
 
     {% dsfr_skiplinks skiplinks %}
 
-    <main id="content" role="main" class="fr-mt-3w">
+    <main id="content" role="main" tabindex="-1" class="fr-mt-3w">
         <p>
             Pour visualiser le lien, faites <kbd>Tab</kbd> depuis cette zone
             d'aperçu. Il devient visible uniquement au focus, conformément

--- a/webapp/templates/ui/components/header/header_menu.html
+++ b/webapp/templates/ui/components/header/header_menu.html
@@ -13,6 +13,7 @@
         <nav role="navigation"
              class="fr-nav"
              id="fr-navigation"
+             tabindex="-1"
              aria-label="{{ main_menu_label }}">
           <ul class="fr-nav__list">
             {% for item in menu_items %}

--- a/webapp/templates/ui/layout/assistant.html
+++ b/webapp/templates/ui/layout/assistant.html
@@ -99,7 +99,7 @@ parsing, which raises VariableDoesNotExist when seo is not in context (e.g., err
         {% endif %}
 
 
-        <main id="content" class="{% if not iframe %}qf-pb-7w{% else %}[@media(min-height:600px)]:qf-pb-2w qf-pb-3w{% endif %}" role="main">
+        <main id="content" class="{% if not iframe %}qf-pb-7w{% else %}[@media(min-height:600px)]:qf-pb-2w qf-pb-3w{% endif %}" role="main" tabindex="-1">
             {% block main %}
             {% endblock main %}
         </main>

--- a/webapp/templates/ui/layout/base.html
+++ b/webapp/templates/ui/layout/base.html
@@ -53,7 +53,7 @@
         {# Skip link for accessibility - using DSFR component (RGAA 12.7) #}
         {% dsfr_skiplinks skiplinks %}
 
-        <main id="content" class="qf-h-full qf-overflow-y-auto qf-overflow-x-hidden" role="main">
+        <main id="content" class="qf-h-full qf-overflow-y-auto qf-overflow-x-hidden" role="main" tabindex="-1">
             <noscript>
                 <div class="fr-container fr-my-3w">
                     <div class="fr-alert fr-alert--error">


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [\[Site Que faire\] - 12.7 - Dans chaque page web, un lien d'évitement ou d'accès rapide à la zone de contenu principal est-il présent (hors cas particuliers) ?](https://app.notion.com/p/3986523d57d7800baac9d41db4bdd2c1)

**N'oublier pas de taguer** : `accessibility`, `bug`

**🗺️ contexte**: Audit RGAA — critère 12.7 (lien d'évitement).

**💡 quoi**: Le lien d'évitement DSFR (« Aller au contenu ») ne fonctionne pas sur Firefox : cliquer dessus ne déplace pas le focus vers le contenu principal.

**🎯 pourquoi**: Il s'agit d'un bug connu de Firefox : la navigation par ancre (`#content`) ne déplace le focus que si l'élément cible est programmatiquement focusable. Sans `tabindex="-1"`, Firefox change l'URL mais ne déplace pas le focus, contrairement à Chrome/Safari.

**🤔 comment**:
- `tabindex="-1"` ajouté sur `<main id="content">` dans les deux layouts du projet (`ui/layout/base.html` pour la carte/configurateur/infotri, `ui/layout/assistant.html` pour les pages de contenu/Wagtail)
- `tabindex="-1"` ajouté sur `<nav id="fr-navigation">` (`ui/components/header/header_menu.html`)
- Mise à jour de la preview Lookbook `A11Y_2_skip_link` existante pour refléter le correctif
- Ajout de tests e2e vérifiant l'attribut sur les deux layouts

**🤓 comment tester**:
```bash
cd webapp && npx playwright test --reporter=list ./e2e_tests/a11y_rgaa.spec.ts
```
Manuellement sur Firefox : charger `/` ou `/carte`, appuyer sur Tab puis Entrée sur le lien d'évitement, vérifier que le focus se déplace bien sur la zone de contenu.

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] Aucun

## 📆 A faire (prochaine PR)

- [ ] Aucun
