### PR TITLE
accessibilité : nettoyage des attributs restants du tooltip de partage (RGAA 7.2, 12.8, 12.11)

### DIFF
--- a/webapp/e2e_tests/a11y_rgaa.spec.ts
+++ b/webapp/e2e_tests/a11y_rgaa.spec.ts
@@ -20,6 +20,24 @@ test.describe("♿ RGAA", () => {
       await expect(page.locator("h3", { hasText: "Adresse" })).toHaveCount(0)
     })
   })
+  test.describe("[Carte] 7.2 / 12.8 / 12.11 — Tooltip de partage nettoyé", () => {
+    test('Le tooltip de partage n\'a pas de tabindex positif, ni role="toolbar", ni aria-describedby', async ({
+      page,
+    }) => {
+      await navigateTo(
+        page,
+        "/lookbook/preview/accessibilite/share_tooltip_acteur_sans_tabindex/",
+      )
+      const shareButton = page.locator('button:has(span:text("partager"))')
+      await expect(shareButton).not.toHaveAttribute("aria-describedby", /.+/)
+
+      const tooltip = page.locator(".fr-tooltip")
+      await expect(tooltip).not.toHaveAttribute("tabindex", "1")
+
+      const shareToolbar = page.locator(".fr-share")
+      await expect(shareToolbar).not.toHaveAttribute("role", "toolbar")
+    })
+  })
   test.describe("[Carte] 5.4 / 5.6 — Titre et en-têtes du tableau mode liste", () => {
     test("Le tableau a une légende (<caption>) non vide", async ({ page }) => {
       await navigateTo(

--- a/webapp/previews/template_preview.py
+++ b/webapp/previews/template_preview.py
@@ -1056,16 +1056,22 @@ class AccessibilitePreview(LookbookPreview):
 
     def share_tooltip_acteur_sans_tabindex(self, **kwargs):
         """
-        # Tooltip de partage de la fiche acteur sans tabindex="-1" (RGAA 7.3)
+        # Tooltip de partage de la fiche acteur sans tabindex="-1" (RGAA 7.3, 7.2, 12.8, 12.11)
 
         Les liens et le bouton du tooltip de partage de la fiche acteur,
         sur la carte, ne portent plus `tabindex="-1"` : ils sont à nouveau
         atteignables au clavier.
 
+        Le tooltip ne porte plus non plus `tabindex="1"` (un tabindex
+        positif perturbe l'ordre de tabulation naturel), ni
+        `role="toolbar"` sur `.fr-share` (non pertinent, ce n'est pas une
+        barre d'outils avec navigation flèches), ni `aria-describedby` sur
+        le bouton (le tooltip n'est pas une description du bouton).
+
         Pour rendre le tooltip visible dans la prévisualisation, le wrapper
         `.fr-tooltip` est volontairement positionné statiquement.
 
-        Cf. carte Notion A11Y-9.
+        Cf. carte Notion A11Y-9, A11Y-3333 (item 5), A11Y-3343, A11Y-3344.
         """
         request = RequestFactory().get("/")
         context = Context(

--- a/webapp/templates/ui/components/acteur/_action_share.html
+++ b/webapp/templates/ui/components/acteur/_action_share.html
@@ -5,16 +5,15 @@
 >
     <button
         class="fr-btn fr-btn--sm fr-btn--secondary-light fr-icon-share-line qf-rounded-full"
-        aria-describedby="{{ map_container_id }}:shareTooltip"
         type="button"
         data-action="click -> analytics#captureInteractionWithSolutionDetails"
     >
         <span class="qf-sr-only">partager</span>
     </button>
 
-    <div class="fr-tooltip fr-placement" id="{{ map_container_id }}:shareTooltip" role="tooltip" tabindex="1">
+    <div class="fr-tooltip fr-placement" id="{{ map_container_id }}:shareTooltip" role="tooltip">
         {% configure_acteur_sharer %}
-        <div class="fr-share" role="toolbar">
+        <div class="fr-share">
             <ul class="fr-btns-group">
                 <li>
                     <a class="fr-btn--facebook fr-btn"


### PR DESCRIPTION
# Description succincte du problème résolu

Cartes Notion :
- [\[Carte\] - 7.2 - Pour chaque script ayant une alternative, cette alternative est-elle pertinente ?](https://app.notion.com/p/3986523d57d780778298c53451bf97d8) (item 5 : tooltip partage)
- [\[Carte\] - 12.8 - Dans chaque page web, l'ordre de tabulation est-il cohérent ?](https://app.notion.com/p/3986523d57d7800094cbfed98635b5f5)
- [\[Carte\] - 12.11 - Dans chaque page web, les contenus additionnels apparaissant au survol... sont-ils atteignables au clavier ?](https://app.notion.com/p/3986523d57d78050b69dcbc1d24705a8)

**N'oublier pas de taguer** : `accessibility`

**🗺️ contexte**: Audit RGAA de la carte interactive. Le tooltip de partage de la fiche acteur avait déjà reçu un premier correctif (retrait de `tabindex="-1"`, RGAA A11Y-9) mais conservait plusieurs autres non-conformités.

**💡 quoi**: Le tooltip de partage de la fiche acteur portait encore : `tabindex="1"` (positif, perturbe l'ordre de tabulation naturel), `role="toolbar"` sur `.fr-share` (non pertinent, ce n'est pas une barre d'outils avec navigation par flèches), et `aria-describedby` sur le bouton déclencheur (le tooltip n'est pas une description du bouton).

**🎯 pourquoi**:
- Un `tabindex` positif force un élément en avant dans l'ordre de tabulation, indépendamment de sa position dans le DOM — c'est une pratique déconseillée qui casse la prévisibilité du parcours clavier
- `role="toolbar"` implique une navigation par flèches directionnelles entre les éléments, ce que ce groupe de liens de partage n'implémente pas
- `aria-describedby` sur le bouton associe le contenu du tooltip comme description du bouton, alors qu'il s'agit d'un menu d'actions déclenché par le bouton, pas d'une description

**🤔 comment**:
- `ui/components/acteur/_action_share.html` : retrait de `tabindex="1"`, `role="toolbar"` et `aria-describedby`
- Mise à jour de la docstring de la preview Lookbook `share_tooltip_acteur_sans_tabindex` (existante) pour refléter l'ensemble des correctifs
- Ajout d'un test e2e vérifiant l'absence des trois attributs/rôles

**🤓 comment tester**:
```bash
cd webapp && npx playwright test --reporter=list ./e2e_tests/a11y_rgaa.spec.ts
```
Ou visuellement : `/lookbook/preview/accessibilite/share_tooltip_acteur_sans_tabindex/`.

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] Aucun

## 📆 A faire (prochaine PR)

- [ ] Le reste du ticket 7.2 (canvas aria-label, pagination en boutons, dialog/modal sémantique) reste à faire — périmètre plus large, voir rgaa/carte-3333-7.2.md
