### PR TITLE
fix: recreate preview DB when deleted out-of-band, fix cleardb label typo

### DIFF
--- a/.github/workflows/_terragrunt-apply.yml
+++ b/.github/workflows/_terragrunt-apply.yml
@@ -27,7 +27,7 @@ on:
         required: false
         default: ""
       clear_db:
-        description: "Whether to clear and re-seed the database (e.g. when preview:clear-db label is present)"
+        description: "Whether to clear and re-seed the database (e.g. when preview:cleardb label is present)"
         type: string
         required: false
         default: "false"

--- a/.github/workflows/preview-up.yml
+++ b/.github/workflows/preview-up.yml
@@ -51,8 +51,8 @@ jobs:
             LABELS="${{ toJSON(github.event.pull_request.labels.*.name) }}"
           fi
 
-          # Check for the preview:clear-db label
-          if echo "$LABELS" | grep -q 'preview:clear-db'; then
+          # Check for the preview:cleardb label
+          if echo "$LABELS" | grep -q 'preview:cleardb'; then
             CLEAR_DB="true"
           else
             CLEAR_DB="false"

--- a/infrastructure/modules/preview_database/main.tf
+++ b/infrastructure/modules/preview_database/main.tf
@@ -34,6 +34,29 @@ locals {
   )
 }
 
+# Detects whether the preview database currently exists on the RDB
+# instance. Terraform's own state can't see this: if the DB was deleted
+# out-of-band (manually, or by some other process), state still says the
+# null_resource below already applied, so trigger diffing alone would keep
+# skipping it forever. Folding live existence into the triggers forces a
+# reseed whenever the DB is actually missing, regardless of clear_db.
+data "external" "db_exists" {
+  program = ["bash", "-c", <<-EOT
+    if scw rdb database list instance-id="$INSTANCE_ID" -o json 2>/dev/null \
+         | grep -q "\"name\":\"$DB_NAME\""; then
+      echo '{"exists":"true"}'
+    else
+      echo '{"exists":"false"}'
+    fi
+  EOT
+  ]
+
+  query = {
+    INSTANCE_ID = local.instance_uuid
+    DB_NAME     = var.preview_db_name
+  }
+}
+
 # Database, user and privilege are managed via the `scw` CLI instead of the
 # scaleway_rdb_database/user/privilege Terraform resources: the provider hit
 # a "Missing Resource Identity After Read" bug on scaleway_rdb_privilege once
@@ -176,6 +199,7 @@ resource "null_resource" "seed_from_sample" {
   triggers = {
     image_tag      = var.clear_db ? var.image_tag : "reuse"
     sample_db_hash = md5(var.sample_db_uri)
-    seed_version   = "4" # bump to force re-seed (e.g. when changing restore logic)
+    seed_version   = "5" # bump to force re-seed (e.g. when changing restore logic)
+    db_exists      = data.external.db_exists.result.exists
   }
 }


### PR DESCRIPTION
## Summary
- Preview environments weren't recreating their database after it was deleted out-of-band (manually, or otherwise): the `null_resource.seed_from_sample` trigger only changed on `clear_db=true` or a `sample_db_hash` change, so Terraform state still considered the DB seeded even though it no longer existed on the RDB instance.
- Added a `data.external.db_exists` check that queries the Scaleway RDB instance for the database's live existence, folded into the `triggers` block — a missing DB now always forces a reseed regardless of `clear_db`.
- Fixed a label mismatch: `preview-up.yml` grepped for `preview:clear-db`, but the actual PR label used in this repo is `preview:cleardb` (no hyphen), so manually applying the label could never force a reseed either.

Already verified live: cherry-picked onto PR #3174's branch, redeployed, and confirmed the preview now boots correctly against a freshly recreated database (`https://qfdmodpreview6b0061c2-lvao-pr-3174-webapp.functions.fnc.fr-par.scw.cloud/` returns 200).

## Test plan
- [x] Merged onto PR #3174's branch and confirmed `terragrunt apply` recreated the preview DB and the app boots (200 response)
- [ ] Confirm a fresh `preview` label + push on a PR without `preview:cleardb` still creates the DB on first deploy (unaffected path)
- [ ] Confirm applying `preview:cleardb` still force-reseeds as before