### PR TITLE
Ne plus utiliser de fonction de utils.django à la racine des fichiers Airflow

### DIFF
--- a/data-platform/dags/acteurs/tasks/business_logic/check_model_table_consistency.py
+++ b/data-platform/dags/acteurs/tasks/business_logic/check_model_table_consistency.py
@@ -1,12 +1,11 @@
-from utils.django import django_setup_full
-
-
 def check_model_table_consistency(
     *,
     django_app: str,
     model_name: str,
     table_name: str,
 ) -> bool:
+    from utils.django import django_setup_full
+
     django_setup_full()
 
     from core.models.tools import compare_model_vs_table

--- a/data-platform/dags/acteurs/tasks/business_logic/copy_db_data.py
+++ b/data-platform/dags/acteurs/tasks/business_logic/copy_db_data.py
@@ -1,7 +1,5 @@
 import logging
 
-from utils.django import django_setup_full
-
 from .copy_utils import drop_tables, dump_and_restore_db
 
 logger = logging.getLogger(__name__)
@@ -57,6 +55,8 @@ EXCLUDE_TABLES = [
 
 def copy_db_data():
     import importlib
+
+    from utils.django import django_setup_full
 
     django_setup_full()
 

--- a/data-platform/dags/acteurs/tasks/business_logic/copy_db_schema.py
+++ b/data-platform/dags/acteurs/tasks/business_logic/copy_db_schema.py
@@ -1,7 +1,5 @@
 import logging
 
-from utils.django import django_setup_full
-
 from .copy_utils import dump_and_restore_db
 
 logger = logging.getLogger(__name__)
@@ -19,6 +17,8 @@ def _get_all_tables(cursor):
 
 
 def copy_db_schema():
+    from utils.django import django_setup_full
+
     django_setup_full()
     from django.conf import settings
     from django.db import connections

--- a/data-platform/dags/acteurs/tasks/business_logic/copy_displayed_data_from_warehouse_task.py
+++ b/data-platform/dags/acteurs/tasks/business_logic/copy_displayed_data_from_warehouse_task.py
@@ -1,7 +1,5 @@
 import logging
 
-from utils.django import django_setup_full
-
 from .copy_utils import dump_and_restore_db
 
 logger = logging.getLogger(__name__)
@@ -23,6 +21,8 @@ EXPOSURE_TABLE_MAPPINGS = {
 
 
 def _drop_exposure_tables_from_webapp_sample():
+    from utils.django import django_setup_full
+
     django_setup_full()
     from django.db import connections
 
@@ -46,6 +46,8 @@ def copy_displayed_data_from_warehouse():
     4. Copy the content of the exposure_sample_* tables to the qfdmo_* tables
     5. Delete the exposure_sample_* tables from webapp_sample
     """
+    from utils.django import django_setup_full
+
     django_setup_full()
     from django.conf import settings
     from django.db import connections

--- a/data-platform/dags/acteurs/tasks/business_logic/export_opendata_csv_to_s3.py
+++ b/data-platform/dags/acteurs/tasks/business_logic/export_opendata_csv_to_s3.py
@@ -8,7 +8,6 @@ import pendulum
 from acteurs.tasks.airflow_logic.config_management import ExportOpendataConfig
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from shared.config.airflow import TMP_FOLDER
-from utils.django import django_setup_full
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +15,8 @@ MAIN_OPENDATA_FILENAME = "acteurs.csv"
 
 
 def export_opendata_csv_to_s3(export_opendata_config: ExportOpendataConfig):
+
+    from utils.django import django_setup_full
 
     django_setup_full()
     from django.conf import settings

--- a/data-platform/dags/acteurs/tasks/business_logic/replace_acteur_table.py
+++ b/data-platform/dags/acteurs/tasks/business_logic/replace_acteur_table.py
@@ -1,7 +1,5 @@
 import logging
 
-from utils.django import django_setup_full
-
 logger = logging.getLogger(__name__)
 
 
@@ -10,6 +8,8 @@ def replace_acteur_table(
     prefix_dbt: str,
     tables: list[str],
 ) -> None:
+    from utils.django import django_setup_full
+
     django_setup_full()
     from django.db import DEFAULT_DB_ALIAS, connections
 
@@ -19,6 +19,8 @@ def replace_acteur_table(
 
 
 def copy_tables_between_servers(cursor, prefix_dbt, prefix_django, tables):
+    from utils.django import django_setup_full
+
     django_setup_full()
     from django.conf import settings
 

--- a/data-platform/dags/clone/tasks/business_logic/clone_old_tables_remove.py
+++ b/data-platform/dags/clone/tasks/business_logic/clone_old_tables_remove.py
@@ -2,7 +2,6 @@ import logging
 import re
 
 from utils import logging_utils as log
-from utils.django import django_setup_full
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +11,8 @@ def clone_old_tables_remove(
     remove_table_name_pattern: re.Pattern,
     dry_run: bool,
 ) -> None:
+    from utils.django import django_setup_full
+
     django_setup_full()
     from django.db import connections
 

--- a/data-platform/dags/clone/tasks/business_logic/clone_table_create.py
+++ b/data-platform/dags/clone/tasks/business_logic/clone_table_create.py
@@ -9,7 +9,6 @@ from pydantic import AnyUrl
 from shared.config.airflow import TMP_FOLDER
 from utils import logging_utils as log
 from utils.cmd import cmd_run
-from utils.django import django_schema_create_and_check, django_setup_full
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +18,8 @@ def command_psql_copy_from_csv(
     delimiter: str,
 ) -> str:
     """Command to load CSV into DB, factored out for reuse"""
+    from utils.django import django_setup_full
+
     django_setup_full()
     from django.conf import settings
 
@@ -38,6 +39,8 @@ def command_ogr2ogr_import_geojson(
 
     For more information about ogr2ogr, see: https://gdal.gloobe.org/ogr/ogr2ogr.html
     """
+    from utils.django import django_setup_full
+
     django_setup_full()
     from django.conf import settings
 
@@ -71,6 +74,8 @@ def command_ogr2ogr_import_geojson_from_stdin(
     geometry_column_name: str = "contours_administratifs",
 ) -> str:
     """Command to load GeoJSON into DB using ogr2ogr from stdin"""
+    from utils.django import django_setup_full
+
     django_setup_full()
     from django.conf import settings
 
@@ -217,6 +222,8 @@ def clone_table_create(
     fix_corrupted_utf8_sed_substitutions: list[str],
     dry_run: bool,
 ) -> None:
+    from utils.django import django_schema_create_and_check, django_setup_full
+
     django_setup_full()
     from django.db import connections
 

--- a/data-platform/dags/clone/tasks/business_logic/clone_table_validate.py
+++ b/data-platform/dags/clone/tasks/business_logic/clone_table_validate.py
@@ -2,13 +2,14 @@ import logging
 
 from clone.config.models import DIR_SQL_VALIDATION
 from utils import logging_utils as log
-from utils.django import DJANGO_WH_CONNECTION_NAME, django_setup_full
 
 logger = logging.getLogger(__name__)
 
 
 def clone_table_validate(table_kind: str, table_name: str, dry_run: bool) -> None:
     """Validate a table in the DB"""
+    from utils.django import DJANGO_WH_CONNECTION_NAME, django_setup_full
+
     django_setup_full()
     from django.db import connections
 

--- a/data-platform/dags/clone/tasks/business_logic/clone_view_in_use_switch.py
+++ b/data-platform/dags/clone/tasks/business_logic/clone_view_in_use_switch.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 
-from utils.django import django_schema_create_and_check
-
 
 def clone_view_in_use_switch(
     view_schema_file_path: Path,
@@ -10,6 +8,8 @@ def clone_view_in_use_switch(
     dry_run: bool,
 ) -> None:
     """Switching the in-use view to point to the new table"""
+    from utils.django import django_schema_create_and_check
+
     sql = (
         view_schema_file_path.read_text()
         .replace(r"{{view_name}}", view_name)

--- a/data-platform/dags/cluster/tasks/airflow_logic/cluster_acteurs_clusters_prepare_task.py
+++ b/data-platform/dags/cluster/tasks/airflow_logic/cluster_acteurs_clusters_prepare_task.py
@@ -14,7 +14,6 @@ from cluster.tasks.business_logic.cluster_acteurs_config_create import (
     cluster_acteurs_config_create,
 )
 from utils import logging_utils as log
-from utils.django import django_setup_full
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +36,8 @@ def task_info_get():
 
 
 def cluster_acteurs_clusters_prepare_wrapper(ti, params) -> None:
+    from utils.django import django_setup_full
+
     django_setup_full()
     logger.info(task_info_get())
 

--- a/data-platform/dags/cluster/tasks/business_logic/cluster_acteurs_clusters_validate.py
+++ b/data-platform/dags/cluster/tasks/business_logic/cluster_acteurs_clusters_validate.py
@@ -1,7 +1,6 @@
 from logging import getLogger
 
 import pandas as pd
-from utils.django import django_setup_full
 
 logger = getLogger(__name__)
 
@@ -15,6 +14,8 @@ def raise_if_df_not_empty(df: pd.DataFrame, error) -> None:
 
 def cluster_acteurs_clusters_validate(df_clusters: pd.DataFrame) -> None:
     """Validate prepared clusters"""
+    from utils.django import django_setup_full
+
     django_setup_full()
 
     df = df_clusters

--- a/data-platform/dags/cluster/tasks/business_logic/cluster_acteurs_config_create.py
+++ b/data-platform/dags/cluster/tasks/business_logic/cluster_acteurs_config_create.py
@@ -1,9 +1,10 @@
 from cluster.config.models import ClusterConfig
-from utils.django import django_setup_full
 
 
 def cluster_acteurs_config_create(params: dict) -> ClusterConfig:
     """Create config by merging params with extra data from DB"""
+    from utils.django import django_setup_full
+
     django_setup_full()
     from qfdmo.models import ActeurType, Source
 

--- a/data-platform/dags/cluster/tasks/business_logic/cluster_acteurs_parents_choose_data.py
+++ b/data-platform/dags/cluster/tasks/business_logic/cluster_acteurs_parents_choose_data.py
@@ -3,7 +3,6 @@ from typing import Any
 
 import pandas as pd
 from cluster.config.constants import COL_PARENT_DATA_NEW, FIELDS_PARENT_DATA_EXCLUDED
-from utils.django import django_setup_full
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +39,8 @@ def cluster_acteurs_parents_choose_data(
     keep_empty: bool = False,
     keep_parent_data_by_default: bool = True,
 ) -> pd.DataFrame:
+    from utils.django import django_setup_full
+
     django_setup_full()
     from data.models.change import COL_CHANGE_MODEL_NAME
     from data.models.changes import ChangeActeurCreateAsParent, ChangeActeurKeepAsParent

--- a/data-platform/dags/cluster/tasks/business_logic/cluster_acteurs_parents_choose_new.py
+++ b/data-platform/dags/cluster/tasks/business_logic/cluster_acteurs_parents_choose_new.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 from cluster.config.constants import COL_PARENT_ID_BEFORE
 from cluster.tasks.business_logic.misc.df_sort import df_sort
-from utils.django import django_setup_full
 
 logger = getLogger(__name__)
 
@@ -48,6 +47,8 @@ def cluster_acteurs_one_cluster_parent_changes_mark(
     - if children not pointing to parent -> point to new parent
     - if orphan -> point to new parent
     """
+    from utils.django import django_setup_full
+
     django_setup_full()
 
     from data.models.change import (
@@ -103,6 +104,8 @@ def cluster_acteurs_one_cluster_parent_changes_mark(
 
 def cluster_acteurs_one_cluster_parent_choose(df: pd.DataFrame) -> tuple[str, str, str]:
     """Generate the decision on the parent selection for 1 cluster"""
+    from utils.django import django_setup_full
+
     django_setup_full()
 
     from data.models.changes import ChangeActeurCreateAsParent, ChangeActeurKeepAsParent
@@ -153,6 +156,8 @@ def cluster_acteurs_one_cluster_parent_choose(df: pd.DataFrame) -> tuple[str, st
 def cluster_acteurs_parents_choose_new(df_clusters: pd.DataFrame) -> pd.DataFrame:
     """Select and assign the new parents to a dataframe
     comprenant 1 ou plusieurs clusters.'"""
+    from utils.django import django_setup_full
+
     django_setup_full()
 
     from data.models.change import COL_CHANGE_ORDER

--- a/data-platform/dags/cluster/tasks/business_logic/cluster_acteurs_read/children.py
+++ b/data-platform/dags/cluster/tasks/business_logic/cluster_acteurs_read/children.py
@@ -1,12 +1,13 @@
 import numpy as np
 import pandas as pd
-from utils.django import django_setup_full
 
 
 def cluster_acteurs_read_children(
     parent_ids: list[str],
     fields_to_include: list[str],
 ) -> pd.DataFrame:
+    from utils.django import django_setup_full
+
     django_setup_full()
     from qfdmo.models.acteur import ActeurStatus, VueActeur
 

--- a/data-platform/dags/cluster/tasks/business_logic/cluster_acteurs_read/for_clustering.py
+++ b/data-platform/dags/cluster/tasks/business_logic/cluster_acteurs_read/for_clustering.py
@@ -4,12 +4,6 @@ import numpy as np
 import pandas as pd
 from cluster.tasks.business_logic.misc.df_sort import df_sort
 from utils import logging_utils as log
-from utils.django import (
-    django_model_queryset_generate,
-    django_model_queryset_to_df,
-    django_model_queryset_to_sql,
-    django_setup_full,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -178,6 +172,13 @@ def _cluster_acteurs_read_base(
     Returns:
         tuple[pd.DataFrame, str]: DataFrame of actors and SQL query used
     """
+    from utils.django import (
+        django_model_queryset_generate,
+        django_model_queryset_to_df,
+        django_model_queryset_to_sql,
+        django_setup_full,
+    )
+
     django_setup_full()
     from qfdmo.models import ActeurType, Source, VueActeur
     from qfdmo.models.acteur import ActeurStatus

--- a/data-platform/dags/cluster/tasks/business_logic/cluster_acteurs_suggestions/prepare.py
+++ b/data-platform/dags/cluster/tasks/business_logic/cluster_acteurs_suggestions/prepare.py
@@ -4,13 +4,14 @@ import pandas as pd
 from cluster.config.constants import COL_PARENT_DATA_NEW
 from utils import logging_utils as log
 from utils.data_serialize_reconstruct import data_serialize
-from utils.django import django_setup_full
 
 logger = logging.getLogger(__name__)
 
 
 def cluster_changes_get(cluster: pd.DataFrame) -> list[dict]:
     """Generate changes for 1 cluster suggestion"""
+    from utils.django import django_setup_full
+
     django_setup_full()
     from data.models.change import (
         COL_CHANGE_MODEL_NAME,

--- a/data-platform/dags/cluster/tasks/business_logic/cluster_acteurs_suggestions/to_db.py
+++ b/data-platform/dags/cluster/tasks/business_logic/cluster_acteurs_suggestions/to_db.py
@@ -6,7 +6,6 @@ from cluster.tasks.business_logic.cluster_acteurs_suggestions.context import (
 )
 from cluster.tasks.business_logic.misc.df_metadata_get import df_metadata_get
 from utils import logging_utils as log
-from utils.django import django_setup_full
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +20,8 @@ def cluster_acteurs_suggestions_to_db(
     cluster_fields_fuzzy: list[str],
 ) -> None:
     """Writing suggestions to DB"""
+    from utils.django import django_setup_full
+
     django_setup_full()
 
     logger.info(f"{identifiant_action=}")

--- a/data-platform/dags/cluster/tasks/business_logic/misc/df_sort.py
+++ b/data-platform/dags/cluster/tasks/business_logic/misc/df_sort.py
@@ -1,6 +1,5 @@
 import pandas as pd
 from cluster.config.constants import COL_PARENT_DATA_NEW
-from utils.django import django_setup_full
 
 
 def df_sort(
@@ -11,6 +10,8 @@ def df_sort(
     """Utility to help us sort dataframes in a consistent way
     throught clustering pipeline despite them having potentially
     different columns"""
+
+    from utils.django import django_setup_full
 
     django_setup_full()
     from data.models.change import (

--- a/data-platform/dags/crawl/tasks/business_logic/crawl_urls_read_urls_from_db.py
+++ b/data-platform/dags/crawl/tasks/business_logic/crawl_urls_read_urls_from_db.py
@@ -10,13 +10,14 @@ from crawl.config.constants import SORT_COLS
 from django.db.models import Q
 from utils import logging_utils as log
 from utils.dataframes import df_sort
-from utils.django import django_setup_full
 
 logger = logging.getLogger(__name__)
 
 
 def crawl_urls_read_urls_from_db(limit: int | None = None) -> pd.DataFrame:
     """Get URLs to crawl from DB"""
+    from utils.django import django_setup_full
+
     django_setup_full()
     from core.models.constants import EMPTY_ACTEUR_FIELD
 

--- a/data-platform/dags/crawl/tasks/business_logic/crawl_urls_suggest.py
+++ b/data-platform/dags/crawl/tasks/business_logic/crawl_urls_suggest.py
@@ -9,7 +9,6 @@ from utils.dataframes import (
     df_col_count_lists,
     df_none_or_empty,
 )
-from utils.django import django_setup_full
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +35,8 @@ def suggestions_prepare(
     """Generate suggestions for URL updates:
     - df_crawl_ok_diff = successful AND different = propose
     - df_crawl_fail = failed = propose None"""
+    from utils.django import django_setup_full
+
     django_setup_full()
     from data.models.change import SuggestionChange
     from data.models.changes import ChangeActeurUpdateRevision
@@ -95,6 +96,8 @@ def crawl_urls_suggestions_to_db(
     identifiant_execution: str,
 ) -> None:
     """Writing suggestions to DB"""
+    from utils.django import django_setup_full
+
     django_setup_full()
 
     logger.info(f"{identifiant_action=}")
@@ -134,6 +137,8 @@ def crawl_urls_suggestion_groupes_to_db(
     identifiant_execution: str,
 ) -> int:
     """Writing suggestion_groupes to DB"""
+    from utils.django import django_setup_full
+
     django_setup_full()
     from data.models.suggestion import (
         SuggestionAction,

--- a/data-platform/dags/enrich/tasks/business_logic/db_read_acteur_cp.py
+++ b/data-platform/dags/enrich/tasks/business_logic/db_read_acteur_cp.py
@@ -3,7 +3,6 @@
 import logging
 
 import pandas as pd
-from utils.django import django_setup_full
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +18,8 @@ def _get_df_acteurs_with_invalid_cp(model) -> pd.DataFrame:
 
 
 def db_read_acteur_cp() -> pd.DataFrame:
+    from utils.django import django_setup_full
+
     django_setup_full()
     from qfdmo.models.acteur import Acteur
 
@@ -26,6 +27,8 @@ def db_read_acteur_cp() -> pd.DataFrame:
 
 
 def db_read_revision_acteur_cp() -> pd.DataFrame:
+    from utils.django import django_setup_full
+
     django_setup_full()
     from qfdmo.models.acteur import RevisionActeur
 

--- a/data-platform/dags/enrich/tasks/business_logic/enrich_dbt_model_read.py
+++ b/data-platform/dags/enrich/tasks/business_logic/enrich_dbt_model_read.py
@@ -4,9 +4,7 @@ import logging
 
 import numpy as np
 import pandas as pd
-
 from utils.dataframes import df_filter
-from utils.django import DJANGO_WH_CONNECTION_NAME, django_setup_full
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +13,8 @@ def enrich_dbt_model_read(
     dbt_model_name: str, filters: list[dict] = []
 ) -> pd.DataFrame:
     """Reads necessary QFDMO acteurs and AE entries from DB"""
+    from utils.django import DJANGO_WH_CONNECTION_NAME, django_setup_full
+
     django_setup_full()
     from django.db import connections
 

--- a/data-platform/dags/enrich/tasks/business_logic/enrich_dbt_model_to_suggestions.py
+++ b/data-platform/dags/enrich/tasks/business_logic/enrich_dbt_model_to_suggestions.py
@@ -5,7 +5,6 @@ import pandas as pd
 from enrich.config.cohorts import COHORTS
 from enrich.config.columns import COLS
 from utils import logging_utils as log
-from utils.django import django_setup_full
 
 logger = logging.getLogger(__name__)
 
@@ -221,6 +220,8 @@ def enrich_dbt_model_to_suggestions(
     identifiant_action: str,
     dry_run: bool = True,
 ) -> bool:
+    from utils.django import django_setup_full
+
     django_setup_full()
 
     from data.models.suggestion import (

--- a/data-platform/dags/enrich/tasks/business_logic/enrich_lien_succession_suggest.py
+++ b/data-platform/dags/enrich/tasks/business_logic/enrich_lien_succession_suggest.py
@@ -10,7 +10,6 @@ import pandas as pd
 from enrich.config.columns import COLS
 from enrich.tasks.business_logic.enrich_dbt_model_read import enrich_dbt_model_read
 from utils import logging_utils as log
-from utils.django import django_setup_full
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +56,8 @@ def enrich_lien_succession_to_suggestion_groupes(
 ) -> bool:
     """Write 1 SuggestionGroupe per acteur and 1 SuggestionUnitaire per changed
     field (SIREN and/or SIRET)."""
+    from utils.django import django_setup_full
+
     django_setup_full()
     from data.models.suggestion import (
         SuggestionAction,

--- a/data-platform/dags/enrich/tasks/business_logic/enrich_siret_siren_suggest.py
+++ b/data-platform/dags/enrich/tasks/business_logic/enrich_siret_siren_suggest.py
@@ -12,7 +12,6 @@ import pandas as pd
 from enrich.config.columns import COLS
 from enrich.tasks.business_logic.enrich_dbt_model_read import enrich_dbt_model_read
 from utils import logging_utils as log
-from utils.django import django_setup_full
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +37,8 @@ def enrich_siret_siren_to_suggestion_groupes(
 ) -> bool:
     """Write 1 SuggestionGroupe per `suggest_field` value and 1
     SuggestionUnitaire per acteur, suggesting `suggest_field`."""
+    from utils.django import django_setup_full
+
     django_setup_full()
     from data.models.suggestion import (
         SuggestionAction,

--- a/data-platform/dags/sources/config/airflow_params.py
+++ b/data-platform/dags/sources/config/airflow_params.py
@@ -36,7 +36,6 @@ from sources.tasks.transform.transform_df import (
     get_latlng_from_geopoint,
     merge_sous_categories_columns,
 )
-from utils.django import django_setup_full
 
 PATH_NOMENCLARURE_DECHET = (
     "https://data.ademe.fr/data-fair/api/v1/datasets/sinoe-r-nomenclature-dechets/lines"
@@ -289,6 +288,8 @@ def get_mapping_config(mapping_key: str = "sous_categories"):
 
 
 def get_souscategorie_mapping_from_db():
+
+    from utils.django import django_setup_full
 
     django_setup_full()
     from qfdmo.models.categorie_objet import SousCategorieObjet

--- a/data-platform/dags/sources/dags/source_cma.py
+++ b/data-platform/dags/sources/dags/source_cma.py
@@ -7,10 +7,6 @@ from shared.config.airflow import DEFAULT_ARGS
 from shared.config.tags import TAGS
 from sources.config.airflow_params import get_mapping_config
 from sources.tasks.airflow_logic.operators import default_params, eo_task_chain
-from utils.django import django_setup_full
-
-django_setup_full()
-from qfdmo.models.acteur import ActeurPublicAccueilli, ActeurStatus  # noqa: E402
 
 NORMALIZATION_RULES = [
     # 1. Renommage des colonnes
@@ -75,9 +71,11 @@ NORMALIZATION_RULES = [
         "destination": "ville",
     },
     # 3. Ajout des colonnes avec une valeur par défaut
+    # Hardcoded values (ActeurStatus.ACTIF):
+    # not ideal, but avoids initializing Django at DAG module load time.
     {
         "column": "statut",
-        "value": ActeurStatus.ACTIF,
+        "value": "ACTIF",
     },
     {
         "column": "label_codes",
@@ -95,9 +93,11 @@ NORMALIZATION_RULES = [
         "column": "action_codes",
         "value": ["reparer"],
     },
+    # Hardcoded values (ActeurPublicAccueilli.PARTICULIERS):
+    # not ideal, but avoids initializing Django at DAG module load time.
     {
         "column": "public_accueilli",
-        "value": ActeurPublicAccueilli.PARTICULIERS,
+        "value": "Particuliers",
     },
     {
         "column": "source_code",

--- a/data-platform/dags/sources/dags/source_generic.py
+++ b/data-platform/dags/sources/dags/source_generic.py
@@ -6,11 +6,12 @@ from shared.config.airflow import DEFAULT_ARGS
 from shared.config.tags import TAGS
 from sources.config.airflow_params import get_mapping_config
 from sources.tasks.airflow_logic.operators import default_params, eo_task_chain
-from utils.django import django_setup_full
 
 
 def default_normalization_rules() -> list[dict]:
     # Import here to avoid import it before django is setup (get_mapping_config import)
+    from utils.django import django_setup_full
+
     django_setup_full()
     from qfdmo.models.acteur import ActeurPublicAccueilli, ActeurStatus
 

--- a/data-platform/dags/sources/dags/source_pharmacies.py
+++ b/data-platform/dags/sources/dags/source_pharmacies.py
@@ -6,10 +6,6 @@ from shared.config.airflow import DEFAULT_ARGS
 from shared.config.tags import TAGS
 from sources.config.airflow_params import get_mapping_config
 from sources.tasks.airflow_logic.operators import default_params, eo_task_chain
-from utils.django import django_setup_full
-
-django_setup_full()
-from qfdmo.models.acteur import ActeurPublicAccueilli, ActeurStatus  # noqa: E402
 
 with DAG(
     dag_id="pharmacies",
@@ -60,8 +56,11 @@ with DAG(
                     },
                     # 3. Ajout des colonnes avec une valeur par défaut
                     {
+                        # Hardcoded values (ActeurStatus.ACTIF):
+                        # not ideal, but avoids initializing Django at DAG module load
+                        # time.
                         "column": "statut",
-                        "value": ActeurStatus.ACTIF.value,
+                        "value": "ACTIF",
                     },
                     {
                         "column": "uniquement_sur_rdv",
@@ -84,8 +83,11 @@ with DAG(
                         "value": ["medicaments"],
                     },
                     {
+                        # Hardcoded values (ActeurPublicAccueilli.PARTICULIERS):
+                        # not ideal, but avoids initializing Django at DAG module load
+                        # time.
                         "column": "public_accueilli",
-                        "value": ActeurPublicAccueilli.PARTICULIERS.value,
+                        "value": "Particuliers",
                     },
                     {
                         "column": "acteur_type_code",

--- a/data-platform/dags/sources/dags/source_sinoe.py
+++ b/data-platform/dags/sources/dags/source_sinoe.py
@@ -9,10 +9,6 @@ from sources.config.airflow_params import (
     source_sinoe_dechet_mapping_get,
 )
 from sources.tasks.airflow_logic.operators import default_params, eo_task_chain
-from utils.django import django_setup_full
-
-django_setup_full()
-from qfdmo.models.acteur import ActeurStatus  # noqa: E402
 
 with DAG(
     dag_id="source_sinoe",
@@ -96,8 +92,11 @@ with DAG(
                         "value": "ademesinoedecheteries",
                     },
                     {
+                        # Hardcoded values (ActeurStatus.ACTIF):
+                        # not ideal, but avoids initializing Django at DAG module load
+                        # time.
                         "column": "statut",
-                        "value": ActeurStatus.ACTIF.value,
+                        "value": "ACTIF",
                     },
                     # 4. Transformation du dataframe
                     {

--- a/data-platform/dags/sources/tasks/business_logic/db_data_prepare.py
+++ b/data-platform/dags/sources/tasks/business_logic/db_data_prepare.py
@@ -5,7 +5,6 @@ import numpy as np
 import pandas as pd
 from sources.tasks.transform.sequence_utils import is_empty_sequence
 from utils import logging_utils as log
-from utils.django import django_setup_full
 
 logger = logging.getLogger(__name__)
 
@@ -14,6 +13,8 @@ def db_data_prepare(
     df_acteur: pd.DataFrame,
     df_acteur_from_db: pd.DataFrame,
 ):
+    from utils.django import django_setup_full
+
     django_setup_full()
     from qfdmo.models.acteur import ActeurStatus
 

--- a/data-platform/dags/sources/tasks/business_logic/db_read_acteur.py
+++ b/data-platform/dags/sources/tasks/business_logic/db_read_acteur.py
@@ -3,13 +3,14 @@ import logging
 import pandas as pd
 from sources.config.models import SourceConfig
 from utils import logging_utils as log
-from utils.django import django_setup_full, get_model_fields
 
 logger = logging.getLogger(__name__)
 
 
 # TODO: To be factorized with PYDANTIC classes
 def db_read_acteur(df_normalized: pd.DataFrame, dag_config: SourceConfig):
+    from utils.django import django_setup_full, get_model_fields
+
     django_setup_full()
 
     from qfdmo.models import Acteur

--- a/data-platform/dags/sources/tasks/business_logic/db_write_type_action_suggestions.py
+++ b/data-platform/dags/sources/tasks/business_logic/db_write_type_action_suggestions.py
@@ -7,7 +7,6 @@ from shared.tasks.database_logic.db_manager import PostgresConnectionManager
 from sources.tasks.transform.sequence_utils import df_convert_numpy_to_jsonify
 from sqlalchemy import TEXT, VARCHAR, text
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
-from utils.django import django_setup_full
 
 logger = logging.getLogger(__name__)
 
@@ -125,6 +124,8 @@ def db_write_type_action_suggestions(
     df_log_warning: pd.DataFrame,
     use_legacy_suggestions: bool,
 ) -> None:
+    from utils.django import django_setup_full
+
     django_setup_full()
 
     from data.models.suggestion import SuggestionAction
@@ -191,6 +192,8 @@ def insert_suggestion(
     df_log_error: pd.DataFrame = pd.DataFrame(),
     df_log_warning: pd.DataFrame = pd.DataFrame(),
 ):
+    from utils.django import django_setup_full
+
     django_setup_full()
     from data.models.suggestion import (
         SuggestionAction,
@@ -332,6 +335,8 @@ def insert_suggestion_legacy(
     df_log_error: pd.DataFrame = pd.DataFrame(),
     df_log_warning: pd.DataFrame = pd.DataFrame(),
 ):
+    from utils.django import django_setup_full
+
     django_setup_full()
 
     from data.models.suggestion import SuggestionCohorteStatut, SuggestionLog

--- a/data-platform/dags/sources/tasks/business_logic/keep_acteur_changed.py
+++ b/data-platform/dags/sources/tasks/business_logic/keep_acteur_changed.py
@@ -9,7 +9,6 @@ from cluster.config.metadata import (
 )
 from sources.config.models import SourceConfig
 from sources.tasks.transform.transform_df import compute_identifiant_unique
-from utils.django import django_setup_full, get_model_fields
 
 logger = logging.getLogger(__name__)
 
@@ -152,6 +151,8 @@ def keep_acteur_changed(
     df_acteur_from_db: pd.DataFrame,
     dag_config: SourceConfig,
 ) -> tuple[pd.DataFrame, pd.DataFrame, dict]:
+    from utils.django import django_setup_full, get_model_fields
+
     django_setup_full()
 
     from data.models.changes.acteur_rgpd_anonymize import VALUE_ANONYMIZED

--- a/data-platform/dags/sources/tasks/transform/transform_column.py
+++ b/data-platform/dags/sources/tasks/transform/transform_column.py
@@ -25,7 +25,6 @@ from sources.tasks.transform.exceptions import (
 from sources.tasks.transform.formatter import format_libelle_to_code
 from sources.tasks.transform.opening_hours import interprete_opening_hours
 from sources.tasks.transform.sequence_utils import convert_numpy_to_jsonify
-from utils.django import django_setup_full
 
 logger = logging.getLogger(__name__)
 
@@ -158,6 +157,8 @@ def clean_acteur_type_code(value, _):
 
 
 def clean_public_accueilli(value, _):
+    from utils.django import django_setup_full
+
     django_setup_full()
 
     from qfdmo.models.acteur import ActeurPublicAccueilli

--- a/data-platform/dags/sources/tasks/transform/transform_df.py
+++ b/data-platform/dags/sources/tasks/transform/transform_df.py
@@ -29,7 +29,6 @@ from sources.tasks.transform.transform_column import (
 )
 from unidecode import unidecode
 from utils import logging_utils as log
-from utils.django import django_setup_full
 
 logger = logging.getLogger(__name__)
 
@@ -220,6 +219,8 @@ def clean_identifiant_externe(row, _):
 
 
 def compute_identifiant_unique(identifiant_externe, source_code):
+    from utils.django import django_setup_full
+
     django_setup_full()
 
     from qfdmo.models.utils import compute_identifiant_unique
@@ -408,6 +409,8 @@ def _sanitize_string(str_to_sanitize):
 
 
 def _clean_lieu_prestation(service_a_domicile):
+    from utils.django import django_setup_full
+
     django_setup_full()
 
     from qfdmo.models.acteur import Acteur
@@ -435,6 +438,8 @@ def _clean_departement_code(departement_code):
 
 
 def _clean_perimetre_adomicile_codes(perimetre_dinterventions):
+    from utils.django import django_setup_full
+
     django_setup_full()
 
     from qfdmo.models.acteur import PerimetreADomicile
@@ -498,6 +503,8 @@ def _clean_perimetre_adomicile_codes(perimetre_dinterventions):
 
 
 def clean_service_a_domicile(row, _):
+    from utils.django import django_setup_full
+
     django_setup_full()
 
     from qfdmo.models.acteur import Acteur

--- a/data-platform/dags/suggestions/tasks/business_logic/db_apply_suggestion.py
+++ b/data-platform/dags/suggestions/tasks/business_logic/db_apply_suggestion.py
@@ -4,7 +4,6 @@ from django.db import transaction
 from suggestions.tasks.business_logic.db_check_suggestion_to_process import (
     get_suggestions_toprocess,
 )
-from utils.django import django_setup_full
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +14,8 @@ def suggestion_apply_atomic(suggestion):
 
 
 def db_apply_suggestion(use_suggestion_groupe: bool = False):
+    from utils.django import django_setup_full
+
     django_setup_full()
     from data.models.suggestion import SuggestionStatut
 

--- a/data-platform/dags/suggestions/tasks/business_logic/db_check_suggestion_to_process.py
+++ b/data-platform/dags/suggestions/tasks/business_logic/db_check_suggestion_to_process.py
@@ -1,5 +1,3 @@
-from utils.django import django_setup_full
-
 # Here we get only the suggestion with AVALIDER status
 # ENCOURS status is for suggestion that are being processed, it can remain sommes
 # suggestions with this status after process it if Airflow cluster shutdown suddenly
@@ -7,6 +5,8 @@ from utils.django import django_setup_full
 
 
 def get_suggestions_toprocess(use_suggestion_groupe: bool = False):
+    from utils.django import django_setup_full
+
     django_setup_full()
     from data.models.suggestion import Suggestion, SuggestionGroupe, SuggestionStatut
 

--- a/data-platform/dags/tests/enrich/tasks/test_enrich_lien_succession_suggest.py
+++ b/data-platform/dags/tests/enrich/tasks/test_enrich_lien_succession_suggest.py
@@ -127,9 +127,7 @@ class TestEnrichLienSuccessionSuggest:
             ]
         )
 
-        mocker.patch(
-            "enrich.tasks.business_logic.enrich_lien_succession_suggest.django_setup_full"
-        )
+        mocker.patch("utils.django.django_setup_full")
         mocker.patch(
             "enrich.tasks.business_logic.enrich_lien_succession_suggest._est_parent_par_acteur",
             return_value={"acteur-a": False},

--- a/data-platform/dags/tools/dags/airflow_logs.py
+++ b/data-platform/dags/tools/dags/airflow_logs.py
@@ -5,7 +5,6 @@ from airflow.providers.standard.operators.python import PythonOperator
 from shared.config.airflow import DEFAULT_ARGS_NO_RETRIES
 from shared.config.start_dates import START_DATES
 from shared.config.tags import TAGS
-from utils.django import django_setup_full
 
 logger = logging.getLogger(__name__)
 
@@ -13,6 +12,8 @@ logger = logging.getLogger(__name__)
 def test_django_and_logs():
     # Load Django environement to test Django and saving airflow logs to s3 storage
     # are compatible
+    from utils.django import django_setup_full
+
     django_setup_full()
     logger.info("Test Django and Logs")
 

--- a/data-platform/dags/utils/airflow_params.py
+++ b/data-platform/dags/utils/airflow_params.py
@@ -8,8 +8,6 @@ https://airflow.apache.org/docs/apache-airflow/stable/best-practices.html#top-le
 
 import re
 
-from utils.django import django_setup_full
-
 ID_PREFIX = "id="
 
 
@@ -49,6 +47,8 @@ def airflow_params_dropdown_codes_to_ids(model_name: str) -> dict[str, str]:
     """Returns a mapping of {code (id=id)} -> id so it can be used in Airflow Params UI:
     - keys = used in Param.examples = what user sees/selects
     - whole dict = used in Param.values_display = converts selections back to ids"""
+    from utils.django import django_setup_full
+
     django_setup_full()
     from qfdmo.models import ActeurType, Source
 

--- a/data-platform/dags/utils/data_serialize_reconstruct.py
+++ b/data-platform/dags/utils/data_serialize_reconstruct.py
@@ -6,13 +6,13 @@ import logging
 from datetime import datetime
 from typing import Any
 
-from utils.django import django_setup_full
-
 logger = logging.getLogger(__name__)
 
 
 def value_to_json_ready(key: str, value):
     """Convert a parent_data_new value to a JSON-serializable form."""
+
+    from utils.django import django_setup_full
 
     django_setup_full()
     from django.db import models
@@ -58,6 +58,8 @@ def data_serialize(model: type[Any], data: dict) -> dict:
     Returns:
     - A dictionary with values adjusted to match the model's requirements.
     """
+    from utils.django import django_setup_full
+
     django_setup_full()
     from django.db import models
     from qfdmo.models.utils import django_model_to_wire

--- a/data-platform/dags/utils/db_tmp_tables.py
+++ b/data-platform/dags/utils/db_tmp_tables.py
@@ -6,7 +6,6 @@ import logging
 import pandas as pd
 from sources.tasks.transform.sequence_utils import convert_numpy_to_jsonify
 from sqlalchemy import text
-from utils.django import DJANGO_WH_CONNECTION_NAME, django_conn_to_sqlalchemy_engine
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +46,8 @@ def create_temporary_table(
         table_name: Name of the temporary table to create
         engine: SQLAlchemy engine for database connection
     """
+
+    from utils.django import DJANGO_WH_CONNECTION_NAME, django_conn_to_sqlalchemy_engine
 
     # Create a SQLAlchemy engine from the Django connection
     engine = django_conn_to_sqlalchemy_engine(using=DJANGO_WH_CONNECTION_NAME)
@@ -103,6 +104,8 @@ def read_temporary_table(table_name: str) -> pd.DataFrame:
     """
     Read a temporary table from the database and convert JSON columns back to dict/list.
     """
+    from utils.django import DJANGO_WH_CONNECTION_NAME, django_conn_to_sqlalchemy_engine
+
     engine = django_conn_to_sqlalchemy_engine(using=DJANGO_WH_CONNECTION_NAME)
 
     df = (
@@ -120,6 +123,8 @@ def drop_temporary_table(table_name: str):
     """
     Drop the temporary table from the database.
     """
+    from utils.django import DJANGO_WH_CONNECTION_NAME, django_conn_to_sqlalchemy_engine
+
     engine = django_conn_to_sqlalchemy_engine(using=DJANGO_WH_CONNECTION_NAME)
 
     with engine.begin() as conn:  # type: ignore

--- a/webapp/core/models/tools.py
+++ b/webapp/core/models/tools.py
@@ -1,12 +1,12 @@
 import logging
 
 from django.db import connections
-from utils.django import DJANGO_WH_CONNECTION_NAME
 
 logger = logging.getLogger(__name__)
 
 
 def compare_model_vs_table(cls, table_name: str) -> bool:
+    from utils.django import DJANGO_WH_CONNECTION_NAME
 
     def are_fields_matched(db_type, model_type):
         logger.info(f"Comparing {db_type} with {model_type}")


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [Résoudre Airflow v3 qui perd les DAGs](https://app.notion.com/p/accelerateur-transition-ecologique-ademe/R-soudre-Airflow-v3-qui-perd-les-DAGs-3796523d57d78008a30bfb2f3f0dad7c?v=7fa49e1bda7e4f8baed5d646aef65fbe&source=copy_link)

**🗺️ contexte**: AIRFLOW

**💡 quoi**: le dag processor de airflow a du mal à charger les DAGs

**🎯 pourquoi**: Pour certains DAG, on charge encore Django lors de l'interprétation des fichiers

**🤔 comment**: 

- On charge désormais Django en lazy : à l'intérieur des fonctions
- Par convention, tous les appels à utils.django sont fait dans les fonctions
- Les valeurs par défaut des DAG de tye soure sont écrites en dur, c'est pas idéale mais ça permet une dépendance à l'API en moins ainsi que des routes d'API en moins

**🤓 comment tester**: 

- tous les DAGs Airflow doivent marcher correctement

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
