### PR TITLE
Interdire les lignes vides pour les propositions de services du jeu de données opendata

### DIFF
--- a/data-platform/dags/acteurs/dags/compute_acteur.py
+++ b/data-platform/dags/acteurs/dags/compute_acteur.py
@@ -72,13 +72,24 @@ with DAG(
     )
     dbt_run_exposure_acteurs_opendata = BashOperator(
         task_id="dbt_run_exposure_acteurs_opendata",
-        bash_command=(f"{DBT_RUN} exposure.acteurs.opendata"),
+        bash_command=(f"{DBT_RUN} exposure.acteurs.opendata.exposure_opendata_acteur"),
     )
     dbt_test_exposure_acteurs_opendata = BashOperator(
         task_id="dbt_test_exposure_acteurs_opendata",
-        bash_command=(f"{DBT_TEST} exposure.acteurs.opendata"),
+        bash_command=(f"{DBT_TEST} exposure.acteurs.opendata.exposure_opendata_acteur"),
     )
-
+    dbt_run_exposure_acteurs_opendata_published = BashOperator(
+        task_id="dbt_run_exposure_acteurs_opendata_published",
+        bash_command=(
+            f"{DBT_RUN} exposure.acteurs.opendata.exposure_opendata_acteur_published"
+        ),
+    )
+    dbt_test_exposure_acteurs_opendata_published = BashOperator(
+        task_id="dbt_test_exposure_acteurs_opendata_published",
+        bash_command=(
+            f"{DBT_TEST} exposure.acteurs.opendata.exposure_opendata_acteur_published"
+        ),
+    )
     dbt_run_marts_acteurs_exhaustive = BashOperator(
         task_id="dbt_run_marts_acteurs_exhaustive",
         bash_command=(f"{DBT_RUN} marts.acteurs.exhaustive"),
@@ -149,14 +160,16 @@ with DAG(
         dbt_test_marts_acteurs_carte,
         dbt_run_exposure_acteurs_carte,
         dbt_test_exposure_acteurs_carte,
-        dbt_run_marts_acteurs_opendata,
-        dbt_test_marts_acteurs_opendata,
-        dbt_run_exposure_acteurs_opendata,
-        dbt_test_exposure_acteurs_opendata,
         dbt_run_marts_acteurs_exhaustive,
         dbt_test_marts_acteurs_exhaustive,
         dbt_run_exposure_acteurs_exhaustive,
         dbt_test_exposure_acteurs_exhaustive,
+        dbt_run_marts_acteurs_opendata,
+        dbt_test_marts_acteurs_opendata,
+        dbt_run_exposure_acteurs_opendata,
+        dbt_test_exposure_acteurs_opendata,
+        dbt_run_exposure_acteurs_opendata_published,
+        dbt_test_exposure_acteurs_opendata_published,
     )
     # Définir la séquence de vérification en parallèle
     # EPCI

--- a/data-platform/dags/acteurs/dags/export_opendata.py
+++ b/data-platform/dags/acteurs/dags/export_opendata.py
@@ -30,7 +30,7 @@ with DAG(
         "bucket_name": "lvao-opendata",
         "remote_dir": "acteurs" if ENVIRONMENT == "prod" else f"acteurs-{ENVIRONMENT}",
         "s3_connection_id": "s3data",
-        "opendata_table": "exposure_opendata_acteur",
+        "opendata_table": "exposure_opendata_acteur_published",
     },
     max_active_runs=1,
 ) as dag:

--- a/data-platform/dbt/models/exposure/acteurs/opendata/exposure_opendata_acteur_published.sql
+++ b/data-platform/dbt/models/exposure/acteurs/opendata/exposure_opendata_acteur_published.sql
@@ -1,0 +1,1 @@
+SELECT * FROM {{ ref('exposure_opendata_acteur') }}

--- a/data-platform/dbt/models/exposure/acteurs/opendata/schema.yml
+++ b/data-platform/dbt/models/exposure/acteurs/opendata/schema.yml
@@ -8,74 +8,83 @@ models:
         description: "L'identifiant unique de l'acteur"
         data_type: text
         tests:
-          - unique
-          - not_null
           - dbt_expectations.expect_column_to_exist
           - not_empty_string
+          - not_null
+          - unique
       - name: paternite
         description: "La paternité de l'acteur"
         data_type: text
         tests:
-          - not_null
           - dbt_expectations.expect_column_to_exist
           - not_empty_string
+          - not_null
       - name: identifiants_des_contributeurs
         description: "Les identifiants des contributeurs de l'acteur"
         data_type: jsonb
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: nom
         description: "Le nom de l'acteur"
         data_type: text
         tests:
-          - not_null
           - dbt_expectations.expect_column_to_exist
           - not_empty_string
+          - not_null
       - name: nom_commercial
         description: "Le nom commercial de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: siren
         description: "Le SIREN de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: siret
         description: "Le SIRET de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: description
         description: "La description de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: type_dacteur
         description: "Le type d'acteur"
         data_type: text
         tests:
-          - not_null
           - dbt_expectations.expect_column_to_exist
+          - not_null
       - name: site_web
         description: "Le site web de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: telephone
         description: "Le téléphone de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: adresse
         description: "L'adresse de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: complement_dadresse
         description: "Le complément d'adresse de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: code_postal
         description: "Le code postal de l'acteur"
@@ -91,37 +100,46 @@ models:
         description: "Le code commune de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: code_epci
         description: "Le code EPCI de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: nom_epci
         description: "Le nom EPCI de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: latitude
         description: "La latitude de l'acteur"
         data_type: float
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: longitude
         description: "La longitude de l'acteur"
         data_type: float
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: qualites_et_labels
         description: "Les qualités et labels de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: public_accueilli
         description: "Le public accueilli par l'acteur"
         data_type: text
         tests:
           - dbt_expectations.expect_column_to_exist
+          - accepted_values:
+              arguments:
+                values: ['', 'Particuliers', 'Professionnels', 'Particuliers et professionnels']
       - name: reprise
         description: "La reprise de l'acteur"
         data_type: text
@@ -155,92 +173,410 @@ models:
         description: "Les consignes d'accès de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: horaires_description
         description: "Les horaires de l'acteur sous forme de texte"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: horaires_osm
         description: "Les horaires au format OSM de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: lieu_prestation
         description: "Le lieu de prestation de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: perimetreadomicile
         description: "Les périmètres à domicile de l'acteur"
         data_type: jsonb
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: propositions_de_services
         description: "Les propositions de services de l'acteur"
         data_type: text
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_empty_string
+          - not_null
       - name: emprunter
         description: "Les sous-categories associées à l'action emprunter de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: preter
         description: "Les sous-categories associées à l'action preter de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: louer
         description: "Les sous-categories associées à l'action louer de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: mettreenlocation
         description: "Les sous-categories associées à l'action mettreenlocation de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: reparer
         description: "Les sous-categories associées à l'action reparer de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: donner
         description: "Les sous-categories associées à l'action donner de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: trier
         description: "Les sous-categories associées à l'action trier de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: echanger
         description: "Les sous-categories associées à l'action echanger de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: revendre
         description: "Les sous-categories associées à l'action revendre de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: acheter
         description: "Les sous-categories associées à l'action acheter de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: rapporter
         description: "Les sous-categories associées à l'action rapporter de l'acteur"
         data_type: text
         tests:
+          - at_least_one_not_empty
           - dbt_expectations.expect_column_to_exist
       - name: date_de_derniere_modification
         description: "La date de dernière modification de l'acteur"
         data_type: text
         tests:
           - dbt_expectations.expect_column_to_exist
+          - not_empty_string
+          - not_null
+    tests:
+      - dbt_expectations.expect_table_row_count_to_be_between:
+          arguments:
+            min_value: 250000
+      - dbt_expectations.expect_table_column_count_to_equal:
+          arguments:
+            value: 44
+    config:
+      contract:
+        enforced: true
+      tags:
+        - exposure
+        - opendata
+        - acteurs
+        - acteur
+      materialized: table
+      indexes:
+        - columns: ['identifiant']
+          unique: true
+          type: btree
+  - name: exposure_opendata_acteur_published
+    description: "Copie des acteurs partagés en Open Data pour la publication"
+    columns:
+      - name: identifiant
+        description: "L'identifiant unique de l'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_empty_string
+          - not_null
+          - unique
+      - name: paternite
+        description: "La paternité de l'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_empty_string
+          - not_null
+      - name: identifiants_des_contributeurs
+        description: "Les identifiants des contributeurs de l'acteur"
+        data_type: jsonb
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: nom
+        description: "Le nom de l'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_empty_string
+          - not_null
+      - name: nom_commercial
+        description: "Le nom commercial de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: siren
+        description: "Le SIREN de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: siret
+        description: "Le SIRET de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: description
+        description: "La description de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: type_dacteur
+        description: "Le type d'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_null
+      - name: site_web
+        description: "Le site web de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: telephone
+        description: "Le téléphone de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: adresse
+        description: "L'adresse de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: complement_dadresse
+        description: "Le complément d'adresse de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: code_postal
+        description: "Le code postal de l'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
+      - name: ville
+        description: "La ville de l'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
+      - name: code_commune
+        description: "Le code commune de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: code_epci
+        description: "Le code EPCI de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: nom_epci
+        description: "Le nom EPCI de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: latitude
+        description: "La latitude de l'acteur"
+        data_type: float
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: longitude
+        description: "La longitude de l'acteur"
+        data_type: float
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: qualites_et_labels
+        description: "Les qualités et labels de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: public_accueilli
+        description: "Le public accueilli par l'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - accepted_values:
+              arguments:
+                values: ['', 'Particuliers', 'Professionnels', 'Particuliers et professionnels']
+      - name: reprise
+        description: "La reprise de l'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - accepted_values:
+              arguments:
+                values: ['','1 pour 1', '1 pour 0']
+      - name: exclusivite_de_reprisereparation
+        description: "L'exclusivité de reprise/réparation de l'acteur"
+        data_type: boolean
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - accepted_values:
+              arguments:
+                values: [true, false]
+      - name: uniquement_sur_rdv
+        description: "L'uniquement sur RDV de l'acteur"
+        data_type: boolean
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - accepted_values:
+              arguments:
+                values: [true, false]
+      - name: type_de_services
+        description: "Le type de services de l'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
+      - name: consignes_dacces
+        description: "Les consignes d'accès de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: horaires_description
+        description: "Les horaires de l'acteur sous forme de texte"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: horaires_osm
+        description: "Les horaires au format OSM de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: lieu_prestation
+        description: "Le lieu de prestation de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: perimetreadomicile
+        description: "Les périmètres à domicile de l'acteur"
+        data_type: jsonb
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: propositions_de_services
+        description: "Les propositions de services de l'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_empty_string
+          - not_null
+      - name: emprunter
+        description: "Les sous-categories associées à l'action emprunter de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: preter
+        description: "Les sous-categories associées à l'action preter de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: louer
+        description: "Les sous-categories associées à l'action louer de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: mettreenlocation
+        description: "Les sous-categories associées à l'action mettreenlocation de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: reparer
+        description: "Les sous-categories associées à l'action reparer de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: donner
+        description: "Les sous-categories associées à l'action donner de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: trier
+        description: "Les sous-categories associées à l'action trier de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: echanger
+        description: "Les sous-categories associées à l'action echanger de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: revendre
+        description: "Les sous-categories associées à l'action revendre de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: acheter
+        description: "Les sous-categories associées à l'action acheter de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: rapporter
+        description: "Les sous-categories associées à l'action rapporter de l'acteur"
+        data_type: text
+        tests:
+          - at_least_one_not_empty
+          - dbt_expectations.expect_column_to_exist
+      - name: date_de_derniere_modification
+        description: "La date de dernière modification de l'acteur"
+        data_type: text
+        tests:
+          - dbt_expectations.expect_column_to_exist
+          - not_empty_string
+          - not_null
     tests:
       - dbt_expectations.expect_table_row_count_to_be_between:
           arguments:

--- a/data-platform/dbt/tests/generic/test_at_least_one_not_empty.sql
+++ b/data-platform/dbt/tests/generic/test_at_least_one_not_empty.sql
@@ -1,0 +1,12 @@
+{% test at_least_one_not_empty(model, column_name) %}
+
+    {# Cast to text: comparing float/jsonb to '' is invalid in Postgres. #}
+    select 1
+    where not exists (
+        select 1
+        from {{ model }}
+        where {{ column_name }} is not null
+          and {{ column_name }}::text not in ('', '{}', '[]')
+    )
+
+{% endtest %}


### PR DESCRIPTION
# Description succincte du problème résolu

Mattermost : [Il manque plusieurs colonnes](https://mattermost.incubateur.net/betagouv/pl/coquph8xkbyt3eyoatbcczj36a)


**🗺️ contexte**: Airflow - opendata

**💡 quoi**: colonnes vides sur le jeu de données opendata

**🎯 pourquoi**: Je n'ai pas trouvé pourquoi

**🤔 comment**: 

- Ajout des controles sur les colonnes pour ne pas publier de jeu de données open-data qui serait incomplet
- Ajout d'une étape qui copie la table opendata `exposure_acteurs_opendata` dans `exposure_acteurs_opendata_published` sans aucune transformation, cela permet de ne pas modifier la table `exposure_acteurs_opendata_published` si les tests de `exposure_acteurs_opendata` échoue
- utilisation de `exposure_acteurs_opendata_published` pour publier les données opendata

**🤓 comment tester**: 

- Faire tourner le DAG `Rafraîchissement des acteurs`
- Vérifier que tous les tests passent bien et que la table `exposure_acteurs_opendata_published` est bien générée
- Faire tourner le DAG `Exporter les Acteurs en Open-Data`

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)
