### PR TITLE
Gestion des identifiants nulles pour la CMA

### DIFF
--- a/data-platform/dags/cluster/config/metadata.py
+++ b/data-platform/dags/cluster/config/metadata.py
@@ -2,10 +2,10 @@ METADATA_NUMBER_OF_UPDATES_BY_FIELD = "Nombre de mises à jour par champ"
 METADATA_ANONYMIZED_ACTEURS_IGNORED = (
     "Nombre d'acteurs mis à jour ignorés car anonymisés pour RGPD"
 )
-METADATA_SERVICE_DOMICILE_FILTERED = (
-    "Nombre d'acteurs filtrés car service à domicile uniquement"
-)
 METADATA_NO_SOUS_CATEGORIE_FILTERED = "Nombre d'acteurs filtrés car sans sous_categorie"
 METADATA_DUPLICATES_FILTERED = (
     "Nombre d'acteurs filtrés car doublons sur identifiant_unique"
+)
+METADATA_NO_LOCATION_FILTERED = (
+    "Nombre d'acteurs filtrés car sans localisation (non digitaux)"
 )

--- a/data-platform/dags/sources/config/models.py
+++ b/data-platform/dags/sources/config/models.py
@@ -71,6 +71,8 @@ class SourceConfig(BaseModel):
     oca: OCAConfig | None = None
     returnable_objects: bool = False
     use_legacy_suggestions: bool = False
+    # Lignes ignorées après téléchargement si l'un de ces champs est null
+    ignore_rows_with_null_or_empty_fields: list[str] = []
 
     @field_validator("endpoint")
     def validate_endpoint(cls, endpoint):

--- a/data-platform/dags/sources/dags/source_cma.py
+++ b/data-platform/dags/sources/dags/source_cma.py
@@ -1,6 +1,7 @@
 import json
 
 from airflow import DAG
+from airflow.sdk import Param
 from airflow.sdk.definitions.param import ParamsDict
 from shared.config.airflow import DEFAULT_ARGS
 from shared.config.tags import TAGS
@@ -10,6 +11,171 @@ from utils.django import django_setup_full
 
 django_setup_full()
 from qfdmo.models.acteur import ActeurPublicAccueilli, ActeurStatus  # noqa: E402
+
+NORMALIZATION_RULES = [
+    # 1. Renommage des colonnes
+    {
+        "origin": "horaires",
+        "destination": "horaires_description",
+    },
+    {
+        "origin": "id",
+        "destination": "identifiant_externe",
+    },
+    {
+        "origin": "nafa",
+        "destination": "naf_principal",
+    },
+    {
+        "origin": "adresse_2",
+        "destination": "adresse_complement",
+    },
+    {
+        "origin": "final_latitude",
+        "destination": "latitude",
+    },
+    {
+        "origin": "final_longitude",
+        "destination": "longitude",
+    },
+    # 2. Transformation des colonnes
+    {
+        "origin": "code_postal",
+        "transformation": "clean_code_postal",
+        "destination": "code_postal",
+    },
+    {
+        "origin": "categories",
+        "transformation": "clean_sous_categorie_codes",
+        "destination": "sous_categorie_codes",
+    },
+    {
+        "origin": "email",
+        "transformation": "clean_email",
+        "destination": "email",
+    },
+    {
+        "origin": "nom",
+        "transformation": "strip_string",
+        "destination": "nom",
+    },
+    {
+        "origin": "adresse",
+        "transformation": "strip_string",
+        "destination": "adresse",
+    },
+    {
+        "origin": "description",
+        "transformation": "strip_string",
+        "destination": "description",
+    },
+    {
+        "origin": "ville",
+        "transformation": "strip_string",
+        "destination": "ville",
+    },
+    # 3. Ajout des colonnes avec une valeur par défaut
+    {
+        "column": "statut",
+        "value": ActeurStatus.ACTIF,
+    },
+    {
+        "column": "label_codes",
+        "value": ["reparacteur"],
+    },
+    {
+        "column": "acteur_type_code",
+        "value": "artisan",
+    },
+    {
+        "column": "acteur_service_codes",
+        "value": ["service_de_reparation"],
+    },
+    {
+        "column": "action_codes",
+        "value": ["reparer"],
+    },
+    {
+        "column": "public_accueilli",
+        "value": ActeurPublicAccueilli.PARTICULIERS,
+    },
+    {
+        "column": "source_code",
+        "value": "cma_reparacteur",
+    },
+    # 4. Transformation du dataframe
+    {
+        "origin": ["website", "facebook", "instagram"],
+        "transformation": "clean_url_from_multi_columns",
+        "destination": ["url"],
+    },
+    {
+        "origin": ["latitude", "longitude"],
+        "transformation": "compute_location",
+        "destination": ["location", "latitude", "longitude"],
+    },
+    {
+        "origin": ["siret"],
+        "transformation": "clean_siret_and_siren",
+        "destination": ["siret", "siren"],
+    },
+    {
+        "origin": ["telephone", "code_postal"],
+        "transformation": "clean_telephone",
+        "destination": ["telephone"],
+    },
+    {
+        "origin": ["identifiant_externe", "nom"],
+        "transformation": "clean_identifiant_externe",
+        "destination": ["identifiant_externe"],
+    },
+    {
+        "origin": [
+            "identifiant_externe",
+            "source_code",
+        ],
+        "transformation": "clean_identifiant_unique",
+        "destination": ["identifiant_unique"],
+    },
+    {
+        "origin": ["action_codes", "sous_categorie_codes"],
+        "transformation": "clean_proposition_services",
+        "destination": ["proposition_service_codes"],
+    },
+    # 5. Supression des colonnes
+    {"remove": "activite"},
+    {"remove": "activites_detaillees"},
+    {"remove": "ban_latitude"},
+    {"remove": "ban_longitude"},
+    {"remove": "categorie_2"},
+    {"remove": "categorie_3"},
+    {"remove": "categorie"},
+    {"remove": "cma_code"},
+    {"remove": "code_departement"},
+    {"remove": "code_region"},
+    {"remove": "cog"},
+    {"remove": "date_creation_entreprise"},
+    {"remove": "departement"},
+    {"remove": "eco_maison"},
+    {"remove": "effectif"},
+    {"remove": "facebook"},
+    {"remove": "final_latitude"},
+    {"remove": "final_longitude"},
+    {"remove": "geocode"},
+    {"remove": "instagram"},
+    {"remove": "libelle_naf"},
+    {"remove": "linkedin"},
+    {"remove": "logo_file"},
+    {"remove": "naf"},
+    {"remove": "nom_gerant"},
+    {"remove": "region"},
+    {"remove": "rgpd"},
+    {"remove": "techloadts"},
+    {"remove": "techprocessid"},
+    {"remove": "techsource"},
+    {"remove": "website"},
+    # 6. Colonnes à garder (rien à faire, utilisé pour le controle)
+]
 
 with DAG(
     dag_id="cma",
@@ -29,176 +195,23 @@ with DAG(
     **default_params,
     params=ParamsDict(
         {
-            "normalization_rules": json.dumps(
-                [
-                    # 1. Renommage des colonnes
-                    {
-                        "origin": "horaires",
-                        "destination": "horaires_description",
-                    },
-                    {
-                        "origin": "id",
-                        "destination": "identifiant_externe",
-                    },
-                    {
-                        "origin": "nafa",
-                        "destination": "naf_principal",
-                    },
-                    {
-                        "origin": "adresse_2",
-                        "destination": "adresse_complement",
-                    },
-                    {
-                        "origin": "final_latitude",
-                        "destination": "latitude",
-                    },
-                    {
-                        "origin": "final_longitude",
-                        "destination": "longitude",
-                    },
-                    # 2. Transformation des colonnes
-                    {
-                        "origin": "code_postal",
-                        "transformation": "clean_code_postal",
-                        "destination": "code_postal",
-                    },
-                    {
-                        "origin": "categories",
-                        "transformation": "clean_sous_categorie_codes",
-                        "destination": "sous_categorie_codes",
-                    },
-                    {
-                        "origin": "email",
-                        "transformation": "clean_email",
-                        "destination": "email",
-                    },
-                    {
-                        "origin": "nom",
-                        "transformation": "strip_string",
-                        "destination": "nom",
-                    },
-                    {
-                        "origin": "adresse",
-                        "transformation": "strip_string",
-                        "destination": "adresse",
-                    },
-                    {
-                        "origin": "description",
-                        "transformation": "strip_string",
-                        "destination": "description",
-                    },
-                    {
-                        "origin": "ville",
-                        "transformation": "strip_string",
-                        "destination": "ville",
-                    },
-                    # 3. Ajout des colonnes avec une valeur par défaut
-                    {
-                        "column": "statut",
-                        "value": ActeurStatus.ACTIF,
-                    },
-                    {
-                        "column": "label_codes",
-                        "value": ["reparacteur"],
-                    },
-                    {
-                        "column": "acteur_type_code",
-                        "value": "artisan",
-                    },
-                    {
-                        "column": "acteur_service_codes",
-                        "value": ["service_de_reparation"],
-                    },
-                    {
-                        "column": "action_codes",
-                        "value": ["reparer"],
-                    },
-                    {
-                        "column": "public_accueilli",
-                        "value": ActeurPublicAccueilli.PARTICULIERS,
-                    },
-                    {
-                        "column": "source_code",
-                        "value": "cma_reparacteur",
-                    },
-                    # 4. Transformation du dataframe
-                    {
-                        "origin": ["website", "facebook", "instagram"],
-                        "transformation": "clean_url_from_multi_columns",
-                        "destination": ["url"],
-                    },
-                    {
-                        "origin": ["latitude", "longitude"],
-                        "transformation": "compute_location",
-                        "destination": ["location", "latitude", "longitude"],
-                    },
-                    {
-                        "origin": ["siret"],
-                        "transformation": "clean_siret_and_siren",
-                        "destination": ["siret", "siren"],
-                    },
-                    {
-                        "origin": ["telephone", "code_postal"],
-                        "transformation": "clean_telephone",
-                        "destination": ["telephone"],
-                    },
-                    {
-                        "origin": ["identifiant_externe", "nom"],
-                        "transformation": "clean_identifiant_externe",
-                        "destination": ["identifiant_externe"],
-                    },
-                    {
-                        "origin": [
-                            "identifiant_externe",
-                            "source_code",
-                        ],
-                        "transformation": "clean_identifiant_unique",
-                        "destination": ["identifiant_unique"],
-                    },
-                    {
-                        "origin": ["action_codes", "sous_categorie_codes"],
-                        "transformation": "clean_proposition_services",
-                        "destination": ["proposition_service_codes"],
-                    },
-                    # 5. Supression des colonnes
-                    {"remove": "activite"},
-                    {"remove": "activites_detaillees"},
-                    {"remove": "ban_latitude"},
-                    {"remove": "ban_longitude"},
-                    {"remove": "categorie_2"},
-                    {"remove": "categorie_3"},
-                    {"remove": "categorie"},
-                    {"remove": "cma_code"},
-                    {"remove": "code_departement"},
-                    {"remove": "code_region"},
-                    {"remove": "cog"},
-                    {"remove": "date_creation_entreprise"},
-                    {"remove": "departement"},
-                    {"remove": "eco_maison"},
-                    {"remove": "effectif"},
-                    {"remove": "facebook"},
-                    {"remove": "final_latitude"},
-                    {"remove": "final_longitude"},
-                    {"remove": "geocode"},
-                    {"remove": "instagram"},
-                    {"remove": "libelle_naf"},
-                    {"remove": "linkedin"},
-                    {"remove": "logo_file"},
-                    {"remove": "naf"},
-                    {"remove": "nom_gerant"},
-                    {"remove": "region"},
-                    {"remove": "rgpd"},
-                    {"remove": "techloadts"},
-                    {"remove": "techprocessid"},
-                    {"remove": "techsource"},
-                    {"remove": "website"},
-                    # 6. Colonnes à garder (rien à faire, utilisé pour le controle)
-                ]
-            ),
+            "normalization_rules": json.dumps(NORMALIZATION_RULES),
             "endpoint": ("https://apiopendata.artisanat.fr/reparacteur"),
             "validate_address_with_ban": False,
             "product_mapping": get_mapping_config(mapping_key="sous_categories_cma"),
             "use_legacy_suggestions": False,
+            "ignore_rows_with_null_or_empty_fields": Param(
+                ["id"],
+                type="array",
+                items={"type": "string"},
+                description_md=r"""
+            Liste des champs source (avant normalisation) à contrôler après
+            téléchargement. Si l'un d'eux est null ou vide, la ligne est ignorée.
+
+            Pour CMA, on ignore les acteurs sans `id` par défaut car cet identifiant est
+            requis pour construire `identifiant_externe` puis `identifiant_unique`.
+            """,
+            ),
         }
     ),
 ) as dag:

--- a/data-platform/dags/sources/tasks/airflow_logic/source_data_download_task.py
+++ b/data-platform/dags/sources/tasks/airflow_logic/source_data_download_task.py
@@ -27,15 +27,23 @@ def source_data_download_wrapper(ti, dag, params):
     endpoint = dag_config.endpoint
     metadata_endpoint = dag_config.metadata_endpoint
     s3_connection_id = dag_config.s3_connection_id
+    ignore_rows_with_null_or_empty_fields = (
+        dag_config.ignore_rows_with_null_or_empty_fields
+    )
 
     log.preview("API end point", endpoint)
     if s3_connection_id:
         log.preview("S3 connection id", s3_connection_id)
+    if ignore_rows_with_null_or_empty_fields:
+        log.preview(
+            "ignore_rows_with_null_fields", ignore_rows_with_null_or_empty_fields
+        )
 
     df = source_data_download(
         endpoint=endpoint,
         s3_connection_id=s3_connection_id,
         metadata_endpoint=metadata_endpoint,
+        ignore_rows_with_null_or_empty_fields=ignore_rows_with_null_or_empty_fields,
     )
 
     xcom_push(ti, XCOMS.SOURCE_DOWNLOADED, df)

--- a/data-platform/dags/sources/tasks/business_logic/source_data_download.py
+++ b/data-platform/dags/sources/tasks/business_logic/source_data_download.py
@@ -19,6 +19,12 @@ def drop_rows_with_null_or_empty_fields(
     if not fields:
         return data
 
+    if isinstance(data, pd.DataFrame):
+        logger.warning(
+            "drop_rows_with_null_or_empty_fields is not applied on a DataFrame"
+        )
+        return data
+
     if isinstance(data, list) and data and isinstance(data[0], dict):
         before = len(data)
 

--- a/data-platform/dags/sources/tasks/business_logic/source_data_download.py
+++ b/data-platform/dags/sources/tasks/business_logic/source_data_download.py
@@ -12,10 +12,42 @@ from utils import logging_utils as log
 logger = logging.getLogger(__name__)
 
 
+def drop_rows_with_null_or_empty_fields(
+    data: list | pd.DataFrame, fields: list[str] | None = None
+) -> list | pd.DataFrame:
+    """Supprime les lignes dont au moins un des champs listés est null."""
+    if not fields:
+        return data
+
+    if isinstance(data, list) and data and isinstance(data[0], dict):
+        before = len(data)
+
+        def _has_null_or_empty_field(row: dict) -> bool:
+            return any(
+                row.get(field) is None or row.get(field) == "" for field in fields
+            )
+
+        null_or_empty_rows = [row for row in data if _has_null_or_empty_field(row)]
+        filtered = [row for row in data if not _has_null_or_empty_field(row)]
+        removed = before - len(filtered)
+        if removed:
+            logger.info(
+                "Lignes avec champ(s) null (%s) supprimées : %s / %s",
+                fields,
+                removed,
+                before,
+            )
+            log.preview("lignes avec champ(s) null supprimées", null_or_empty_rows)
+        return filtered
+
+    return data
+
+
 def source_data_download(
     endpoint: str,
     s3_connection_id: str | None = None,
     metadata_endpoint: str | None = None,
+    ignore_rows_with_null_or_empty_fields: list[str] | None = None,
 ) -> pd.DataFrame:
     """Téléchargement de la données source sans lui apporter de modification"""
 
@@ -49,6 +81,13 @@ def source_data_download(
     # tant que possible
     data = fetch_data_from_endpoint(endpoint, s3_connection_id)
     logger.info("Téléchargement données de l'API : ✅ succès.")
+    logger.info(
+        "Suppression des lignes avec champ(s) null ou vide : %s",
+        ignore_rows_with_null_or_empty_fields,
+    )
+    data = drop_rows_with_null_or_empty_fields(
+        data, ignore_rows_with_null_or_empty_fields
+    )
     df = pd.DataFrame(data).replace({pd.NA: None, np.nan: None})
     # create dataframe with only string, boolean or list dtype columns
     for column in df.columns:

--- a/data-platform/dags/sources/tasks/business_logic/source_data_download.py
+++ b/data-platform/dags/sources/tasks/business_logic/source_data_download.py
@@ -31,11 +31,9 @@ def drop_rows_with_null_or_empty_fields(
         filtered = [row for row in data if not _has_null_or_empty_field(row)]
         removed = before - len(filtered)
         if removed:
-            logger.info(
-                "Lignes avec champ(s) null (%s) supprimées : %s / %s",
-                fields,
-                removed,
-                before,
+            logger.error(
+                f"Lignes avec champ(s) null ({fields}) supprimées : "
+                f"{removed} / {before}"
             )
             log.preview("lignes avec champ(s) null supprimées", null_or_empty_rows)
         return filtered

--- a/data-platform/dags/sources/tasks/business_logic/source_data_normalize.py
+++ b/data-platform/dags/sources/tasks/business_logic/source_data_normalize.py
@@ -5,8 +5,8 @@ import pandas as pd
 import requests
 from cluster.config.metadata import (
     METADATA_DUPLICATES_FILTERED,
+    METADATA_NO_LOCATION_FILTERED,
     METADATA_NO_SOUS_CATEGORIE_FILTERED,
-    METADATA_SERVICE_DOMICILE_FILTERED,
 )
 from pydantic import BaseModel
 from shared.tasks.database_logic.db_manager import PostgresConnectionManager
@@ -127,20 +127,20 @@ def _transform_df(df: pd.DataFrame, dag_config: SourceConfig) -> pd.DataFrame:
         normalisation_function = get_transformation_function(function_name, dag_config)
         logger.warning(f"Transformation {function_name}")
 
-        # Initialiser les colonnes de destination si elles n'existent pas
+        # Initialize destination columns if they do not exist
         for dest_col in column_to_transform_df.destination:
             if dest_col not in df.columns:
                 df[dest_col] = ""
 
         for index, row in df.iterrows():
-            # Récupérer les valeurs d'origine (peut être une ou plusieurs colonnes)
+            # Get origin values (may be one or several columns)
             origin_values = row[column_to_transform_df.origin]
             try:
-                # La fonction de normalisation doit retourner un dict ou une liste
-                # correspondant aux colonnes de destination
+                # The normalization function must return a dict or a list
+                # matching the destination columns
                 result = normalisation_function(origin_values)
 
-                # Assigner les résultats aux colonnes de destination
+                # Assign results to destination columns
                 if isinstance(result, pd.Series):
                     for i, dest_col in enumerate(column_to_transform_df.destination):
                         if i < len(result):
@@ -162,7 +162,7 @@ def _transform_df(df: pd.DataFrame, dag_config: SourceConfig) -> pd.DataFrame:
                         message=str(e),
                     )
                 )
-                # Définir des valeurs par défaut pour toutes les colonnes de destination
+                # Set default values for all destination columns
                 for dest_col in column_to_transform_df.destination:
                     df.at[index, dest_col] = [] if dest_col.endswith("_codes") else ""
 
@@ -194,33 +194,15 @@ def _remove_columns(df: pd.DataFrame, dag_config: SourceConfig) -> pd.DataFrame:
     return df.drop(columns=columns_to_remove)
 
 
-def _remove_undesired_lines(
-    df: pd.DataFrame, dag_config: SourceConfig
-) -> tuple[pd.DataFrame, dict]:
-    metadata = {}
+def _remove_undesired_lines(df: pd.DataFrame) -> tuple[pd.DataFrame, dict]:
+    """Filter rows according to their content.
 
-    # Compute metadata
-    if "service_a_domicile" in df.columns:
-        metadata[METADATA_SERVICE_DOMICILE_FILTERED] = str(
-            (
-                df["service_a_domicile"]
-                .str.lower()
-                .str.contains("service à domicile uniquement")
-                .sum()
-            )
-            + (
-                df["service_a_domicile"]
-                .str.lower()
-                .str.contains("oui exclusivement")
-                .sum()
-            )
-        )
-
-    if "sous_categorie_codes" in df.columns:
-        if nb_empty_sous_categorie := len(
-            df[df["sous_categorie_codes"].apply(len) == 0]
-        ) + len(df[df["sous_categorie_codes"].isnull()]):
-            metadata[METADATA_NO_SOUS_CATEGORIE_FILTERED] = str(nb_empty_sous_categorie)
+    Ignored rows (with error logged if rows are filtered) :
+    - duplicates on identifiant_unique (after merge if needed)
+    - actors without subcategories
+    - actors without digital location
+    """
+    metadata: dict = {}
 
     if all(
         column in df.columns
@@ -236,54 +218,53 @@ def _remove_undesired_lines(
             merge_as_list_columns=["label_codes", "acteur_service_codes"],
             merge_as_proposition_service_columns=["proposition_service_codes"],
         )
-    # Remove acteurs which propose only service à domicile
-    if "service_a_domicile" in df.columns:
-        nb_before = len(df)
-        df = df[df["service_a_domicile"].str.lower() != "oui exclusivement"]
-        df = df[df["service_a_domicile"].str.lower() != "service à domicile uniquement"]
-        if nb_filtered := nb_before - len(df):
-            logger.warning(
-                "Acteurs filtrés car service à domicile uniquement: "
-                f"{nb_filtered} / {nb_before}"
-            )
 
-    # Remove acteurs which have no sous_categorie_codes
+    # Ignore actors without subcategories
     if "sous_categorie_codes" in df.columns:
         nb_before = len(df)
-        df = df[df["sous_categorie_codes"].notnull()]
-        df = df[df["sous_categorie_codes"].apply(len) > 0]
+        has_sous_categorie = df["sous_categorie_codes"].notnull() & df[
+            "sous_categorie_codes"
+        ].apply(lambda x: len(x) > 0 if x is not None else False)
+        df_ignored = df[~has_sous_categorie]
+        df = df[has_sous_categorie]
         if nb_filtered := nb_before - len(df):
-            logger.warning(
-                "Acteurs filtrés car sans sous_categorie: "
+            metadata[METADATA_NO_SOUS_CATEGORIE_FILTERED] = str(nb_filtered)
+            logger.error(
+                "Acteurs ignorés car sans sous_categorie: "
                 f"{nb_filtered} / {nb_before}"
             )
+            log.preview("Acteurs ignorés (sans sous_categorie)", df_ignored)
 
-    # Find duplicates for logging
-    dups = df[df["identifiant_unique"].duplicated(keep=False)]
-    if not dups.empty:
-        logger.warning(
-            f"==== DOUBLONS SUR LES IDENTIFIANTS UNIQUES {len(dups) / 2} ====="
+    # Ignore duplicates on identifiant_unique
+    if "identifiant_unique" in df.columns:
+        nb_before = len(df)
+        dups = df[df["identifiant_unique"].duplicated(keep=False)]
+        if not dups.empty:
+            nb_duplicate_groups = int(df["identifiant_unique"].duplicated().sum())
+            metadata[METADATA_DUPLICATES_FILTERED] = str(nb_duplicate_groups)
+            logger.error(
+                "Acteurs ignorés car doublons sur identifiant_unique: "
+                f"{nb_duplicate_groups} / {nb_before}"
+            )
+            log.preview("Doublons sur identifiant_unique", dups)
+            df = df.drop_duplicates(subset=["identifiant_unique"], keep="first")
+
+    # Ignore not digital actors without location (e.g. physical actors)
+    if "location" in df.columns and "acteur_type_code" in df.columns:
+        nb_before = len(df)
+        missing_location = (df["location"].isnull()) & (
+            df["acteur_type_code"] != "acteur_digital"
         )
-        log.preview("Doublons sur identifiant_unique", dups)
-        metadata[METADATA_DUPLICATES_FILTERED] = str(len(dups) / 2)
+        df_ignored = df[missing_location]
+        df = df[~missing_location]
+        if nb_filtered := nb_before - len(df):
+            metadata[METADATA_NO_LOCATION_FILTERED] = str(nb_filtered)
+            logger.error(
+                "Acteurs ignorés car sans localisation: " f"{nb_filtered} / {nb_before}"
+            )
+            log.preview("Acteurs ignorés (sans localisation)", df_ignored)
 
     return df, metadata
-
-
-def _display_warning_about_missing_location(df: pd.DataFrame) -> None:
-    # TODO: A voir ce qu'on doit faire de ces acteurs non digitaux mais sans
-    # localisation (proposition : les afficher en erreur directement ?)
-    if "location" in df.columns and "acteur_type_code" in df.columns:
-        df_acteur_sans_loc = df[
-            (df["location"].isnull()) & (df["acteur_type_code"] != "acteur_digital")
-        ]
-        if not df_acteur_sans_loc.empty:
-            nb_acteurs = len(df)
-            logger.warning(
-                f"Nombre d'acteurs sans localisation: {len(df_acteur_sans_loc)} / "
-                f"{nb_acteurs}"
-            )
-            log.preview("Acteurs sans localisation", df_acteur_sans_loc)
 
 
 def _manage_oca_config(df: pd.DataFrame, dag_config: SourceConfig) -> pd.DataFrame:
@@ -295,7 +276,7 @@ def _manage_oca_config(df: pd.DataFrame, dag_config: SourceConfig) -> pd.DataFra
         df["source_code"] = df["source_code"].apply(
             lambda x: oca_prefix + "_" + x.strip().lower()
         )
-    # Recalcul de l'identifiant unique
+    # Recompute identifiant_unique
     normalisation_function = get_transformation_function(
         "clean_identifiant_unique", dag_config
     )
@@ -311,18 +292,18 @@ def source_data_normalize(
     dag_id: str,
 ) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, dict]:
     """
-    Normalisation des données source. Passée cette étape:
-    - toutes les sources doivent avoir une nomenclature et formatage alignés
-    - les sources peuvent préservées des spécificités (ex: présence/absence de SIRET)
-        mais toujours en cohérence avec les règles de nommage et formatage
-    - Ajout des colonnes avec valeurs par défaut
+    Normalization of source data. Passed this step:
+    - all sources must have a nomenclature and formatting aligned
+    - sources may preserve specificities (ex: presence/absence of SIRET)
+        but always consistent with the naming and formatting rules
+    - Add columns with default values
     """
 
     df = df_acteur_from_source
 
     if dag_id == "pharmacies":
-        # Patch pour les pharmacies car l'apostrophe n'est pas bien géré dans la
-        # configuration de airflow
+        # Patch for pharmacies because the apostrophe is not well managed in the
+        # airflow configuration
         df.rename(
             columns={"Numéro d'établissement": "identifiant_externe"},
             inplace=True,
@@ -389,11 +370,7 @@ def source_data_normalize(
     df = df.drop(columns=["log_error"])
     df = df.drop(columns=["log_warning"])
 
-    # Merge and delete undesired lines
-    df, metadata = _remove_undesired_lines(df, dag_config)
-    log.preview("df after removing undesired lines", df)
-
-    # deduplication_on_source_code
+    # deduplication_on_source_code / config OCA
     if dag_config.is_oca:
         df = _manage_oca_config(df, dag_config)
 
@@ -407,15 +384,16 @@ def source_data_normalize(
             Colonnes manquantes: {expected_columns - set(df.columns)}"""
         )
 
-    # Etapes de normalisation spécifiques aux sources
+    # Source-specific normalization steps
     if dag_id == "pharmacies":
         df = df_normalize_pharmacie(df)
 
     if dag_id == "source_sinoe":
         df = df_normalize_sinoe(df)
 
-    # Log si des localisations sont manquantes parmis les acteurs non digitaux
-    _display_warning_about_missing_location(df)
+    # Filter by content (home, duplicates, subcategory, location)
+    df, metadata = _remove_undesired_lines(df)
+    log.preview("df after filtering rows by content", df)
 
     log.preview("df après normalisation", df)
     if df.empty:
@@ -424,10 +402,10 @@ def source_data_normalize(
 
 
 def df_normalize_pharmacie(df: pd.DataFrame) -> pd.DataFrame:
-    # FIXME : à déplacer dans une fonction df ?
-    # controle des adresses et localisation des pharmacies
+    # FIXME: move this into a df function?
+    # Validate pharmacy addresses and locations
     df = df.apply(enrich_from_ban_api, axis=1)
-    # On supprime les pharmacies sans localisation
+    # Remove pharmacies without a location
     nb_pharmacies_sans_loc = len(df[(df["latitude"] == 0) | (df["longitude"] == 0)])
     nb_pharmacies = len(df)
     logger.warning(
@@ -441,9 +419,9 @@ def df_normalize_pharmacie(df: pd.DataFrame) -> pd.DataFrame:
 def df_normalize_sinoe(
     df: pd.DataFrame,
 ) -> pd.DataFrame:
-    # DOUBLONS: extra sécurité: même si on ne devrait pas obtenir
-    # de doublon grâce à l'API (q_mode=simple&ANNEE_eq=2025)
-    # on vérifie qu'on a qu'une année
+    # DUPLICATES: extra safety — even though the API should not return
+    # duplicates (q_mode=simple&ANNEE_eq=2025),
+    # we still check that there is only one year
     log.preview("ANNEE uniques", df["ANNEE"].unique().tolist())
     if df["ANNEE"].nunique() != 1:
         raise ValueError("Plusieurs ANNEE, changer requête API pour n'en avoir qu'une")

--- a/data-platform/dags/sources/tasks/business_logic/source_data_normalize.py
+++ b/data-platform/dags/sources/tasks/business_logic/source_data_normalize.py
@@ -12,12 +12,12 @@ from pydantic import BaseModel
 from shared.tasks.database_logic.db_manager import PostgresConnectionManager
 from sources.config.airflow_params import TRANSFORMATION_MAPPING
 from sources.config.models import (
-    SourceConfig,
     NormalizationColumnDefault,
     NormalizationColumnRemove,
     NormalizationColumnRename,
     NormalizationColumnTransform,
     NormalizationDFTransform,
+    SourceConfig,
 )
 from sources.tasks.transform.exceptions import (
     ImportSourceException,
@@ -238,13 +238,25 @@ def _remove_undesired_lines(
         )
     # Remove acteurs which propose only service à domicile
     if "service_a_domicile" in df.columns:
+        nb_before = len(df)
         df = df[df["service_a_domicile"].str.lower() != "oui exclusivement"]
         df = df[df["service_a_domicile"].str.lower() != "service à domicile uniquement"]
+        if nb_filtered := nb_before - len(df):
+            logger.warning(
+                "Acteurs filtrés car service à domicile uniquement: "
+                f"{nb_filtered} / {nb_before}"
+            )
 
     # Remove acteurs which have no sous_categorie_codes
     if "sous_categorie_codes" in df.columns:
+        nb_before = len(df)
         df = df[df["sous_categorie_codes"].notnull()]
         df = df[df["sous_categorie_codes"].apply(len) > 0]
+        if nb_filtered := nb_before - len(df):
+            logger.warning(
+                "Acteurs filtrés car sans sous_categorie: "
+                f"{nb_filtered} / {nb_before}"
+            )
 
     # Find duplicates for logging
     dups = df[df["identifiant_unique"].duplicated(keep=False)]

--- a/data-platform/dags/tests/sources/tasks/airflow_logic/test_config_management.py
+++ b/data-platform/dags/tests/sources/tasks/airflow_logic/test_config_management.py
@@ -1,12 +1,12 @@
 import pytest
 from sources.config.models import (
-    SourceConfig,
     NormalizationColumnDefault,
     NormalizationColumnKeep,
     NormalizationColumnRemove,
     NormalizationColumnRename,
     NormalizationColumnTransform,
     NormalizationDFTransform,
+    SourceConfig,
     get_nested_config_parameter,
 )
 
@@ -67,6 +67,7 @@ class TestSourceConfig:
         assert dag_config.product_mapping == {}
         assert dag_config.source_code is None
         assert dag_config.validate_address_with_ban is False
+        assert dag_config.ignore_rows_with_null_or_empty_fields == []
 
     @pytest.mark.parametrize(
         "input_value",

--- a/data-platform/dags/tests/sources/tasks/business_logic/test_source_data_download.py
+++ b/data-platform/dags/tests/sources/tasks/business_logic/test_source_data_download.py
@@ -24,9 +24,9 @@ class TestDropRowsWithNullFields:
             {"id": 4, "nom": "d"},
         ]
 
-    def test_warns_on_missing_dataframe_columns(self, caplog):
+    def test_warns_on_dataframe(self, caplog):
         df = pd.DataFrame([{"id": 1}])
         with caplog.at_level("WARNING"):
-            filtered = drop_rows_with_null_or_empty_fields(df, ["missing"])
+            filtered = drop_rows_with_null_or_empty_fields(df, ["id"])
         assert len(filtered) == 1
-        assert "absents des données" in caplog.text
+        assert "is not applied on a DataFrame" in caplog.text

--- a/data-platform/dags/tests/sources/tasks/business_logic/test_source_data_download.py
+++ b/data-platform/dags/tests/sources/tasks/business_logic/test_source_data_download.py
@@ -1,0 +1,32 @@
+import pandas as pd
+from sources.tasks.business_logic.source_data_download import (
+    drop_rows_with_null_or_empty_fields,
+)
+
+
+class TestDropRowsWithNullFields:
+    def test_noop_when_fields_empty(self):
+        data = [{"id": 1}, {"id": None}, {"id": ""}]
+        assert drop_rows_with_null_or_empty_fields(data, []) == data
+        assert drop_rows_with_null_or_empty_fields(data, None) == data
+
+    def test_filters_list_of_dicts(self):
+        data = [
+            {"id": 1, "nom": "a"},
+            {"id": None, "nom": "b"},
+            {"id": 3, "nom": None},
+            {"id": 4, "nom": "d"},
+            {"id": 5, "nom": ""},
+        ]
+        filtered = drop_rows_with_null_or_empty_fields(data, ["id", "nom"])
+        assert filtered == [
+            {"id": 1, "nom": "a"},
+            {"id": 4, "nom": "d"},
+        ]
+
+    def test_warns_on_missing_dataframe_columns(self, caplog):
+        df = pd.DataFrame([{"id": 1}])
+        with caplog.at_level("WARNING"):
+            filtered = drop_rows_with_null_or_empty_fields(df, ["missing"])
+        assert len(filtered) == 1
+        assert "absents des données" in caplog.text

--- a/data-platform/dags/tests/sources/tasks/business_logic/test_source_data_normalize.py
+++ b/data-platform/dags/tests/sources/tasks/business_logic/test_source_data_normalize.py
@@ -481,33 +481,6 @@ class TestRemoveUndesiredLines:
     @pytest.mark.parametrize(
         "df, expected_df",
         [
-            # Cas suppression service à domicile
-            (
-                pd.DataFrame(
-                    {
-                        "identifiant_unique": ["id1", "id2", "id3"],
-                        "service_a_domicile": [
-                            "non",
-                            "oui exclusivement",
-                            "service à domicile uniquement",
-                        ],
-                        "public_accueilli": [
-                            "Particuliers",
-                            "Particuliers",
-                            "Particuliers",
-                        ],
-                        "sous_categorie_codes": [["code1"], ["code2"], ["code3"]],
-                    }
-                ),
-                pd.DataFrame(
-                    {
-                        "identifiant_unique": ["id1"],
-                        "service_a_domicile": ["non"],
-                        "public_accueilli": ["Particuliers"],
-                        "sous_categorie_codes": [["code1"]],
-                    }
-                ),
-            ),
             # Cas avec suppression des lignes sans produits acceptés
             (
                 pd.DataFrame(
@@ -531,17 +504,52 @@ class TestRemoveUndesiredLines:
                     }
                 ),
             ),
+            # Cas suppression acteurs non digitaux sans localisation
+            (
+                pd.DataFrame(
+                    {
+                        "identifiant_unique": ["id1", "id2", "id3"],
+                        "acteur_type_code": [
+                            "artisan",
+                            "acteur_digital",
+                            "artisan",
+                        ],
+                        "location": ["POINT(1 1)", None, None],
+                        "sous_categorie_codes": [["code1"], ["code2"], ["code3"]],
+                    }
+                ),
+                pd.DataFrame(
+                    {
+                        "identifiant_unique": ["id1", "id2"],
+                        "acteur_type_code": ["artisan", "acteur_digital"],
+                        "location": ["POINT(1 1)", None],
+                        "sous_categorie_codes": [["code1"], ["code2"]],
+                    }
+                ),
+            ),
         ],
     )
-    def test_remove_undesired_lines_suppressions(self, df, expected_df, dag_config):
-        # Mock the SourceConfig
-
-        result_df, _ = _remove_undesired_lines(df, dag_config)
+    def test_filter_rows_by_content_suppressions(self, df, expected_df):
+        result_df, _ = _remove_undesired_lines(df)
         pd.testing.assert_frame_equal(
             result_df.reset_index(drop=True), expected_df.reset_index(drop=True)
         )
 
-    def test_merge_duplicated(self, dag_config):
+    def test_filter_rows_by_content_drops_remaining_duplicates(self):
+        df = pd.DataFrame(
+            {
+                "identifiant_unique": ["id1", "id1", "id2"],
+                "sous_categorie_codes": [["a"], ["b"], ["c"]],
+            }
+        )
+        result_df, metadata = _remove_undesired_lines(df)
+        assert list(result_df["identifiant_unique"]) == ["id1", "id2"]
+        assert (
+            metadata["Nombre d'acteurs filtrés car doublons sur identifiant_unique"]
+            == "1"
+        )
+
+    def test_merge_duplicated(self):
         result, _ = _remove_undesired_lines(
             pd.DataFrame(
                 {
@@ -574,7 +582,6 @@ class TestRemoveUndesiredLines:
                     ],
                 }
             ),
-            dag_config,
         )
         result = result.sort_values("identifiant_unique")
         result = result.reset_index(drop=True)


### PR DESCRIPTION
# Description succincte du problème résolu

Mattermost: [Le DAG CMA me propose de supprimer l'ensemble des acteurs CMA](https://mattermost.incubateur.net/betagouv/pl/uyouz7rzbt8b5898z7oa7qdz3e)


**🗺️ contexte**: AIRFLOW - Source - CMA

**💡 quoi**:
Ignorer les lignes téléchargées qui ont une colonne `id` à nulle

**🎯 pourquoi**: 
la CMA retourne une ligne avec un id null, cela force la colonne en float et casse la chaine de normalisation

**🤔 comment**: 

Ajout d'un paramètre qui liste les colonne à ignorer après téléchargement si la valeur est vide
On en profite pour remanier les exclusions de lignes :

Avant : 

On ignorait les lignes :

- les services à domicile seulement
- les doublons
- les acteurs sans sous-catégories

On conservait avec un warning :

- les acteurs sans localisation

Avec cette PR 

On conserve les services à domicile seulement

On ignore : 

- les doublons
- les acteurs sans sous-catégories
- les acteurs sans localisation

**🤓 comment tester**: 

- Lancer le DAG d'ingestion de la CMA, ignorer les lignes dont la colonne id est nulle (configuration par défaut, paramètre `ignore_row_with_null_or_empty_fields`)
- Constater à l'étape de téléchargement des données `source_data_download` qu'une ligne est ignorée
- Constater que les suggestions des sources CMA sont correctes

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)
