### PR TITLE
Récupération des paramètres du DAG de clustering via API

### DIFF
--- a/data-platform/dags/.env.template
+++ b/data-platform/dags/.env.template
@@ -1,8 +1,8 @@
 ENVIRONMENT=development
-# Nécessaire car variable dans /core/settings.py
-# qu'on a souhaité laissé nulle par défaut
-# pour des raisons de sécurité
-# Voir PR: https://github.com/incubateur-ademe/quefairedemesobjets/pull/1189
+# Required because this variable in /core/settings.py
+# was intentionally left null by default
+# for security reasons
+# See PR: https://github.com/incubateur-ademe/quefairedemesobjets/pull/1189
 SECRET_KEY='my-secret-key' # pragma: allowlist secret
 
 # AIRFLOW
@@ -70,9 +70,9 @@ _PIP_ADDITIONAL_REQUIREMENTS=${_PIP_ADDITIONAL_REQUIREMENTS:-}
 ### CONNECTOR
 AIRFLOW_CONN_WEBAPP_DB='postgres://webapp:webapp@lvao-webapp-db:5432/webapp' # pragma: allowlist secret
 DATABASE_URL=postgres://webapp:webapp@lvao-webapp-db:5432/webapp # pragma: allowlist secret
-# URL de la webapp pour les appels API depuis les DAGs
-# (ex: métadonnées des modèles acteurs au parsing des DAGs)
-# En local, la webapp tourne sur le host (make run-django)
+# Webapp URL for API calls from DAGs
+# (e.g. acteur model metadata when parsing DAGs)
+# Locally, the webapp runs on the host (make run-django)
 WEBAPP_URL=http://host.docker.internal:8000
 DB_WEBAPP_SAMPLE=postgres://webapp_sample:webapp_sample@lvao-webapp-db:5432/webapp_sample # pragma: allowlist secret
 DB_WAREHOUSE=postgres://warehouse:warehouse@lvao-warehouse-db:5432/warehouse # pragma: allowlist secret
@@ -90,3 +90,4 @@ SCW_ACCESS_KEY=
 SCW_SECRET_KEY=
 SCW_DEFAULT_ORGANIZATION_ID=
 SCW_DEFAULT_PROJECT_ID=
+

--- a/data-platform/dags/.env.template
+++ b/data-platform/dags/.env.template
@@ -72,7 +72,7 @@ AIRFLOW_CONN_WEBAPP_DB='postgres://webapp:webapp@lvao-webapp-db:5432/webapp' # p
 DATABASE_URL=postgres://webapp:webapp@lvao-webapp-db:5432/webapp # pragma: allowlist secret
 # Webapp URL for API calls from DAGs
 # (e.g. acteur model metadata when parsing DAGs)
-# Locally, the webapp runs on the host (make run-django)
+# Locally, the webapp runs on the host (make runserver)
 WEBAPP_URL=http://host.docker.internal:8000
 DB_WEBAPP_SAMPLE=postgres://webapp_sample:webapp_sample@lvao-webapp-db:5432/webapp_sample # pragma: allowlist secret
 DB_WAREHOUSE=postgres://warehouse:warehouse@lvao-warehouse-db:5432/warehouse # pragma: allowlist secret

--- a/data-platform/dags/.env.template
+++ b/data-platform/dags/.env.template
@@ -70,6 +70,10 @@ _PIP_ADDITIONAL_REQUIREMENTS=${_PIP_ADDITIONAL_REQUIREMENTS:-}
 ### CONNECTOR
 AIRFLOW_CONN_WEBAPP_DB='postgres://webapp:webapp@lvao-webapp-db:5432/webapp' # pragma: allowlist secret
 DATABASE_URL=postgres://webapp:webapp@lvao-webapp-db:5432/webapp # pragma: allowlist secret
+# URL de la webapp pour les appels API depuis les DAGs
+# (ex: métadonnées des modèles acteurs au parsing des DAGs)
+# En local, la webapp tourne sur le host (make run-django)
+WEBAPP_URL=http://host.docker.internal:8000
 DB_WEBAPP_SAMPLE=postgres://webapp_sample:webapp_sample@lvao-webapp-db:5432/webapp_sample # pragma: allowlist secret
 DB_WAREHOUSE=postgres://warehouse:warehouse@lvao-warehouse-db:5432/warehouse # pragma: allowlist secret
 

--- a/data-platform/dags/cluster/dags/cluster_acteur_suggestions.py
+++ b/data-platform/dags/cluster/dags/cluster_acteur_suggestions.py
@@ -10,7 +10,11 @@ from shared.config.airflow import DEFAULT_ARGS_NO_RETRIES
 from shared.config.start_dates import START_DATES
 from shared.config.tags import TAGS
 from utils.airflow_params import airflow_params_dropdown_from_mapping
-from utils.webapp import acteurs_metadata
+from utils.webapp import (
+    get_acteur_columns_from_webapp,
+    get_acteur_types_from_webapp,
+    get_sources_from_webapp,
+)
 
 # -------------------------------------------
 # Manage dropdowns in Airflow
@@ -18,20 +22,25 @@ from utils.webapp import acteurs_metadata
 # Beware of performance impact, see min_file_process_interval
 # https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#config-scheduler-min-file-process-interval
 # https://airflow.apache.org/docs/apache-airflow/stable/best-practices.html#top-level-python-code
-# Data is fetched via the webapp API (single HTTP call) instead of
-# django.setup() + ORM which caused DagBag import timeouts
+# Data is fetched via the webapp API instead of django.setup() + ORM
+# which caused DagBag import timeouts
 
-metadata = acteurs_metadata()
-mapping_source_id_by_code = metadata["sources"]
-mapping_acteur_type_id_by_code = metadata["acteur_types"]
+mapping_source_id_by_code = {
+    source["code"]: source["id"] for source in get_sources_from_webapp()
+}
+mapping_acteur_type_id_by_code = {
+    acteur_type["code"]: acteur_type["id"]
+    for acteur_type in get_acteur_types_from_webapp()
+}
 # Create dropdowns
 dropdown_sources = airflow_params_dropdown_from_mapping(mapping_source_id_by_code)
 dropdown_acteur_types = airflow_params_dropdown_from_mapping(
     mapping_acteur_type_id_by_code
 )
 
-fields_vue_acteur = metadata["model_fields"]["vue_acteur"]
-fields_revision_acteur = metadata["model_fields"]["revision_acteur"]
+acteur_columns = get_acteur_columns_from_webapp()
+fields_vue_acteur = acteur_columns["vue_acteur"]
+fields_revision_acteur = acteur_columns["revision_acteur"]
 
 fields_all = sorted(
     list(set(fields_vue_acteur["with_properties"]) - set(UNNORMALIZABLE_FIELDS))

--- a/data-platform/dags/cluster/dags/cluster_acteur_suggestions.py
+++ b/data-platform/dags/cluster/dags/cluster_acteur_suggestions.py
@@ -10,10 +10,7 @@ from shared.config.airflow import DEFAULT_ARGS_NO_RETRIES
 from shared.config.start_dates import START_DATES
 from shared.config.tags import TAGS
 from utils.airflow_params import airflow_params_dropdown_from_mapping
-from utils.django import django_model_fields_get, django_setup_full
-
-django_setup_full()
-from qfdmo.models import ActeurType, RevisionActeur, Source, VueActeur  # noqa: E402
+from utils.webapp import acteurs_metadata
 
 # -------------------------------------------
 # Manage dropdowns in Airflow
@@ -21,27 +18,31 @@ from qfdmo.models import ActeurType, RevisionActeur, Source, VueActeur  # noqa: 
 # Beware of performance impact, see min_file_process_interval
 # https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#config-scheduler-min-file-process-interval
 # https://airflow.apache.org/docs/apache-airflow/stable/best-practices.html#top-level-python-code
-# But OK for now given low amount of requested data
+# Data is fetched via the webapp API (single HTTP call) instead of
+# django.setup() + ORM which caused DagBag import timeouts
 
-# Get data from DB
-mapping_source_id_by_code = {obj.code: obj.id for obj in Source.objects.all()}
-mapping_acteur_type_id_by_code = {obj.code: obj.id for obj in ActeurType.objects.all()}
+metadata = acteurs_metadata()
+mapping_source_id_by_code = metadata["sources"]
+mapping_acteur_type_id_by_code = metadata["acteur_types"]
 # Create dropdowns
 dropdown_sources = airflow_params_dropdown_from_mapping(mapping_source_id_by_code)
 dropdown_acteur_types = airflow_params_dropdown_from_mapping(
     mapping_acteur_type_id_by_code
 )
 
+fields_vue_acteur = metadata["model_fields"]["vue_acteur"]
+fields_revision_acteur = metadata["model_fields"]["revision_acteur"]
+
 fields_all = sorted(
-    list(set(django_model_fields_get(VueActeur)) - set(UNNORMALIZABLE_FIELDS))
+    list(set(fields_vue_acteur["with_properties"]) - set(UNNORMALIZABLE_FIELDS))
 )
 
 # intersection of RevisionActeur and VueActeur fields
 # because VueActeur is the source and RevisionActeur is the target
 fields_enrich = sorted(
     list(
-        set(django_model_fields_get(VueActeur, include_properties=False))
-        & set(django_model_fields_get(RevisionActeur, include_properties=False))
+        set(fields_vue_acteur["db_only"])
+        & set(fields_revision_acteur["db_only"])
         # Exclude some fields based on business rules (ex: source)
         - set(FIELDS_PARENT_DATA_EXCLUDED)
     )
@@ -110,8 +111,12 @@ PARAMS = {
         description_md="""**➕ INCLUSION ACTEURS**: ceux dont le champ 'nom'
             correspond à cette expression régulière ([voir recettes](https://www.notion.so/accelerateur-transition-ecologique-ademe/Expressions-r-guli-res-regex-1766523d57d780939a37edd60f367b75))
 
-            🧹 Note: la normalisation basique est appliquée à la volée sur ce
+            🧹 Note:
+            - la normalisation basique est appliquée à la volée sur ce
             champ avant l'application de la regex pour simplifier les expressions
+            - la regex n'est pas sensible à la casse mais est sensible aux caractères
+            accentués, par exemple, pour chercher école avec ou sans accent, il faut
+            utiliser la regex `école` ou `école|ecole` ou `[ée]cole`
 
             0️⃣ Si aucune valeur spécifiée =  cette option n'a PAS d'effet""",
     ),

--- a/data-platform/dags/tests/utils/test_webapp.py
+++ b/data-platform/dags/tests/utils/test_webapp.py
@@ -2,55 +2,78 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
-from utils.webapp import WEBAPP_URL_DEFAULT, acteurs_metadata, webapp_url
+from utils.webapp import (
+    get_acteur_columns_from_webapp,
+    get_acteur_types_from_webapp,
+    get_sources_from_webapp,
+)
 
-METADATA = {
-    "sources": {"source1": 1},
-    "acteur_types": {"type1": 10},
-    "model_fields": {
-        "vue_acteur": {"with_properties": ["nom", "latitude"], "db_only": ["nom"]},
-        "revision_acteur": {"with_properties": ["nom"], "db_only": ["nom"]},
-    },
+SOURCES = [{"id": 1, "code": "source1", "libelle": "Source 1"}]
+ACTEUR_TYPES = [{"id": 10, "code": "type1", "libelle": "Type 1"}]
+ACTEUR_COLUMNS = {
+    "vue_acteur": {"with_properties": ["nom", "latitude"], "db_only": ["nom"]},
+    "revision_acteur": {"with_properties": ["nom"], "db_only": ["nom"]},
 }
 
 
-class TestWebappUrl:
-    def test_default(self, monkeypatch):
-        monkeypatch.delenv("WEBAPP_URL", raising=False)
-        assert webapp_url() == WEBAPP_URL_DEFAULT
+@pytest.fixture(autouse=True)
+def clear_cache():
+    get_sources_from_webapp.cache_clear()
+    get_acteur_types_from_webapp.cache_clear()
+    get_acteur_columns_from_webapp.cache_clear()
+    yield
+    get_sources_from_webapp.cache_clear()
+    get_acteur_types_from_webapp.cache_clear()
+    get_acteur_columns_from_webapp.cache_clear()
 
-    def test_from_env_and_strips_trailing_slash(self, monkeypatch):
-        monkeypatch.setenv("WEBAPP_URL", "https://webapp.example.org/")
-        assert webapp_url() == "https://webapp.example.org"
 
-
-class TestActeursMetadata:
-    @pytest.fixture(autouse=True)
-    def clear_cache(self):
-        acteurs_metadata.cache_clear()
-        yield
-        acteurs_metadata.cache_clear()
+class TestGetSourcesFromWebapp:
 
     def test_calls_webapp_api(self, monkeypatch):
-        monkeypatch.setenv("WEBAPP_URL", "https://webapp.example.org")
+        monkeypatch.setattr("utils.webapp.WEBAPP_URL", "https://webapp.example.org")
         response = MagicMock()
-        response.json.return_value = METADATA
+        response.json.return_value = SOURCES
         with patch("utils.webapp.requests.get", return_value=response) as mock_get:
-            assert acteurs_metadata() == METADATA
+            assert get_sources_from_webapp() == SOURCES
         args, kwargs = mock_get.call_args
-        assert args[0] == "https://webapp.example.org/api/qfdmo/metadata/acteurs"
+        assert args[0] == "https://webapp.example.org/api/qfdmo/sources"
         assert kwargs["timeout"]
 
     def test_result_is_cached(self, monkeypatch):
-        monkeypatch.setenv("WEBAPP_URL", "https://webapp.example.org")
+        monkeypatch.setattr("utils.webapp.WEBAPP_URL", "https://webapp.example.org")
         response = MagicMock()
-        response.json.return_value = METADATA
+        response.json.return_value = SOURCES
         with patch("utils.webapp.requests.get", return_value=response) as mock_get:
-            acteurs_metadata()
-            acteurs_metadata()
+            get_sources_from_webapp()
+            get_sources_from_webapp()
         assert mock_get.call_count == 1
 
     def test_explicit_error_when_unreachable(self):
         with patch("utils.webapp.requests.get", side_effect=requests.ConnectionError()):
             with pytest.raises(RuntimeError, match="Webapp API unreachable"):
-                acteurs_metadata()
+                get_sources_from_webapp()
+
+
+class TestGetActeurTypesFromWebapp:
+    def test_calls_webapp_api(self, monkeypatch):
+        monkeypatch.setattr("utils.webapp.WEBAPP_URL", "https://webapp.example.org")
+        response = MagicMock()
+        response.json.return_value = ACTEUR_TYPES
+        with patch("utils.webapp.requests.get", return_value=response) as mock_get:
+            assert get_acteur_types_from_webapp() == ACTEUR_TYPES
+        args, kwargs = mock_get.call_args
+        assert args[0] == "https://webapp.example.org/api/qfdmo/acteurs/types"
+        assert kwargs["timeout"]
+
+
+class TestGetActeurColumnsFromWebapp:
+
+    def test_calls_webapp_api(self, monkeypatch):
+        monkeypatch.setattr("utils.webapp.WEBAPP_URL", "https://webapp.example.org")
+        response = MagicMock()
+        response.json.return_value = ACTEUR_COLUMNS
+        with patch("utils.webapp.requests.get", return_value=response) as mock_get:
+            assert get_acteur_columns_from_webapp() == ACTEUR_COLUMNS
+        args, kwargs = mock_get.call_args
+        assert args[0] == "https://webapp.example.org/api/qfdmo/acteurs/columns"
+        assert kwargs["timeout"]

--- a/data-platform/dags/tests/utils/test_webapp.py
+++ b/data-platform/dags/tests/utils/test_webapp.py
@@ -1,0 +1,56 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from utils.webapp import WEBAPP_URL_DEFAULT, acteurs_metadata, webapp_url
+
+METADATA = {
+    "sources": {"source1": 1},
+    "acteur_types": {"type1": 10},
+    "model_fields": {
+        "vue_acteur": {"with_properties": ["nom", "latitude"], "db_only": ["nom"]},
+        "revision_acteur": {"with_properties": ["nom"], "db_only": ["nom"]},
+    },
+}
+
+
+class TestWebappUrl:
+    def test_default(self, monkeypatch):
+        monkeypatch.delenv("WEBAPP_URL", raising=False)
+        assert webapp_url() == WEBAPP_URL_DEFAULT
+
+    def test_from_env_and_strips_trailing_slash(self, monkeypatch):
+        monkeypatch.setenv("WEBAPP_URL", "https://webapp.example.org/")
+        assert webapp_url() == "https://webapp.example.org"
+
+
+class TestActeursMetadata:
+    @pytest.fixture(autouse=True)
+    def clear_cache(self):
+        acteurs_metadata.cache_clear()
+        yield
+        acteurs_metadata.cache_clear()
+
+    def test_calls_webapp_api(self, monkeypatch):
+        monkeypatch.setenv("WEBAPP_URL", "https://webapp.example.org")
+        response = MagicMock()
+        response.json.return_value = METADATA
+        with patch("utils.webapp.requests.get", return_value=response) as mock_get:
+            assert acteurs_metadata() == METADATA
+        args, kwargs = mock_get.call_args
+        assert args[0] == "https://webapp.example.org/api/qfdmo/metadata/acteurs"
+        assert kwargs["timeout"]
+
+    def test_result_is_cached(self, monkeypatch):
+        monkeypatch.setenv("WEBAPP_URL", "https://webapp.example.org")
+        response = MagicMock()
+        response.json.return_value = METADATA
+        with patch("utils.webapp.requests.get", return_value=response) as mock_get:
+            acteurs_metadata()
+            acteurs_metadata()
+        assert mock_get.call_count == 1
+
+    def test_explicit_error_when_unreachable(self):
+        with patch("utils.webapp.requests.get", side_effect=requests.ConnectionError()):
+            with pytest.raises(RuntimeError, match="Webapp API unreachable"):
+                acteurs_metadata()

--- a/data-platform/dags/utils/webapp.py
+++ b/data-platform/dags/utils/webapp.py
@@ -1,0 +1,46 @@
+"""Utilities to fetch webapp data through its HTTP API.
+
+Used at DAG parse time instead of the Django ORM so the DAG processor
+doesn't pay the cost of django.setup() + DB connections on every parse
+(which caused DagBag import timeouts, see
+https://airflow.apache.org/docs/apache-airflow/stable/best-practices.html#top-level-python-code)
+"""
+
+import functools
+import os
+
+import requests
+
+WEBAPP_URL_DEFAULT = "http://host.docker.internal:8000"
+TIMEOUT_SECONDS = 10
+
+
+def webapp_url() -> str:
+    """Base URL of the webapp, configurable via the WEBAPP_URL env var"""
+    return os.environ.get("WEBAPP_URL", WEBAPP_URL_DEFAULT).rstrip("/")
+
+
+@functools.lru_cache(maxsize=1)
+def acteurs_metadata() -> dict:
+    """Referentials (sources, acteur types) and acteurs model fields
+    from the webapp API, see /api/qfdmo/metadata/acteurs:
+    {
+        "sources": {code: id, ...},
+        "acteur_types": {code: id, ...},
+        "model_fields": {
+            "vue_acteur": {"with_properties": [...], "db_only": [...]},
+            "revision_acteur": {"with_properties": [...], "db_only": [...]},
+        },
+    }
+    """
+    url = f"{webapp_url()}/api/qfdmo/metadata/acteurs"
+    try:
+        response = requests.get(url, timeout=TIMEOUT_SECONDS)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        raise RuntimeError(
+            f"Webapp API unreachable at {url}: check that the webapp is"
+            " running (locally: `cd webapp && make runserver`) and that"
+            " the WEBAPP_URL env var points to it"
+        ) from e
+    return response.json()

--- a/data-platform/dags/utils/webapp.py
+++ b/data-platform/dags/utils/webapp.py
@@ -7,33 +7,18 @@ https://airflow.apache.org/docs/apache-airflow/stable/best-practices.html#top-le
 """
 
 import functools
-import os
 
 import requests
+from decouple import config
 
-WEBAPP_URL_DEFAULT = "http://host.docker.internal:8000"
 TIMEOUT_SECONDS = 10
 
-
-def webapp_url() -> str:
-    """Base URL of the webapp, configurable via the WEBAPP_URL env var"""
-    return os.environ.get("WEBAPP_URL", WEBAPP_URL_DEFAULT).rstrip("/")
+WEBAPP_URL = config("WEBAPP_URL", default="http://host.docker.internal:8000")
 
 
-@functools.lru_cache(maxsize=1)
-def acteurs_metadata() -> dict:
-    """Referentials (sources, acteur types) and acteurs model fields
-    from the webapp API, see /api/qfdmo/metadata/acteurs:
-    {
-        "sources": {code: id, ...},
-        "acteur_types": {code: id, ...},
-        "model_fields": {
-            "vue_acteur": {"with_properties": [...], "db_only": [...]},
-            "revision_acteur": {"with_properties": [...], "db_only": [...]},
-        },
-    }
-    """
-    url = f"{webapp_url()}/api/qfdmo/metadata/acteurs"
+def _get_json(path: str):
+    """GET JSON from the webapp API, or raise a clear error if unreachable"""
+    url = f"{WEBAPP_URL}{path}"
     try:
         response = requests.get(url, timeout=TIMEOUT_SECONDS)
         response.raise_for_status()
@@ -44,3 +29,26 @@ def acteurs_metadata() -> dict:
             " the WEBAPP_URL env var points to it"
         ) from e
     return response.json()
+
+
+@functools.lru_cache(maxsize=1)
+def get_sources_from_webapp() -> list[dict]:
+    """Get the list of sources from the webapp API"""
+    return _get_json("/api/qfdmo/sources")
+
+
+@functools.lru_cache(maxsize=1)
+def get_acteur_types_from_webapp() -> list[dict]:
+    """Get the list of acteur types from the webapp API"""
+    return _get_json("/api/qfdmo/acteurs/types")
+
+
+@functools.lru_cache(maxsize=1)
+def get_acteur_columns_from_webapp() -> dict:
+    """Get the list of acteur columns from the webapp API:
+    {
+        "vue_acteur": {"with_properties": [...], "db_only": [...]},
+        "revision_acteur": {"with_properties": [...], "db_only": [...]},
+    }
+    """
+    return _get_json("/api/qfdmo/acteurs/columns")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,7 @@ services:
     profiles: [lvao, airflow]
 
   lvao-warehouse-db:
+    platform: linux/amd64
     image: postgis/postgis:15-3.3-alpine
     environment:
       - POSTGRES_USER=warehouse

--- a/infrastructure/environments/preprod/airflow_containers/terragrunt.hcl
+++ b/infrastructure/environments/preprod/airflow_containers/terragrunt.hcl
@@ -100,4 +100,6 @@ inputs = {
 
   AIRFLOW__DAG_PROCESSOR__MIN_FILE_PROCESS_INTERVAL = 300
   AIRFLOW__DAG_PROCESSOR__PARSING_PROCESSES         = 1
+
+  WEBAPP_URL = "https://quefairedemesdechets.incubateur.ademe.dev"
 }

--- a/infrastructure/environments/prod/airflow_containers/terragrunt.hcl
+++ b/infrastructure/environments/prod/airflow_containers/terragrunt.hcl
@@ -100,4 +100,6 @@ inputs = {
 
   AIRFLOW__DAG_PROCESSOR__MIN_FILE_PROCESS_INTERVAL = 300
   AIRFLOW__DAG_PROCESSOR__PARSING_PROCESSES         = 1
+
+  WEBAPP_URL = "https://quefairedemesdechets.ademe.fr"
 }

--- a/infrastructure/modules/airflow_containers/airflow-dag-processor.tf
+++ b/infrastructure/modules/airflow_containers/airflow-dag-processor.tf
@@ -40,6 +40,7 @@ resource "scaleway_container" "airflow_dag_processor" {
     AIRFLOW__WEBSERVER__EXPOSE_CONFIG                     = "true"
     AIRFLOW__WEBSERVER__WARN_DEPLOYMENT_EXPOSURE          = "false"
     ENVIRONMENT                                           = var.environment
+    WEBAPP_URL                                            = var.WEBAPP_URL
   }
   secret_environment_variables = {
     AIRFLOW__CORE__EXECUTION_API_SERVER_URL = "https://${scaleway_container.airflow_webserver.domain_name}/execution/"

--- a/infrastructure/modules/airflow_containers/airflow-scheduler.tf
+++ b/infrastructure/modules/airflow_containers/airflow-scheduler.tf
@@ -39,6 +39,7 @@ resource "scaleway_container" "airflow_scheduler" {
     AIRFLOW__WEBSERVER__EXPOSE_CONFIG                     = "true"
     AIRFLOW__WEBSERVER__WARN_DEPLOYMENT_EXPOSURE          = "false"
     ENVIRONMENT                                           = var.environment
+    WEBAPP_URL                                            = var.WEBAPP_URL
   }
   secret_environment_variables = {
     AIRFLOW__CORE__EXECUTION_API_SERVER_URL = "https://${scaleway_container.airflow_webserver.domain_name}/execution/"

--- a/infrastructure/modules/airflow_containers/variables.tf
+++ b/infrastructure/modules/airflow_containers/variables.tf
@@ -167,3 +167,7 @@ variable "AIRFLOW__DAG_PROCESSOR__MIN_FILE_PROCESS_INTERVAL" {
 variable "AIRFLOW__DAG_PROCESSOR__PARSING_PROCESSES" {
   type = number
 }
+variable "WEBAPP_URL" {
+  description = "Webapp base URL for API calls from DAGs (parse time and runtime)"
+  type        = string
+}

--- a/webapp/.env.template
+++ b/webapp/.env.template
@@ -1,4 +1,5 @@
 # AWS credentials, needed for images s3 storage (using Scaleway)
+ALLOWED_HOSTS=localhost,127.0.0.1,testserver,gunicorn,host.docker.internal
 AWS_ACCESS_KEY_ID=
 AWS_S3_ENDPOINT_URL='https://s3.fr-par.scw.cloud'
 AWS_S3_REGION_NAME='fr-par'

--- a/webapp/integration_tests/carte/test_qfdmo_api.py
+++ b/webapp/integration_tests/carte/test_qfdmo_api.py
@@ -232,3 +232,34 @@ def test_get_sous_categories(client):
         assert "code" in data[0]
         assert "id" in data[0]
         assert "libelle" in data[0]
+
+
+@pytest.mark.django_db
+def test_get_metadata_acteurs(client):
+    """Test the /metadata/acteurs endpoint used by the data-platform"""
+    # Unlike /sources, all sources are returned (even hidden ones)
+    # because DAGs must be able to work on all of them
+    displayed_source = SourceFactory(afficher=True)
+    hidden_source = SourceFactory(afficher=False)
+
+    response = client.get(f"{BASE_URL}/metadata/acteurs")
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["sources"][displayed_source.code] == displayed_source.id
+    assert data["sources"][hidden_source.code] == hidden_source.id
+    # acteur_types loaded via fixtures
+    assert data["acteur_types"]
+    assert all(isinstance(x, int) for x in data["acteur_types"].values())
+
+    model_fields = data["model_fields"]
+    for model in ["vue_acteur", "revision_acteur"]:
+        assert "nom" in model_fields[model]["db_only"]
+        assert "nom" in model_fields[model]["with_properties"]
+        # db_only is a subset of with_properties
+        assert set(model_fields[model]["db_only"]) <= set(
+            model_fields[model]["with_properties"]
+        )
+    # properties (ex: latitude on RevisionActeur) are only in with_properties
+    assert "latitude" in model_fields["revision_acteur"]["with_properties"]
+    assert "latitude" not in model_fields["revision_acteur"]["db_only"]

--- a/webapp/integration_tests/carte/test_qfdmo_api.py
+++ b/webapp/integration_tests/carte/test_qfdmo_api.py
@@ -235,31 +235,17 @@ def test_get_sous_categories(client):
 
 
 @pytest.mark.django_db
-def test_get_metadata_acteurs(client):
-    """Test the /metadata/acteurs endpoint used by the data-platform"""
-    # Unlike /sources, all sources are returned (even hidden ones)
-    # because DAGs must be able to work on all of them
-    displayed_source = SourceFactory(afficher=True)
-    hidden_source = SourceFactory(afficher=False)
-
-    response = client.get(f"{BASE_URL}/metadata/acteurs")
+def test_get_acteurs_columns(client):
+    """Test the /acteurs/columns endpoint used by the data-platform"""
+    response = client.get(f"{BASE_URL}/acteurs/columns")
     assert response.status_code == 200
     data = response.json()
 
-    assert data["sources"][displayed_source.code] == displayed_source.id
-    assert data["sources"][hidden_source.code] == hidden_source.id
-    # acteur_types loaded via fixtures
-    assert data["acteur_types"]
-    assert all(isinstance(x, int) for x in data["acteur_types"].values())
-
-    model_fields = data["model_fields"]
     for model in ["vue_acteur", "revision_acteur"]:
-        assert "nom" in model_fields[model]["db_only"]
-        assert "nom" in model_fields[model]["with_properties"]
+        assert "nom" in data[model]["db_only"]
+        assert "nom" in data[model]["with_properties"]
         # db_only is a subset of with_properties
-        assert set(model_fields[model]["db_only"]) <= set(
-            model_fields[model]["with_properties"]
-        )
+        assert set(data[model]["db_only"]) <= set(data[model]["with_properties"])
     # properties (ex: latitude on RevisionActeur) are only in with_properties
-    assert "latitude" in model_fields["revision_acteur"]["with_properties"]
-    assert "latitude" not in model_fields["revision_acteur"]["db_only"]
+    assert "latitude" in data["revision_acteur"]["with_properties"]
+    assert "latitude" not in data["revision_acteur"]["db_only"]

--- a/webapp/qfdmo/api.py
+++ b/webapp/qfdmo/api.py
@@ -129,8 +129,8 @@ class ActeurFilterSchema(FilterSchema):
 @router.get("/sources", response=List[SourceSchema], summary="Liste des sources")
 def sources(request):
     """
-    Liste l'ensemble des <i>sources</i> possibles pour un acteur.
-    """  # noqa
+    List the possible <i>sources</i> for an actor.
+    """
     qs = Source.objects.filter(afficher=True)
     return qs
 
@@ -142,8 +142,8 @@ def sources(request):
 )
 def sous_categories(request):
     """
-    Liste l'ensemble des <i>sous-catégories d'objet</i> possibles pour un acteur.
-    """  # noqa
+    List the possible <i>sub-categories of objects</i> for an actor.
+    """
     qs = SousCategorieObjet.objects.filter(afficher=True)
     return qs
 
@@ -153,8 +153,8 @@ def sous_categories(request):
 )
 def actions(request):
     """
-    Liste l'ensemble des <i>actions</i> possibles sur un objet / déchet.
-    """  # noqa
+    List the possible <i>actions</i> on an object / waste.
+    """
     qs = Action.objects.all()
     return qs
 
@@ -166,8 +166,8 @@ def actions(request):
 )
 def groupe_actions(request):
     """
-    Liste l'ensemble des <i>actions</i> possibles sur un objet / déchet.
-    """  # noqa
+    List the possible <i>actions</i> on an object / waste.
+    """
     qs = GroupeAction.objects.all()
     return qs
 
@@ -182,14 +182,16 @@ def acteurs(
     rayon: int = 2,
 ):
     """
-    Les acteurs correspondant à un point sur la carte Que faire de mes objets et déchets
+    The actors corresponding to a point on the "Que faire de mes objets et déchets" map.
 
-    Pour retrouver les acteurs à proximité :
-    - Indiquer une latitude / longitude (exemple : latitude=48.86 et longitude=2.3)
-    - Indiquer un rayon (optionnel) en km : les résultats en dehors de ce rayon ne seront pas retournés
+    To find actors near a point:
+    - provide a latitude / longitude (example: latitude=48.86 and longitude=2.3)
+    - provide a radius (optional) in km: results outside this radius will not be
+      returned
 
-    Si la latitude ou longitude sont manquantes, alors tous les résultats seront retournés triés par nom.
-    """  # noqa
+    If the latitude or longitude are missing, then all results will be returned sorted
+    by name.
+    """
     qs = DisplayedActeur.objects.filter(
         statut=ActeurStatus.ACTIF,
     ).order_by("nom")
@@ -218,8 +220,8 @@ def acteurs(
 )
 def acteurs_types(request):
     """
-    Liste l'ensemble des <i>types</i> d'acteurs possibles.
-    """  # noqa
+    List the possible <i>types</i> of actors.
+    """
     qs = ActeurType.objects.all()
     return qs
 
@@ -232,7 +234,7 @@ def acteurs_types(request):
 def services(request):
     """
     Liste l'ensemble des <i>services</i> qui peuvent être proposés par un acteur.
-    """  # noqa
+    """
     qs = ActeurService.objects.all()
     return qs
 
@@ -287,35 +289,23 @@ class ModelFieldsSchema(Schema):
     db_only: List[str]
 
 
-class ActeursMetadataSchema(Schema):
-    sources: dict[str, int]
-    acteur_types: dict[str, int]
-    model_fields: dict[str, ModelFieldsSchema]
-
-
 @router.get(
-    "/metadata/acteurs",
-    response=ActeursMetadataSchema,
-    summary="Métadonnées des modèles acteurs (usage interne data-platform)",
+    "/acteurs/columns",
+    response=dict[str, ModelFieldsSchema],
+    summary="Champs des modèles acteurs",
 )
-def acteurs_metadata(request):
+def acteurs_columns(request):
     """
-    Expose les référentiels (sources, types d'acteur) et les champs des
-    modèles acteurs. Utilisé par la data-platform (Airflow) pour construire
-    les paramètres des DAGs (ex: cluster_acteur_suggestions) sans dépendre
-    d'un accès direct à la base de données de la webapp au parsing des DAGs.
-    """  # noqa
+    Actor models columns.
+    Used by the data-platform (Airflow) to build the DAGs parameters.
+    """
     return {
-        "sources": {s.code: s.id for s in Source.objects.all()},
-        "acteur_types": {t.code: t.id for t in ActeurType.objects.all()},
-        "model_fields": {
-            "vue_acteur": {
-                "with_properties": _model_field_names(VueActeur),
-                "db_only": _model_field_names(VueActeur, include_properties=False),
-            },
-            "revision_acteur": {
-                "with_properties": _model_field_names(RevisionActeur),
-                "db_only": _model_field_names(RevisionActeur, include_properties=False),
-            },
+        "vue_acteur": {
+            "with_properties": _model_field_names(VueActeur),
+            "db_only": _model_field_names(VueActeur, include_properties=False),
+        },
+        "revision_acteur": {
+            "with_properties": _model_field_names(RevisionActeur),
+            "db_only": _model_field_names(RevisionActeur, include_properties=False),
         },
     }

--- a/webapp/qfdmo/api.py
+++ b/webapp/qfdmo/api.py
@@ -5,7 +5,7 @@ from django.contrib.gis.db.models.functions import Distance
 from django.contrib.gis.geos import Point
 from django.contrib.gis.measure import D
 from django.shortcuts import get_object_or_404
-from ninja import Field, FilterSchema, ModelSchema, Query, Router
+from ninja import Field, FilterSchema, ModelSchema, Query, Router, Schema
 from ninja.pagination import paginate
 from qfdmo.admin.acteur import GenericExporterMixin
 from qfdmo.geo_api import search_epci_code
@@ -16,8 +16,10 @@ from qfdmo.models import (
     Action,
     DisplayedActeur,
     GroupeAction,
+    RevisionActeur,
     Source,
     SousCategorieObjet,
+    VueActeur,
 )
 
 router = Router()
@@ -249,3 +251,71 @@ def acteur(request, identifiant_unique: str):
 @router.get("/autocomplete/configurateur")
 def autocomplete_epcis(request, query: str):
     return search_epci_code(query)
+
+
+def _model_field_names(model_class, include_properties=True) -> list[str]:
+    """Field names of a Django model, mirroring the behaviour of
+    the data-platform's `django_model_fields_get` so Airflow DAGs
+    can build their UI params from the API instead of the ORM.
+
+    Always excluded: internals (pk) & ManyToMany
+    """
+    from django.db import models
+    from django.utils.functional import cached_property
+
+    excluded = ["pk"]
+
+    fields = [
+        x.name
+        for x in model_class._meta.get_fields()
+        # ManyToMany case causing massive performance issues (e.g. on "sources")
+        if not isinstance(x, models.ManyToManyField)
+    ]
+
+    attributes = []
+    if include_properties:
+        for attr_name in dir(model_class):
+            attr = getattr(model_class, attr_name, None)
+            if isinstance(attr, (property, cached_property)):
+                attributes.append(attr_name)
+
+    return [x for x in fields + attributes if x not in excluded]
+
+
+class ModelFieldsSchema(Schema):
+    with_properties: List[str]
+    db_only: List[str]
+
+
+class ActeursMetadataSchema(Schema):
+    sources: dict[str, int]
+    acteur_types: dict[str, int]
+    model_fields: dict[str, ModelFieldsSchema]
+
+
+@router.get(
+    "/metadata/acteurs",
+    response=ActeursMetadataSchema,
+    summary="Métadonnées des modèles acteurs (usage interne data-platform)",
+)
+def acteurs_metadata(request):
+    """
+    Expose les référentiels (sources, types d'acteur) et les champs des
+    modèles acteurs. Utilisé par la data-platform (Airflow) pour construire
+    les paramètres des DAGs (ex: cluster_acteur_suggestions) sans dépendre
+    d'un accès direct à la base de données de la webapp au parsing des DAGs.
+    """  # noqa
+    return {
+        "sources": {s.code: s.id for s in Source.objects.all()},
+        "acteur_types": {t.code: t.id for t in ActeurType.objects.all()},
+        "model_fields": {
+            "vue_acteur": {
+                "with_properties": _model_field_names(VueActeur),
+                "db_only": _model_field_names(VueActeur, include_properties=False),
+            },
+            "revision_acteur": {
+                "with_properties": _model_field_names(RevisionActeur),
+                "db_only": _model_field_names(RevisionActeur, include_properties=False),
+            },
+        },
+    }


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [Résoudre Airflow v3 qui perd les DAGs](https://app.notion.com/p/accelerateur-transition-ecologique-ademe/R-soudre-Airflow-v3-qui-perd-les-DAGs-3796523d57d78008a30bfb2f3f0dad7c?v=7fa49e1bda7e4f8baed5d646aef65fbe&source=copy_link)


**🗺️ contexte**: Airflow - Clustering

**💡 quoi**: Très souvent le DAG de clustering n'est pas dispo car le dag_processor met trop de temps à l'interpréter

**🎯 pourquoi**: Certainement parce qu'on charge trop de dépendances, parmis celle-ci, on chage la webapp pour permettre à l'utilisateur de configurer son DAG selon des information qui viennent de la webapp : source, acteur_type, colonnes des objets Acteurs

**🤔 comment**: 

Au lieu de charger le module webapp qui est un peu lourd car il embarque Django et wagtail, on utilise l'API de la webapp pour aller chercher les informations à afficher dans les paramètres du DAG.
Du coup, le DAG processor n'a plus besoin de charger lemodule webapp

**🤓 comment tester**: 

- Lancer Airflow
- Lancer un DAG de clustering
- Tous les paramètres doivent-être configurable

## Exemple résultats / UI / Data

<img width="2700" height="1620" alt="CleanShot 2026-08-04 at 11 50 23@2x" src="https://github.com/user-attachments/assets/c43e13c6-5cc9-43bd-baf9-222957076f14" />

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] Ajouter la variable d'environnement `WEBAPP_URL` via le déploiement de l'infrastructure
