### PR TITLE
accessibilité : titre de page pertinent pour la carte interactive (RGAA 8.6)

### DIFF
--- a/webapp/e2e_tests/a11y_rgaa.spec.ts
+++ b/webapp/e2e_tests/a11y_rgaa.spec.ts
@@ -64,4 +64,12 @@ test.describe("♿ RGAA", () => {
       }
     })
   })
+  test.describe("[Carte] 8.6 — Titre de page pertinent", () => {
+    test("La page carte a un titre mentionnant « carte interactive »", async ({
+      page,
+    }) => {
+      await navigateTo(page, "/carte")
+      await expect(page).toHaveTitle(/carte interactive/i)
+    })
+  })
 })

--- a/webapp/templates/ui/pages/carte.html
+++ b/webapp/templates/ui/pages/carte.html
@@ -1,6 +1,8 @@
 {% extends base_template %}
 {% load static turbo_tags %}
 
+{% block page_title %}Carte interactive - Que faire de mes objets et déchets{% endblock %}
+
 {% block body_classes %}qf-h-screen{% endblock %}
 
 {% block content %}


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [\[Carte\] - 8.6 - Pour chaque page web ayant un titre de page, ce titre est-il pertinent ?](https://app.notion.com/p/3986523d57d780d996e1efe289194a71)

**N'oublier pas de taguer** : `accessibility`

**🗺️ contexte**: Audit RGAA de la carte interactive — critère 8.6 (pertinence du titre de page).

**💡 quoi**: Le titre de la page carte n'indique pas qu'il s'agit d'une carte interactive.

**🎯 pourquoi**: La page `ui/pages/carte.html` n'avait pas de bloc `page_title`, elle héritait donc du titre générique du layout (« Que faire de mes objets et déchets »), identique à celui de nombreuses autres pages du site. Un titre distinct aide les utilisateurs de lecteurs d'écran (et tout le monde) à distinguer les onglets/favoris.

**🤔 comment**:
- Ajout d'un bloc `{% block page_title %}Carte interactive - Que faire de mes objets et déchets{% endblock %}` dans `ui/pages/carte.html`
- Ajout d'un test e2e vérifiant le titre de la page

**🤓 comment tester**:
```bash
cd webapp && npx playwright test --reporter=list ./e2e_tests/a11y_rgaa.spec.ts
```
Ou visuellement : ouvrir `/carte` et vérifier le titre de l'onglet du navigateur.

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] Aucun

## 📆 A faire (prochaine PR)

- [ ] Aucun
