### PR TITLE
corrige dependabot depuis le passage aux workspace uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,7 @@ version: 2
 
 updates:
   - package-ecosystem: "uv"
-    directories:
-      - "/webapp"
-      - "/data-platform"
+    directory: "/"
     open-pull-requests-limit: 100
     schedule:
       interval: "weekly"


### PR DESCRIPTION


**🗺️ contexte**: dependabot

**💡 quoi**: 
`webapp` et `data-platform` partagent un seul workspace `uv` avec un unique `uv.lock` à la racine du repo.

**🎯 pourquoi**: 
pour s'aligner avec les workspace uv 

**🤔 comment**:
Remplace les deux `directories` (`/webapp`, `/data-platform`) de l'écosystème `uv` dans `dependabot.yml` par un seul `directory: "/"`.

**🤓 comment tester**: 
Vérifier dans l'onglet Insights > Dependency graph > Dependabot du repo GitHub que la config est valide, et attendre la prochaine exécution planifiée (mardi 06:00 UTC) pour confirmer que les PRs sont bien générées.

## Auto-review

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)
