### PR TITLE
a11y(carte): ajoute une alternative textuelle à l'illustration mode l…

### DIFF
--- a/webapp/e2e_tests/a11y_rgaa.spec.ts
+++ b/webapp/e2e_tests/a11y_rgaa.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test"
-import { navigateTo } from "./helpers"
+import { navigateTo, switchToListeMode } from "./helpers"
 
 /**
  * E2E tests for the RGAA audit fixes (contre-audit accessibilité, carte).
@@ -104,6 +104,20 @@ test.describe("♿ RGAA", () => {
       await navigateTo(page, "/lookbook/preview/pages/acteur/")
       const updatedDate = page.locator("p", { hasText: "Mis à jour le" })
       await expect(updatedDate).toBeVisible()
+    })
+  })
+  test.describe("[Carte] 10.8 — Alternative textuelle pour l'illustration mode liste vide", () => {
+    test("Le mode liste sans résultat a une alternative textuelle pour les technologies d'assistance", async ({
+      page,
+    }) => {
+      // Bounding box en pleine mer : garantit l'absence de résultat.
+      await navigateTo(
+        page,
+        '/carte?bounding_box={"southWest":{"lat":0,"lng":0},"northEast":{"lat":1,"lng":1}}',
+      )
+      await switchToListeMode(page)
+      const alt = page.getByText("Aucun résultat trouvé pour votre recherche.")
+      await expect(alt).toBeAttached()
     })
   })
 })

--- a/webapp/templates/ui/components/carte/mode_liste.html
+++ b/webapp/templates/ui/components/carte/mode_liste.html
@@ -20,6 +20,7 @@
                 <span class="max-md:qf-pb-1w qf-mr-auto qf-text-grey-425 qf-text-sm">{{ count }} {{ MODE_LISTE.pagination_suffixe }}</span>
                 {% acteurs_table paginated_acteurs_obj %}
             {% else %}
+            <p class="qf-sr-only">Aucun résultat trouvé pour votre recherche.</p>
             <svg class="qf-max-w-full qf-h-auto qf-mt-[8rem] qf-mb-[4rem]" width="482" height="256" viewBox="0 0 482 256" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
                 <path fill-rule="evenodd" clip-rule="evenodd" d="M193 25.5C192.173 25.5 191.5 24.8271 191.5 24C191.5 23.1728 192.173 22.5 193 22.5C193.827 22.5 194.5 23.1728 194.5 24C194.5 24.8271 193.827 25.5 193 25.5Z" fill="#ECECFE"/>
                 <path fill-rule="evenodd" clip-rule="evenodd" d="M278.5 108C277.673 108 277 107.327 277 106.5C277 105.673 277.673 105 278.5 105C279.327 105 280 105.673 280 106.5C280 107.327 279.327 108 278.5 108Z" fill="#ECECFE"/>


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [\[Carte\] - 10.8 - Pour chaque page web, les contenus cachés ont-ils vocation à être ignorés par les technologies d'assistance ?](https://app.notion.com/p/3986523d57d7804dbe5ff2109a698926)

**N'oublier pas de taguer** : `accessibility`

**🗺️ contexte**: Audit RGAA de la carte interactive — critère 10.8 (contenus cachés ayant vocation à être ignorés par les technologies d'assistance).

**💡 quoi**: Lorsque le mode liste n'a aucun résultat, l'illustration affichée (un SVG) est `aria-hidden` sans qu'aucune alternative textuelle ne soit fournie.

**🎯 pourquoi**: Le SVG est correctement masqué aux technologies d'assistance (il est purement graphique), mais aucune information alternative n'est fournie à la place : un utilisateur de lecteur d'écran naviguant en mode liste sans résultat n'a aucun moyen de savoir que la recherche n'a rien retourné.

**🤔 comment**:
- `ui/components/carte/mode_liste.html` : ajout d'un `<p class="qf-sr-only">Aucun résultat trouvé pour votre recherche.</p>` avant le SVG (masqué visuellement, lu par les lecteurs d'écran)
- Ajout d'un test e2e forçant une recherche sans résultat (bounding box en pleine mer) et vérifiant la présence de ce texte

**🤓 comment tester**:
```bash
cd webapp && npx playwright test --reporter=list ./e2e_tests/a11y_rgaa.spec.ts
```

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] Vérifier que le texte proposé (« Aucun résultat trouvé pour votre recherche. ») correspond bien à l'intention du message illustré par le SVG — je n'ai pas pu visualiser le rendu du SVG pour confirmer le message exact qu'il représente (voir détails dans le commentaire Notion / rgaa/log.txt)

## 📆 A faire (prochaine PR)

- [ ] Aucun
