### PR TITLE
accessibilité : champ de recherche résiste au redimensionnement d'espacement (RGAA 10.12)

### DIFF
--- a/webapp/e2e_tests/a11y_rgaa.spec.ts
+++ b/webapp/e2e_tests/a11y_rgaa.spec.ts
@@ -183,4 +183,36 @@ test.describe("♿ RGAA", () => {
       await expect(legend).toContainText("Labels et certifications")
     })
   })
+  test.describe("[Site Que faire] 10.12 — Espacement du texte du champ de recherche", () => {
+    test("le champ de recherche n'est pas rogné avec un espacement de texte élargi (WCAG 1.4.12)", async ({
+      page,
+    }) => {
+      await navigateTo(page, "/")
+      await page.addStyleTag({
+        content: `
+          * {
+            line-height: 1.5 !important;
+            letter-spacing: 0.12em !important;
+            word-spacing: 0.16em !important;
+          }
+          p {
+            margin-bottom: 2em !important;
+          }
+        `,
+      })
+      const searchWrapper = page.locator(
+        '[data-controller="search"]:has(' + SEARCH_INPUT_SELECTOR + ")",
+      )
+      const box = await searchWrapper.boundingBox()
+      const input = page.locator(SEARCH_INPUT_SELECTOR)
+      const inputBox = await input.boundingBox()
+      expect(box).not.toBeNull()
+      expect(inputBox).not.toBeNull()
+      // The input row must not be clipped by its ancestor: the input's
+      // bottom edge should stay within the wrapper's bounds.
+      if (box && inputBox) {
+        expect(inputBox.y + inputBox.height).toBeLessThanOrEqual(box.y + box.height + 1)
+      }
+    })
+  })
 })

--- a/webapp/templates/ui/components/search/view.html
+++ b/webapp/templates/ui/components/search/view.html
@@ -11,7 +11,7 @@
         class="
         {# Z-index here helps prevent autocomplete overlapping on the accordion on the homepage #}
         qf-relative qf-z-10
-        qf-rounded-3xl qf-overflow-hidden
+        qf-rounded-3xl
         group-data-[home]:qf-rounded-[2rem]
         max-md:qf-rounded-[2rem]
         qf-border-solid qf-border-[3px] qf-border-green-menthe-sun-373-moon-652-hover qf-bg-white
@@ -23,8 +23,8 @@
             action="{% url 'qfdmd:search' %}"
             class="qf-pl-4w {# should match the svg icon width #}
             qf-flex qf-flex-row-reverse qf-relative
-            md:group-data-[home]:qf-h-7w
-            qf-h-5w
+            md:group-data-[home]:qf-min-h-7w
+            qf-min-h-5w
             qf-content-center
             "
         >


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion :
- [\[Site Que faire\] - 10.12 - Chaque page web dont l'espacement du texte est redéfini par l'utilisateur, garde-t-elle une présentation cohérente ?](https://app.notion.com/p/3986523d57d780c8a850e143c659e241)

**N'oublier pas de taguer** : `accessibility`

**🗺️ contexte**: Audit RGAA du site — critère 10.12 (espacement du texte redéfinissable sans perte de contenu).

**💡 quoi**: Sur la page d'accueil (et partout où le composant de recherche est utilisé, header inclus), une fois l'espacement du texte augmenté (ex. via un bookmarklet WCAG 1.4.12), le texte du champ de recherche se retrouve rogné.

**🎯 pourquoi**: Le formulaire de recherche (`ui/components/search/view.html`) avait une hauteur fixe (`qf-h-5w` / `md:group-data-[home]:qf-h-7w`), et son conteneur parent utilisait `overflow-hidden`. Une fois la `line-height` augmentée par l'utilisateur, le texte dépasse la hauteur fixe du formulaire et se retrouve coupé par le `overflow-hidden` du parent.

**🤔 comment**:
- Hauteur fixe remplacée par une hauteur minimale (`qf-min-h-5w` / `qf-min-h-7w`), permettant au formulaire de grandir avec le texte au lieu de le contraindre
- `overflow-hidden` retiré du conteneur parent — il ne servait qu'à garantir l'arrondi visuel des coins (`qf-rounded-3xl`), déjà suffisant seul puisqu'aucun enfant ne dépend de ce clipping pour son rendu (vérifié : le fond des résultats d'autocomplétion n'en dépend pas)
- Ajout d'un test e2e

**🤓 comment tester**:
```bash
cd webapp && npx playwright test --reporter=list ./e2e_tests/a11y_rgaa.spec.ts
```
Ou manuellement : ouvrir la page d'accueil, appliquer un espacement de texte élargi (ex. bookmarklet WCAG 1.4.12 : https://www.html5accessibility.com/tests/tsbookmarklet.html), vérifier que le champ de recherche n'est plus rogné.

**⚠️ note**: en investiguant ce composant, une régression pré-existante et indépendante a été repérée — l'attribut `action="{% url 'qfdmd:search' %}"` du formulaire pointe vers un nom d'URL Django introuvable (`NoReverseMatch`), présent depuis 2024 (commit `8633462ca1`). Le composant fonctionne en pratique car la soumission passe toujours par le contrôleur Stimulus JS (`data-controller="search"`), qui intercepte le submit — le fallback HTML natif ne semble jamais utilisé. Non corrigé dans cette PR (hors périmètre du critère 10.12), signalé pour revue humaine séparée.

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] Aucun

## 📆 A faire (prochaine PR)

- [ ] Investiguer/corriger le `NoReverseMatch` sur `{% url 'qfdmd:search' %}` dans `ui/components/search/view.html` (bug pré-existant, indépendant de cette PR)
