### PR TITLE
Corrections diverses pour améliorer la robustesse des tests e2e

### DIFF
--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -10,10 +10,10 @@ endif
 BASE_DOMAIN := quefairedemesdechets.ademe.local
 BLACK := uv run black
 DB_URL := postgres://webapp:***@localhost:6543/webapp# pragma: allowlist secret
-DJANGO_ADMIN := $(PYTHON) manage.py
 FIXTURES_OPTIONS := --indent 4 --natural-foreign --natural-primary
 PYTEST := uv run pytest
 PYTHON := uv run python
+DJANGO_ADMIN := $(PYTHON) manage.py
 RUFF := uv run ruff
 
 .PHONY: sync

--- a/webapp/e2e_tests/iframe_navigation.spec.ts
+++ b/webapp/e2e_tests/iframe_navigation.spec.ts
@@ -119,7 +119,7 @@ test.describe("📄 Découpe du contenu de la fiche dans l'iframe", () => {
     expect(onclick).toContain("window.open")
     expect(onclick).toContain("_blank")
     // It opens a fiche déchet URL, not the generic "En savoir plus sur cet outil" target.
-    expect(onclick).toContain("/dechet/")
+    expect(onclick).toContain("/categories/")
   })
 
   test("Le contenu détaillé est masqué dans l'iframe mais présent en version autonome", async ({

--- a/webapp/e2e_tests/iframe_navigation.spec.ts
+++ b/webapp/e2e_tests/iframe_navigation.spec.ts
@@ -58,6 +58,7 @@ test.describe("🧭 Navigation dans l'iframe avec persistance de l'UI", () => {
     // Wait for product page to load (heading with product name)
     await iframe.locator("h1").waitFor({ state: "visible", timeout: TIMEOUT.DEFAULT })
     await expect(iframe.locator("h1")).toContainText("Écran", {
+      ignoreCase: true,
       timeout: TIMEOUT.DEFAULT,
     })
 
@@ -80,6 +81,7 @@ test.describe("🧭 Navigation dans l'iframe avec persistance de l'UI", () => {
     // Wait for product page to load
     await iframe.locator("h1").waitFor({ state: "visible", timeout: TIMEOUT.DEFAULT })
     await expect(iframe.locator("h1")).toContainText("Écran", {
+      ignoreCase: true,
       timeout: TIMEOUT.DEFAULT,
     })
 
@@ -95,6 +97,7 @@ test.describe("📄 Découpe du contenu de la fiche dans l'iframe", () => {
     await results.first().click()
     await iframe.locator("h1").waitFor({ state: "visible", timeout: TIMEOUT.DEFAULT })
     await expect(iframe.locator("h1")).toContainText("Écran", {
+      ignoreCase: true,
       timeout: TIMEOUT.DEFAULT,
     })
   }


### PR DESCRIPTION
# Description succincte du problème résolu


**🗺️ contexte**: tests / ci

**💡 quoi**: les e2e sont en échec sur la main 

**🎯 pourquoi**: 
- pour rendre les tests e2e plus résilient 
- parce que la CI n'utilisait pas les commandes préfixées de uv run ce qui empêche d'avoir toutes les dépendances correctements installées

**🤔 comment**: 
- utilisation d'une option ignoreCase pour les comparaisons de strings dans les assertions playwright, ce qui permet d'éviter de casser lors de la mise à jour d'un wording
- correction d'une assertion qui reposait sur un ancien contenu 
- remontée d'une variable dans le makefile

**🤓 comment tester**: 

`npx playwright test --update-snapshots all ./e2e_tests/iframe_navigation.spec.ts`

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

