### PR TITLE
accessibilité : balise sémantique pour la date de mise à jour (RGAA 8.9)

### DIFF
--- a/webapp/e2e_tests/a11y_rgaa.spec.ts
+++ b/webapp/e2e_tests/a11y_rgaa.spec.ts
@@ -97,4 +97,13 @@ test.describe("♿ RGAA", () => {
     // Lookbook du tooltip de partage n'ayant pas de request.resolver_match
     // pour générer le sharer réel.
   })
+  test.describe("[Carte] 8.9 — Balise sémantique pour la date de mise à jour", () => {
+    test("La date de mise à jour de la fiche acteur est dans une balise <p>", async ({
+      page,
+    }) => {
+      await navigateTo(page, "/lookbook/preview/pages/acteur/")
+      const updatedDate = page.locator("p", { hasText: "Mis à jour le" })
+      await expect(updatedDate).toBeVisible()
+    })
+  })
 })

--- a/webapp/templates/ui/components/acteur/tabs/sections/meta.html
+++ b/webapp/templates/ui/components/acteur/tabs/sections/meta.html
@@ -16,9 +16,9 @@
             </span>
         {% endif %}
 
-        <span>
+        <p class="qf-m-0">
             Mis à jour le {{ object.modifie_le_display }}
-        </span>
+        </p>
     </div>
 
     <a class="fr-my-1w fr-btn fr-btn--tertiary qf-whitespace-nowrap qf-w-full qf-justify-center"


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [\[Carte\] - 8.9 - Dans chaque page web, les balises ne doivent pas être utilisées uniquement à des fins de présentation. Cette règle est-elle respectée ?](https://app.notion.com/p/3986523d57d78060b7a3ec9b8b7d885a)

**N'oublier pas de taguer** : `accessibility`

**🗺️ contexte**: Audit RGAA de la carte interactive — critère 8.9 (balises non utilisées uniquement à des fins de présentation).

**💡 quoi**: La date de mise à jour de la fiche acteur (« Mis à jour le JJ/MM/AAAA ») est dans une balise `<span>` plutôt qu'une balise sémantique adaptée.

**🎯 pourquoi**: Un `<span>` n'a pas de sens sémantique propre (il ne fait qu'appliquer un style) alors qu'il s'agit ici d'un contenu textuel autonome, qui devrait être dans un `<p>`.

**🤔 comment**:
- `ui/components/acteur/tabs/sections/meta.html` : `<span>` → `<p class="qf-m-0">` (la classe `qf-m-0` neutralise la marge par défaut du navigateur sur `<p>` pour ne pas modifier le rendu visuel)
- Ajout d'un test e2e vérifiant la présence de la date dans un `<p>`

**🤓 comment tester**:
```bash
cd webapp && npx playwright test --reporter=list ./e2e_tests/a11y_rgaa.spec.ts
```
Ou visuellement : `/lookbook/preview/pages/acteur/`, section « Mis à jour le... » en bas de l'encart.

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] Aucun

## 📆 A faire (prochaine PR)

- [ ] Aucun
