### PR TITLE
a11y(produit): masque l'image info-tri décorative aux technologies d'…

### DIFF
--- a/webapp/e2e_tests/a11y_rgaa.spec.ts
+++ b/webapp/e2e_tests/a11y_rgaa.spec.ts
@@ -120,4 +120,11 @@ test.describe("♿ RGAA", () => {
       await expect(alt).toBeAttached()
     })
   })
+  test.describe("[Site Que faire] 1.2 — Image info-tri décorative ignorée", () => {
+    test("L'image info-tri a un alt vide", async ({ page }) => {
+      await navigateTo(page, "/lookbook/preview/pages/produit/")
+      const infotriImg = page.locator(".qf-h-\\[80px\\] img")
+      await expect(infotriImg.first()).toHaveAttribute("alt", "")
+    })
+  })
 })

--- a/webapp/templates/ui/components/produit/_infotri.html
+++ b/webapp/templates/ui/components/produit/_infotri.html
@@ -5,7 +5,7 @@
         <div class="qf-flex md:qf-flex-row qf-flex-col qf-gap-2w">
             {% for infotri_image in infotri %}
                 <div class="qf-h-[80px]">
-                {% image infotri_image.value original preserve-svg height="80" width="auto" class="qf-object-left qf-max-w-full" %}
+                {% image infotri_image.value original preserve-svg height="80" width="auto" class="qf-object-left qf-max-w-full" alt="" %}
                 </div>
             {% endfor %}
         </div>


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [\[Site Que faire\] - 1.2 - Chaque image de décoration est-elle correctement ignorée par les technologies d'assistance ?](https://app.notion.com/p/3986523d57d780d1b4e6f654fb5e16f4)

**N'oublier pas de taguer** : `accessibility`

**🗺️ contexte**: Audit RGAA — critère 1.2 (images de décoration correctement ignorées). Sous-partie « image info-tri » commune aux pages Vêtements et ancienne fiche Téléphone mobile.

**💡 quoi**: L'image info-tri (composant `_infotri.html`, utilisé sur toutes les pages produit) n'a pas d'attribut `alt=""` malgré son caractère purement décoratif.

**🎯 pourquoi**: Un lien texte adjacent (« En savoir plus sur l'Info-tri ») porte déjà l'information ; l'image ne fait qu'illustrer visuellement le tri sans apporter d'information supplémentaire. Sans `alt=""`, les technologies d'assistance tentent de restituer une description de l'image (issue des métadonnées Wagtail), ce qui n'apporte rien à l'utilisateur.

**🤔 comment**:
- `ui/components/produit/_infotri.html` : ajout de `alt=""` au tag `{% image %}` Wagtail
- Ce composant étant partagé par toutes les pages produit (Wagtail et fiches legacy), le correctif s'applique sans changement supplémentaire aux deux pages mentionnées par le ticket
- Ajout d'un test e2e vérifiant l'attribut `alt` vide

**🤓 comment tester**:
```bash
cd webapp && npx playwright test --reporter=list ./e2e_tests/a11y_rgaa.spec.ts
```
Ou visuellement : `/lookbook/preview/pages/produit/`.

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] Aucun

## 📆 A faire (prochaine PR)

- [ ] Les autres sous-points du ticket 1.2 (carte de France et photo d'équipe sur « Qui sommes-nous ? », image objets/bonus sur « Bonus réparation ») nécessitent une édition de contenu Wagtail, pas un correctif de code — voir rgaa/log.txt pour le détail
