### PR TITLE
Corrige un problème d'import de dépendances sur les dags depuis la mise à jour de Django Tasks

### DIFF
--- a/webapp/settings/airflow.py
+++ b/webapp/settings/airflow.py
@@ -29,7 +29,7 @@ INSTALLED_APPS = [
     "qfdmo",
     "data",
     "django_tasks",
-    "django_tasks.backends.database",
+    "django_tasks_db",
 ]
 
 # Minimal middleware for Airflow (no web requests to handle)


### PR DESCRIPTION
# Description succincte du problème résolu

Corrige un pb de dependance à django_tasks coté data-platform


**🗺️ contexte**: Airflow

**💡 quoi**: Corrige un pb de dependance à django_tasks coté data-platform

**🎯 pourquoi**: dépendance de django_task db qui a été modifiée

