### PR TITLE
accessibilité : légendes pertinentes dans la modale filtres (RGAA 11.6, 11.7)

### DIFF
--- a/webapp/e2e_tests/a11y_rgaa.spec.ts
+++ b/webapp/e2e_tests/a11y_rgaa.spec.ts
@@ -164,4 +164,23 @@ test.describe("♿ RGAA", () => {
       await expect(logoLink).toHaveAccessibleName(/Accueil — /)
     })
   })
+  test.describe("[Carte] 11.6 — Légende du toggle Carte/Liste", () => {
+    test("Le fieldset du toggle Carte/Liste a une légende « Mode d'affichage »", async ({
+      page,
+    }) => {
+      await navigateTo(page, "/lookbook/preview/formulaires/mode_carte_liste/")
+      const legend = page.locator(".fr-segmented__legend")
+      await expect(legend).toHaveText(/Mode d'affichage/)
+    })
+  })
+
+  test.describe("[Carte] 11.7 — Légende pertinente dans la modale filtres", () => {
+    test('La légende du groupe de labels/certifications n\'est pas juste "Optional"', async ({
+      page,
+    }) => {
+      await navigateTo(page, "/lookbook/preview/modals/filtres/")
+      const legend = page.locator("#id_label_qualite-legend")
+      await expect(legend).toContainText("Labels et certifications")
+    })
+  })
 })

--- a/webapp/qfdmo/forms.py
+++ b/webapp/qfdmo/forms.py
@@ -453,7 +453,7 @@ class FiltresForm(GetFormMixin, CarteConfigFormMixin, DsfrBaseForm):
         to_field_name="code",
         widget=forms.CheckboxSelectMultiple,
         required=False,
-        label="",
+        label="Labels et certifications",
     )
 
     pas_exclusivite_reparation = forms.BooleanField(
@@ -826,7 +826,7 @@ class ViewModeForm(AutoSubmitMixin, GetFormMixin, CarteConfigFormMixin, DsfrBase
         }
 
     view = forms.ChoiceField(
-        label="",
+        label="Mode d'affichage",
         choices=ViewModeSegmentedControlChoices.choices,
         required=False,
         initial=CarteConfig.ModesAffichage.CARTE,

--- a/webapp/templates/dsfr/form_field_snippets/segmented_control_snippet.html
+++ b/webapp/templates/dsfr/form_field_snippets/segmented_control_snippet.html
@@ -1,0 +1,10 @@
+{% load dsfr_tags %}
+
+<div class="fr-input-group">
+  <fieldset class="fr-segmented {{ field.field.widget.extra_classes }}">
+    <legend class="fr-segmented__legend qf-sr-only {% if field.field.widget.is_inline %}fr-segmented__legend--inline{% endif %}">
+      {{ field.label }}
+    </legend>
+    {{ field }}
+  </fieldset>
+</div>


### PR DESCRIPTION
# Description succincte du problème résolu

Cartes Notion :
- [\[Carte\] - 11.6 - Dans chaque formulaire, chaque regroupement de champs de même nature a-t-il une légende ?](https://app.notion.com/p/3986523d57d780b5a1a8f88dff79fe83)
- [\[Carte\] - 11.7 - Dans chaque formulaire, chaque légende associée à un regroupement de champs de même nature est-elle pertinente ?](https://app.notion.com/p/3986523d57d780a2950fd5127d672c52)

**N'oublier pas de taguer** : `accessibility`

**🗺️ contexte**: Audit RGAA de la carte interactive — critères 11.6 et 11.7 (légendes de regroupement de champs).

**💡 quoi**:
1. Le toggle Carte/Liste (boutons segmentés) a une légende présente mais vide et invisible.
2. Dans la modale filtres, la légende du groupe de cases à cocher « labels et certifications » n'affiche que « (Optionnel) », sans intitulé pertinent.

**🎯 pourquoi**: Les deux champs (`ViewModeForm.view` et `FiltresForm.label_qualite`) avaient un `label=""` codé en dur. Le composant de rendu DSFR (`segmented_control_snippet.html`, `checkboxselectmultiple_snippet.html`) affiche systématiquement une `<legend>` reprenant ce label — un label vide produit une légende vide (toggle) ou réduite à la seule mention « (Optionnel) » (filtres).

**🤔 comment**:
- `qfdmo/forms.py` : `ViewModeForm.view` reçoit le libellé « Mode d'affichage », `FiltresForm.label_qualite` reçoit « Labels et certifications »
- Pour le toggle Carte/Liste, le libellé doit rester masqué visuellement (design compact existant) : ajout d'un override local `templates/dsfr/form_field_snippets/segmented_control_snippet.html` (le composant projet `SegmentedControl` ne rend pas de fieldset lui-même — celui-ci vient du snippet de rendu de champ django-dsfr) ajoutant la classe `qf-sr-only` à la légende, plutôt que de modifier le CSS global de DSFR
- Pour la modale filtres, la légende est laissée visible (comportement DSFR standard, cohérent avec les autres légendes de la modale)
- Ajout de deux tests e2e

**🤓 comment tester**:
```bash
cd webapp && npx playwright test --reporter=list ./e2e_tests/a11y_rgaa.spec.ts
```
Ou visuellement : `/lookbook/preview/formulaires/mode_carte_liste/` et `/lookbook/preview/modals/filtres/`.

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] Aucun

## 📆 A faire (prochaine PR)

- [ ] Aucun
