### PR TITLE
accessibilité : title du lien info-tri cohérent avec son intitulé (RGAA 6.1)

### DIFF
--- a/webapp/e2e_tests/a11y_rgaa.spec.ts
+++ b/webapp/e2e_tests/a11y_rgaa.spec.ts
@@ -72,4 +72,14 @@ test.describe("♿ RGAA", () => {
       await expect(page).toHaveTitle(/carte interactive/i)
     })
   })
+  test.describe("[Site Que faire] 6.1 — Lien info-tri explicite", () => {
+    test("Le title du lien info-tri reprend son intitulé visible", async ({ page }) => {
+      await navigateTo(page, "/lookbook/preview/pages/produit/")
+      const link = page.getByTestId("infotri-link")
+      await expect(link).toBeVisible()
+      const text = (await link.textContent())?.trim()
+      const title = await link.getAttribute("title")
+      expect(title).toBe(`${text} - Nouvelle fenêtre`)
+    })
+  })
 })

--- a/webapp/templates/ui/components/produit/_infotri.html
+++ b/webapp/templates/ui/components/produit/_infotri.html
@@ -11,7 +11,7 @@
         </div>
 
         <p class="qf-m-0 qf-ml-auto">
-            <a href="{{ ASSISTANT.infotri.lien }}" class="fr-link" rel="noopener external" target="_blank" title="Lien vers les infotris - Nouvelle fenêtre" data-testid="infotri-link">{{ ASSISTANT.infotri.texte_du_lien }}</a>
+            <a href="{{ ASSISTANT.infotri.lien }}" class="fr-link" rel="noopener external" target="_blank" title="{{ ASSISTANT.infotri.texte_du_lien }} - Nouvelle fenêtre" data-testid="infotri-link">{{ ASSISTANT.infotri.texte_du_lien }}</a>
         </p>
     </div>
 {% endif %}


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [\[Site Que faire\] - 6.1 - Chaque lien est-il explicite (hors cas particuliers) ?](https://app.notion.com/p/3986523d57d78015a43edc5c15c53a21)

**N'oublier pas de taguer** : `accessibility`

**🗺️ contexte**: Audit RGAA — critère 6.1 (liens explicites). Sous-partie liée aux pages fiche famille (Vêtements) et ancienne fiche (Téléphone mobile).

**💡 quoi**: L'attribut `title` du lien info-tri ne reprend pas l'intitulé visible du lien.

**🎯 pourquoi**: `title="Lien vers les infotris - Nouvelle fenêtre"` était codé en dur alors que le texte visible du lien (`ASSISTANT.infotri.texte_du_lien`, actuellement « En savoir plus sur l'Info-tri ») est configurable. Un `title` qui ne reprend pas l'intitulé visible peut désorienter les utilisateurs de lecteurs d'écran ou de commande vocale.

**🤔 comment**:
- `ui/components/produit/_infotri.html` : le `title` reprend désormais dynamiquement `{{ ASSISTANT.infotri.texte_du_lien }}` suivi de « - Nouvelle fenêtre », au lieu d'un texte fixe
- Ce composant est inclus par `heading.html` et `pages/produit.html`, donc le correctif s'applique à toutes les pages produit (dont Vêtements) sans changement supplémentaire
- Ajout d'un test e2e vérifiant que le `title` correspond exactement au texte visible + suffixe

**🤓 comment tester**:
```bash
cd webapp && npx playwright test --reporter=list ./e2e_tests/a11y_rgaa.spec.ts
```
Ou visuellement : `/lookbook/preview/pages/produit/`, inspecter le lien info-tri (`data-testid="infotri-link"`).

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] Aucun

## 📆 A faire (prochaine PR)

- [ ] Aucun
