### PR TITLE
Suppression du filtrage des etablissements avec un code étranger

### DIFF
--- a/data-platform/dags/clone/tasks/business_logic/clone_table_create.py
+++ b/data-platform/dags/clone/tasks/business_logic/clone_table_create.py
@@ -143,7 +143,7 @@ def commands_download_to_disk_first(
     fix_corrupted_utf8_sed_substitutions: list[str],
     dry_run: bool,
 ):
-    """Commands to create table while first dowloading to disk"""
+    """Commands to create table while first downloading to disk"""
 
     file_unpacked = file_unpacked or file_downloaded
 

--- a/data-platform/dbt/models/base/ae/base_ae_etablissement.sql
+++ b/data-platform/dbt/models/base/ae/base_ae_etablissement.sql
@@ -9,30 +9,29 @@ Notes:
 SELECT
 
 -- Codes
-{{ target.schema }}.udf_ae_string_cleanup(siret) AS siret,
-{{ target.schema }}.udf_ae_string_cleanup(siren) AS siren,
-{{ target.schema }}.udf_ae_string_cleanup(activite_principale) AS activite_principale,
+siret,
+siren,
+activite_principale,
 
 -- Names
-{{ target.schema }}.udf_ae_string_cleanup(denomination_usuelle) AS denomination_usuelle,
+denomination_usuelle,
 
 -- Status
-{{ target.schema }}.udf_ae_string_cleanup(etat_administratif) AS etat_administratif,
+etat_administratif,
 
 -- Address
-{{ target.schema }}.udf_ae_string_cleanup(numero_voie) AS numero_voie,
-{{ target.schema }}.udf_ae_string_cleanup(complement_adresse) AS complement_adresse,
-{{ target.schema }}.udf_ae_string_cleanup(type_voie) AS type_voie,
-{{ target.schema }}.udf_ae_string_cleanup(libelle_voie) AS libelle_voie,
-{{ target.schema }}.udf_ae_string_cleanup(code_postal) AS code_postal,
-{{ target.schema }}.udf_ae_string_cleanup(libelle_commune) AS libelle_commune
+numero_voie,
+complement_adresse,
+type_voie,
+libelle_voie,
+code_postal,
+libelle_commune
 
 FROM {{ source('ae', 'clone_ae_etablissement_in_use') }}
 -- Filtering out foreign establishments as our focus is France
 -- On 2025-03-17 this allows excluding ~316K rows
-WHERE code_pays_etranger IS NULL
 -- Ignore closed establishments before 2006 (20 years ago)
-AND NOT (date_debut < '2006-01-01' AND etat_administratif = 'F')
+WHERE NOT (date_debut < '2006-01-01' AND etat_administratif = 'F')
 
 {% if env_var('DBT_SAMPLING', 'false') == 'true' %}
 /* We can't do random sampling else we risk having

--- a/data-platform/dbt/models/intermediate/ae/int_ae_etablissement.sql
+++ b/data-platform/dbt/models/intermediate/ae/int_ae_etablissement.sql
@@ -1,13 +1,32 @@
 /*
 Notes:
+ - 🧹 Converting '[ND]' (non-diffusible) to NULL to make
+      our data lighter and easier to work with
  - 🖊️ Renaming columns to follow our naming convention
  - 🧱 We force tu use indexes `Merge Join` instead of `Hash Join`
       to improve performance because siren has a high cardinality
 */
 
+WITH cleaned AS (
+    SELECT
+        {{ target.schema }}.udf_ae_string_cleanup(siret) AS siret,
+        {{ target.schema }}.udf_ae_string_cleanup(siren) AS siren,
+        {{ target.schema }}.udf_ae_string_cleanup(activite_principale) AS activite_principale,
+        {{ target.schema }}.udf_ae_string_cleanup(denomination_usuelle) AS denomination_usuelle,
+        {{ target.schema }}.udf_ae_string_cleanup(etat_administratif) AS etat_administratif,
+        {{ target.schema }}.udf_ae_string_cleanup(numero_voie) AS numero_voie,
+        {{ target.schema }}.udf_ae_string_cleanup(complement_adresse) AS complement_adresse,
+        {{ target.schema }}.udf_ae_string_cleanup(type_voie) AS type_voie,
+        {{ target.schema }}.udf_ae_string_cleanup(libelle_voie) AS libelle_voie,
+        {{ target.schema }}.udf_ae_string_cleanup(code_postal) AS code_postal,
+        {{ target.schema }}.udf_ae_string_cleanup(libelle_commune) AS libelle_commune
+    FROM {{ ref('base_ae_etablissement') }}
+)
+
 SELECT
     -- Codes
     etab.siret,
+    etab.siren,
     etab.activite_principale AS naf, -- Making NAF explicit being a well-known code
 
     -- Names
@@ -48,7 +67,7 @@ SELECT
       )
     ) AS adresse_normalize_string_for_match
 
-FROM {{ ref('base_ae_etablissement') }} AS etab
+FROM cleaned AS etab
 /* Joining with unite_legale to bring some essential
 data from parent unite into each etablissement (saves
 us from making expensive JOINS in downstream models) */

--- a/data-platform/dbt/models/intermediate/ae/schema.yml
+++ b/data-platform/dbt/models/intermediate/ae/schema.yml
@@ -10,6 +10,11 @@ models:
         data_tests:
           - not_null
           - unique
+      - name: siren
+        description: "Numéro SIREN"
+        data_type: varchar(9)
+        data_tests:
+          - not_null
       - name: activite_principale
         description: "Code NAF Rev2"
       - name: nom

--- a/data-platform/dbt/models/marts/enrich_siren_siret/marts_enrich_siren_from_siret.sql
+++ b/data-platform/dbt/models/marts/enrich_siren_siret/marts_enrich_siren_from_siret.sql
@@ -4,6 +4,6 @@ SELECT
     ae.siret,
     ae.code_postal
 FROM {{ ref('int_acteur_with_siret_without_siren') }} AS av
-INNER JOIN {{ ref('base_ae_etablissement') }} AS ae
+INNER JOIN {{ ref('int_ae_etablissement') }} AS ae
     ON ae.siret = av.siret
 WHERE ae.etat_administratif = 'A'

--- a/data-platform/dbt/models/marts/enrich_siren_siret/marts_enrich_siret_from_siren.sql
+++ b/data-platform/dbt/models/marts/enrich_siren_siret/marts_enrich_siret_from_siren.sql
@@ -4,7 +4,7 @@ WITH acteurs AS (
 ),
 active_etablissements AS (
     SELECT ae.siren, ae.siret, ae.code_postal
-    FROM {{ ref('base_ae_etablissement') }} AS ae
+    FROM {{ ref('int_ae_etablissement') }} AS ae
     INNER JOIN {{ ref('int_acteur_with_siren_without_siret') }} AS av
         ON ae.siren = av.siren
     WHERE ae.etat_administratif = 'A'


### PR DESCRIPTION
# Description succincte du problème résolu

Mattermost : [siret 87879207600019 marqué non trouvé alors qu'il existe dasn AE](https://mattermost.incubateur.net/betagouv/pl/y3e7mw3b4pyifg88of6gqxmn8w)

**🗺️ contexte**: Airflow - SIRET

**💡 quoi**: un siret est affiché comme n'exitant pas dans la DB alors 

**🎯 pourquoi**: 

la donnée est filtrée sur les établissements qui ont un `code_pays_etranger` ne sont pas pris en compte dans les traitement DBT. Ce filtre date de la mise en place par Max

je suppose que ce filtre est fait pour réduire le nombre de ligne de la table à traiter mais cela représente un faible proportion de la DB

```
warehouse=> select count(*) from clone_ae_etablissement_in_use;
  count   
----------
 43700154
(1 row)

warehouse=> select count(*) from clone_ae_etablissement_in_use where code_pays_etranger IS NOT NULL;
 count  
--------
 364188
(1 row)
```

**🤔 comment**: 

- Suppression du filtre sur le champ `code_pays_etranger`
- déplacement de la normalisation des champs sur le modèle `int_ae_etablissement`
- utilisation de `int_ae_etablissement` en lieu et place de `base_ae_etablissement` sur les autres modèle `int` et `marts`

**🤓 comment tester**: 

- Lancer sans échècs les DAGs :  
  - Clone AE établissement
  - Enrichir - Acteurs SIRET & SIREN (lien succession)
  - Stat

- vérifier la présence du siret `87879207600019` dans `int_ae_etablissement`

```
select * from int_ae_etablissement where siret = '87879207600019';
```

vérifier que ce même siret ne soit pas dans la table `exposure_stats_acteur_no_siret_actif`

```
SELECT *
FROM exposure_stats_acteur_no_siret_actif
WHERE etat_administratif IS NULL AND siret = '87879207600019';
```

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien