### PR TITLE
lors de la copie de la table, on récupère les colonnes de la table depuis le schema public uniquement

### DIFF
--- a/data-platform/dags/acteurs/tasks/business_logic/replace_acteur_table.py
+++ b/data-platform/dags/acteurs/tasks/business_logic/replace_acteur_table.py
@@ -49,13 +49,19 @@ def copy_tables_between_servers(cursor, prefix_dbt, prefix_django, tables):
                 f"INCLUDING INDEXES)"
             )
 
-            # Get column names in correct order
-            cursor.execute(f"""
+            # Get column names in correct order (public schema only: avoid
+            # duplicates from FDW mirrors like webapp_public.qfdmo_vueacteur)
+            django_table = f"{prefix_django}{table}"
+            cursor.execute(
+                """
                 SELECT column_name
                 FROM information_schema.columns
-                WHERE table_name = '{prefix_django}{table}'
+                WHERE table_schema = 'public'
+                  AND table_name = %s
                 ORDER BY ordinal_position
-            """)
+                """,
+                [django_table],
+            )
             columns = [col[0] for col in cursor.fetchall()]
             columns_str = ", ".join(columns)
 


### PR DESCRIPTION
# Description succincte du problème résolu

Bug du DAG `compute_acteur`
A la fin du calcul des acteurs à afficher
quand on copie les tables de la base de données `warehouse` vers la base de données `webapp`
les colonnes de la table sont inspectées pour véridier qu'on a la même définition avant de copier
les colonnes était récupérées en collectant sur tous les schema, en preprod, il y a 2 schema avec les tables visées : `public` et `webapp_public`, du coup on récupérait les champs 2 fois :

```
LINE 1: INSERT INTO int_epci (id, id, code, code, nom, nom) SELECT i
```

**🗺️ contexte**: Airflow compute_acteur

**💡 quoi**: copie des tables de `warehouse` vers `webapp` cassée

**🎯 pourquoi**: On récupère les colonnes sans discriminer le schema

**🤔 comment**: récupération des colonnes sur le schema `public`

**🤓 comment tester**: 

- copier le schema `public` de la db `webapp` dans un autre schema
- lancer le DAG "Rafraîchir les acteurs" 

Le DAG doit tourner jusqu'au bout

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
