### PR TITLE
Corrige des erreurs sur le déploiement des environnements de preview

### DIFF
--- a/.github/workflows/_webapp-build-and-push-docker.yml
+++ b/.github/workflows/_webapp-build-and-push-docker.yml
@@ -52,7 +52,7 @@ jobs:
       - name: "[🟣 Scaleway] Build and push webapp Docker image"
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
-          context: webapp
+          context: .
           file: webapp/Dockerfile
           # Scaleway Serverless Containers only run amd64
           platforms: linux/amd64

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,8 @@ x-airflow-common: &airflow-common
 services:
   lvao-proxy:
     build:
-      context: ./webapp
-      dockerfile: nginx/Dockerfile
+      context: .
+      dockerfile: webapp/nginx/Dockerfile
     extra_hosts:
       - "host.docker.internal:host-gateway"
     ports:

--- a/webapp/.env.template
+++ b/webapp/.env.template
@@ -58,6 +58,10 @@ NOTION_CONTACT_FORM_DATABASE_ID=17c6523d57d78140b87f000cd3ecef4b # Correspond à
 BASE_URL=https://quefairedemesdechets.ademe.local
 LEGACY_SITE_VITRINE_DOMAIN=longuevieauxobjets.ademe.local
 
+# Local Ollama instance, used by the report_genre_nombre_migrated_pages
+# management command as a fallback classifier. Local-only, not deployed.
+# OLLAMA_BASE_URL=https://ollama.home.fabien.cool
+
 # API Stats
 POSTHOG_PERSONAL_API_KEY=
 
@@ -72,4 +76,8 @@ NGINX_DISABLE_CACHE=0
 
 # Local dev uses settings.dev — overrides from base with developer
 # conveniences (DEBUG toolbar, etc.) and the geo-libs guard above.
-DJANGO_SETTINGS_MODULE=settings.dev
+# Uncomment in your local .env. It MUST stay commented in this template:
+# pytest loads this file (pyproject `env_files`) and an active
+# DJANGO_SETTINGS_MODULE env var would override the pytest-django ini
+# setting (settings.test), making tests run under dev settings.
+# DJANGO_SETTINGS_MODULE=settings.dev

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -6,9 +6,10 @@ FROM node:24-slim AS node_build
 WORKDIR /build
 
 # Install JS deps first for better caching
-COPY webapp/ .
-RUN npm ci
-RUN npm run build
+COPY webapp/ ./webapp/
+COPY package-lock.json package.json .
+RUN npm -w webapp ci
+RUN npm -w webapp run build
 
 
 ############################################
@@ -19,7 +20,7 @@ RUN npm run build
 FROM ruby:alpine AS nginx_config
 
 WORKDIR /build
-COPY webapp/servers.conf.erb .
+COPY servers.conf.erb .
 
 # PORT=8000: Scaleway container port (TLS terminated by Scaleway).
 # NGINX_ALLOW_ALL_HOSTS=1: preview domain unknown at build time.
@@ -44,7 +45,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     UV_LINK_MODE=copy
 
-WORKDIR /opt/app
+WORKDIR /app
 
 # System deps: GDAL for GeoDjango, gettext for compilemessages,
 # libpq5 for psycopg at runtime (mirrors the Scalingo Aptfile),
@@ -70,26 +71,21 @@ COPY webapp/pyproject.toml webapp/pyproject.toml
 RUN /root/.local/bin/uv sync --project webapp --frozen --no-dev
 
 # Use the venv for subsequent RUN/CMD
-ENV VIRTUAL_ENV="/opt/app/.venv" \
-    PATH="/opt/app/.venv/bin:${PATH}"
+ENV VIRTUAL_ENV="/app/.venv" \
+    PATH="/app/.venv/bin:${PATH}"
 
 # Copy app code
-WORKDIR /opt/app/webapp
-COPY webapp/ ./
+COPY webapp/ /app/webapp
 
 # Internationalisation and customisation of Wagtail messages.
-# SECRET_KEY is the only env var without a default in settings; any value
-# works for build-time management commands.
-# RUN DJANGO_SETTINGS_MODULE=settings.base SECRET_KEY=dummy python manage.py compilemessages -l fr
+# This must be ran from git repo root for some obscure reason.
+# Running it from webapp subdirectory causes issues
+RUN SECRET_KEY=dummy python /app/webapp/manage.py compilemessages -l fr
 
+WORKDIR /app/webapp
 # Copy built frontend assets, then collect them
-COPY --from=node_build /build/static/compiled/ static/compiled/
-
-RUN DJANGO_SETTINGS_MODULE=settings.base SECRET_KEY=dummy python manage.py collectstatic --noinput
-
-# Required while we share scalingo and scaleway config.
-RUN mkdir -p /app/staticfiles
-RUN cp -r /opt/app/webapp/staticfiles/* /app/staticfiles/
+COPY --from=node_build /build/webapp/static/compiled/ static/compiled/
+RUN SECRET_KEY=dummy python manage.py collectstatic --noinput
 
 # Nginx: use the same nginx.conf + rendered servers.conf as Scalingo.
 # The rendered servers.conf is compiled in stage 2 with preview vars.

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -3,14 +3,11 @@
 ############################################
 FROM node:24-slim AS node_build
 
-WORKDIR /app
+WORKDIR /build
 
 # Install JS deps first for better caching
-COPY package.json package-lock.json ./
+COPY webapp/ .
 RUN npm ci
-
-# Parcel build inputs
-COPY . ./
 RUN npm run build
 
 
@@ -22,7 +19,7 @@ RUN npm run build
 FROM ruby:alpine AS nginx_config
 
 WORKDIR /build
-COPY servers.conf.erb .
+COPY webapp/servers.conf.erb .
 
 # PORT=8000: Scaleway container port (TLS terminated by Scaleway).
 # NGINX_ALLOW_ALL_HOSTS=1: preview domain unknown at build time.
@@ -47,7 +44,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     UV_LINK_MODE=copy
 
-WORKDIR /app
+WORKDIR /opt/app
 
 # System deps: GDAL for GeoDjango, gettext for compilemessages,
 # libpq5 for psycopg at runtime (mirrors the Scalingo Aptfile),
@@ -68,30 +65,37 @@ RUN apt-get update \
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh -s -- --no-modify-path
 
 # Install python deps (cached as long as lockfiles unchanged)
-COPY pyproject.toml uv.lock ./
-RUN /root/.local/bin/uv sync --frozen --no-dev
+COPY pyproject.toml uv.lock .
+COPY webapp/pyproject.toml webapp/pyproject.toml
+RUN /root/.local/bin/uv sync --project webapp --frozen --no-dev
 
 # Use the venv for subsequent RUN/CMD
-ENV VIRTUAL_ENV="/app/.venv" \
-    PATH="/app/.venv/bin:${PATH}"
+ENV VIRTUAL_ENV="/opt/app/.venv" \
+    PATH="/opt/app/.venv/bin:${PATH}"
 
 # Copy app code
-COPY . ./
+WORKDIR /opt/app/webapp
+COPY webapp/ ./
 
 # Internationalisation and customisation of Wagtail messages.
 # SECRET_KEY is the only env var without a default in settings; any value
 # works for build-time management commands.
-RUN SECRET_KEY=dummy python manage.py compilemessages -l fr
+# RUN DJANGO_SETTINGS_MODULE=settings.base SECRET_KEY=dummy python manage.py compilemessages -l fr
 
 # Copy built frontend assets, then collect them
-COPY --from=node_build /app/static/compiled ./static/compiled
-RUN SECRET_KEY=dummy python manage.py collectstatic --noinput
+COPY --from=node_build /build/static/compiled/ static/compiled/
+
+RUN DJANGO_SETTINGS_MODULE=settings.base SECRET_KEY=dummy python manage.py collectstatic --noinput
+
+# Required while we share scalingo and scaleway config.
+RUN mkdir -p /app/staticfiles
+RUN cp -r /opt/app/webapp/staticfiles/* /app/staticfiles/
 
 # Nginx: use the same nginx.conf + rendered servers.conf as Scalingo.
 # The rendered servers.conf is compiled in stage 2 with preview vars.
 RUN rm -f /etc/nginx/sites-enabled/default \
     && rm -f /etc/nginx/conf.d/default.conf 2>/dev/null
-COPY nginx/nginx.conf /etc/nginx/nginx.conf
+RUN mv nginx/nginx.conf /etc/nginx/nginx.conf
 COPY --from=nginx_config /build/servers.conf /etc/nginx/servers.conf
 
 EXPOSE 8000

--- a/webapp/nginx/Dockerfile
+++ b/webapp/nginx/Dockerfile
@@ -1,7 +1,7 @@
 FROM nginx:alpine
 RUN apk add --no-cache ruby
-COPY nginx/nginx.conf /etc/nginx/nginx.conf
-COPY nginx/entrypoint.sh /entrypoint.sh
+COPY webapp/nginx/nginx.conf /etc/nginx/nginx.conf
+COPY webapp/nginx/entrypoint.sh /entrypoint.sh
 COPY servers.conf.erb /etc/nginx/servers.conf.erb
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
# Description succincte du problème résolu

récupération de changements appliqués pour déployer #3160 


**🗺️ contexte**: environnements de preview

**💡 quoi**: modification du dockerfile depuis les changements sur les workspaces uv pour s'aligner avec ce qui est fait sur les dockerfile airflow 

**🎯 pourquoi**: 

car depuis qu'on a déplacé les lockfiles, build / déployer depuis le sous-dossier webapp ne permettait plus d'avoir un lockfile à jour dans le conteneur docker

**🤔 comment**: 

- remontée d'un cran pour le contexte du build 
- adaptation des chemins 
- 2-3 modifications dans l'environnement local qui étaient accidentellement passées sur main 

**🤓 comment tester**: 
- vérifier que la preview se déploie bien sur cette PR ou sur #3160 

