### PR TITLE
accessibilité : cohérence des liens explicites sur la carte (RGAA 6.1)

### DIFF
--- a/webapp/core/templatetags/share_tags.py
+++ b/webapp/core/templatetags/share_tags.py
@@ -41,20 +41,20 @@ def get_sharer_content(request, object, social_network=None):
     template = {
         "url": url,
         "facebook": {
-            "title": f"partager {object} sur Facebook - nouvelle fenêtre",
+            "title": f"Partager sur Facebook {object} - nouvelle fenêtre",
             "url": f"https://www.facebook.com/sharer.php?u={quoted_url}",
         },
         "twitter": {
-            "title": f"partager {object} sur X - nouvelle fenêtre",
+            "title": f"Partager sur X {object} - nouvelle fenêtre",
             "url": f"https://twitter.com/intent/tweet?url={quoted_url}"
             f"&text={share_intro}&via=Longue+vie+aux+objets&hashtags=longuevieauxobjets,ademe",
         },
         "linkedin": {
-            "title": f"partager {object} sur LinkedIn - nouvelle fenêtre",
+            "title": f"Partager sur LinkedIn {object} - nouvelle fenêtre",
             "url": f"https://www.linkedin.com/shareArticle?url={quoted_url}&title={share_intro}",
         },
         "email": {
-            "title": f"partager {object} par email - nouvelle fenêtre",
+            "title": f"Partager par email {object} - nouvelle fenêtre",
             "url": f"mailto:?subject={quote(share_intro)}&body={quote(share_body)}",
         },
     }

--- a/webapp/e2e_tests/a11y_rgaa.spec.ts
+++ b/webapp/e2e_tests/a11y_rgaa.spec.ts
@@ -82,4 +82,19 @@ test.describe("♿ RGAA", () => {
       expect(title).toBe(`${text} - Nouvelle fenêtre`)
     })
   })
+  test.describe("[Carte] 6.1 — Liens explicites (ajouter un lieu)", () => {
+    test('Le bouton "ajouter un lieu" a un aria-label cohérent avec son texte visible', async ({
+      page,
+    }) => {
+      await navigateTo(page, "/lookbook/preview/carte/ajouter_un_lieu/")
+      const link = page.locator("a").first()
+      const text = (await link.textContent())?.trim()
+      const ariaLabel = await link.getAttribute("aria-label")
+      expect(ariaLabel).toBe(`${text} - Nouvelle fenêtre`)
+    })
+    // Le title des liens de partage (Facebook, X, LinkedIn, email) est
+    // couvert par integration_tests/core/test_sharer.py, la preview
+    // Lookbook du tooltip de partage n'ayant pas de request.resolver_match
+    // pour générer le sharer réel.
+  })
 })

--- a/webapp/integration_tests/core/test_sharer.py
+++ b/webapp/integration_tests/core/test_sharer.py
@@ -23,19 +23,19 @@ class TestSharer:
         assert sharer == {
             "url": "http://testserver/dechet/nom-du-synonyme/",
             "facebook": {
-                "title": "partager Nom du synonyme sur Facebook - nouvelle fenêtre",
+                "title": "Partager sur Facebook Nom du synonyme - nouvelle fenêtre",
                 "url": "https://www.facebook.com/sharer.php?u=http%3A%2F%2Ftestserver%2Fdechet%2Fnom-du-synonyme%2F",
             },
             "twitter": {
-                "title": "partager Nom du synonyme sur X - nouvelle fenêtre",
+                "title": "Partager sur X Nom du synonyme - nouvelle fenêtre",
                 "url": "https://twitter.com/intent/tweet?url=http%3A%2F%2Ftestserver%2Fdechet%2Fnom-du-synonyme%2F&text=Découvrez le site de l'ADEME “Que faire de mes objets & déchets”&via=Longue+vie+aux+objets&hashtags=longuevieauxobjets,ademe",
             },
             "linkedin": {
-                "title": "partager Nom du synonyme sur LinkedIn - nouvelle fenêtre",
+                "title": "Partager sur LinkedIn Nom du synonyme - nouvelle fenêtre",
                 "url": "https://www.linkedin.com/shareArticle?url=http%3A%2F%2Ftestserver%2Fdechet%2Fnom-du-synonyme%2F&title=Découvrez le site de l'ADEME “Que faire de mes objets & déchets”",
             },
             "email": {
-                "title": "partager Nom du synonyme par email - nouvelle fenêtre",
+                "title": "Partager par email Nom du synonyme - nouvelle fenêtre",
                 "url": "mailto:?subject=D%C3%A9couvrez%20le%20site%20de%20l%27ADEME%20%E2%80%9CQue%20faire%20de%20mes%20objets%20%26%20d%C3%A9chets%E2%80%9D&body=Bonjour%2C%0A%20Vous%20souhaitez%20encourager%20au%20tri%20et%20la%20consommation%20responsable%2C%20le%20site%20de%20l%E2%80%99ADEME%20Que%20faire%20de%20mes%20objets%20%26%20d%C3%A9chets%20accompagne%20les%20citoyens%20gr%C3%A2ce%20%C3%A0%20des%20bonnes%20pratiques%20et%20adresses%20pr%C3%A8s%20de%20chez%20eux%2C%20pour%20%C3%A9viter%20l%27achat%20neuf%20et%20r%C3%A9duire%20les%20d%C3%A9chets.%0AD%C3%A9couvrez%20le%20ici%20%3A%20http%3A//testserver/dechet/nom-du-synonyme/",
             },
         }
@@ -50,19 +50,19 @@ class TestSharer:
         assert sharer == {
             "url": "http://testserver/adresse_details/un-coucou-unique",
             "facebook": {
-                "title": "partager Coucou sur Facebook - nouvelle fenêtre",
+                "title": "Partager sur Facebook Coucou - nouvelle fenêtre",
                 "url": "https://www.facebook.com/sharer.php?u=http%3A%2F%2Ftestserver%2Fadresse_details%2Fun-coucou-unique",
             },
             "twitter": {
-                "title": "partager Coucou sur X - nouvelle fenêtre",
+                "title": "Partager sur X Coucou - nouvelle fenêtre",
                 "url": "https://twitter.com/intent/tweet?url=http%3A%2F%2Ftestserver%2Fadresse_details%2Fun-coucou-unique&text=Découvrez le site de l'ADEME “Que faire de mes objets & déchets”&via=Longue+vie+aux+objets&hashtags=longuevieauxobjets,ademe",
             },
             "linkedin": {
-                "title": "partager Coucou sur LinkedIn - nouvelle fenêtre",
+                "title": "Partager sur LinkedIn Coucou - nouvelle fenêtre",
                 "url": "https://www.linkedin.com/shareArticle?url=http%3A%2F%2Ftestserver%2Fadresse_details%2Fun-coucou-unique&title=Découvrez le site de l'ADEME “Que faire de mes objets & déchets”",
             },
             "email": {
-                "title": "partager Coucou par email - nouvelle fenêtre",
+                "title": "Partager par email Coucou - nouvelle fenêtre",
                 "url": "mailto:?subject=D%C3%A9couvrez%20le%20site%20de%20l%27ADEME%20%E2%80%9CQue%20faire%20de%20mes%20objets%20%26%20d%C3%A9chets%E2%80%9D&body=Bonjour%2C%0A%20Vous%20souhaitez%20encourager%20au%20tri%20et%20la%20consommation%20responsable%2C%20le%20site%20de%20l%E2%80%99ADEME%20Que%20faire%20de%20mes%20objets%20%26%20d%C3%A9chets%20accompagne%20les%20citoyens%20gr%C3%A2ce%20%C3%A0%20des%20bonnes%20pratiques%20et%20adresses%20pr%C3%A8s%20de%20chez%20eux%2C%20pour%20%C3%A9viter%20l%27achat%20neuf%20et%20r%C3%A9duire%20les%20d%C3%A9chets.%0AD%C3%A9couvrez%20le%20ici%20%3A%20http%3A//testserver/adresse_details/un-coucou-unique",
             },
         }

--- a/webapp/templates/ui/components/carte/buttons/ajouter_un_lieu.html
+++ b/webapp/templates/ui/components/carte/buttons/ajouter_un_lieu.html
@@ -7,7 +7,7 @@
     href="{% url 'qfdmo:address-suggestion-form' %}"
     target="_blank"
     rel="noreferrer"
-    aria-label="Proposer une adresse - Nouvelle fenêtre"
+    aria-label="{{ CARTE.ajouter_un_lieu }} - Nouvelle fenêtre"
 >
     {{ CARTE.ajouter_un_lieu }}
 </a>

--- a/webapp/templates/ui/components/carte/buttons/ajouter_un_lieu_mode_liste.html
+++ b/webapp/templates/ui/components/carte/buttons/ajouter_un_lieu_mode_liste.html
@@ -3,7 +3,7 @@
     href="{% url 'qfdmo:address-suggestion-form' %}"
     target="_blank"
     rel="noreferrer"
-    aria-label="Proposer une adresse - Nouvelle fenêtre"
+    aria-label="{{ CARTE.ajouter_un_lieu_mode_liste }} - Nouvelle fenêtre"
 >
   {{ CARTE.ajouter_un_lieu_mode_liste }}
 </a>


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [\[Carte\] - 6.1 - Chaque lien est-il explicite (hors cas particuliers) ?](https://app.notion.com/p/3986523d57d7806abbabd7c9dc8ab3b1)

**N'oublier pas de taguer** : `accessibility`

**🗺️ contexte**: Audit RGAA de la carte interactive — critère 6.1 (liens explicites).

**💡 quoi**: Deux incohérences entre le nom accessible et le texte visible des liens :
1. Les boutons « Ajouter un nouveau lieu » (mode carte et mode liste) ont un `aria-label` qui ne reprend pas leur intitulé visible.
2. Les `title` des liens de partage (mode liste) suivent l'ordre « partager {nom} sur {plateforme} » au lieu de reprendre l'intitulé accessible attendu « Partager sur {plateforme} {nom} ».

**🎯 pourquoi**: Un `aria-label`/`title` qui ne correspond pas au texte visible désoriente les utilisateurs de lecteurs d'écran ou de commande vocale, qui s'attendent à ce que le nom annoncé corresponde à ce qu'ils voient/prononcent.

**🤔 comment**:
- `ui/components/carte/buttons/ajouter_un_lieu.html` et `ajouter_un_lieu_mode_liste.html` : `aria-label` reprend désormais dynamiquement `{{ CARTE.ajouter_un_lieu }}` / `{{ CARTE.ajouter_un_lieu_mode_liste }}` au lieu du texte fixe « Proposer une adresse »
- `core/templatetags/share_tags.py` : les `title` des liens Facebook/X/LinkedIn/email suivent désormais « Partager sur {plateforme} {nom} »
- Mise à jour des assertions de `integration_tests/core/test_sharer.py` pour refléter le nouvel ordre
- Ajout d'un test e2e pour le bouton « ajouter un lieu »

**🤓 comment tester**:
```bash
cd webapp && npx playwright test --reporter=list ./e2e_tests/a11y_rgaa.spec.ts
cd webapp && uv run pytest ./integration_tests/core/test_sharer.py
```
Ou visuellement : `/lookbook/preview/carte/ajouter_un_lieu/` et `/lookbook/preview/carte/ajouter_un_lieu_mode_liste/`.

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] Aucun

## 📆 A faire (prochaine PR)

- [ ] Aucun
