### PR TITLE
a11y(carte): masque le logo décoratif des onglets Labels/Sources

### DIFF
--- a/webapp/e2e_tests/a11y_rgaa.spec.ts
+++ b/webapp/e2e_tests/a11y_rgaa.spec.ts
@@ -127,4 +127,14 @@ test.describe("♿ RGAA", () => {
       await expect(infotriImg.first()).toHaveAttribute("alt", "")
     })
   })
+  test.describe("[Carte] 1.2 — Logo décoratif dans les onglets Labels/Sources", () => {
+    test("Le logo précédant un label/source a un alt vide", async ({ page }) => {
+      await navigateTo(page, "/lookbook/preview/pages/acteur/")
+      const logoImg = page.locator('img[src*="/media/logos/"], img[src*="/logos/"]')
+      const count = await logoImg.count()
+      if (count > 0) {
+        await expect(logoImg.first()).toHaveAttribute("alt", "")
+      }
+    })
+  })
 })

--- a/webapp/templates/ui/components/acteur/_label.html
+++ b/webapp/templates/ui/components/acteur/_label.html
@@ -17,7 +17,7 @@
         {% elif source_or_label.logo_file %}
             <img
                 src="{{ source_or_label.logo_file.url }}"
-                alt="Ademe - Agence de la transition écologique"
+                alt=""
                 class="qf-cursor-pointer"
                 width=32
                 height=32


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion : [\[Carte\] - 1.2 - Chaque image de décoration est-elle correctement ignorée par les technologies d'assistance ?](https://app.notion.com/p/3986523d57d780908a41cbd2759cd3f6)

**N'oublier pas de taguer** : `accessibility`, `bug`

**🗺️ contexte**: Audit RGAA de la carte interactive — critère 1.2 (images de décoration correctement ignorées). Sous-partie « logo dans la modale des fiches, onglets Labels et Sources ».

**💡 quoi**: Le logo précédant un label/source dans les onglets « Labels » et « Sources » de la fiche acteur a un `alt` codé en dur « Ademe - Agence de la transition écologique », qui ne correspond pas toujours au logo réellement affiché.

**🎯 pourquoi**: Le libellé visible adjacent (`{{ source_or_label.libelle }}`) porte déjà l'information : le logo est purement décoratif dans ce contexte. De plus, `logo_file` est un champ propre à chaque label/source — le texte alternatif codé en dur était incorrect dès qu'un label/source autre que l'ADEME utilisait ce composant (vérifié : un label « Bonus Répar » avec son propre logo affichait pourtant « Ademe - Agence de la transition écologique » comme alternative).

**🤔 comment**:
- `ui/components/acteur/_label.html` : `alt="Ademe - Agence de la transition écologique"` → `alt=""`
- Ajout d'un test e2e vérifiant l'attribut `alt` vide

**🤓 comment tester**:
```bash
cd webapp && npx playwright test --reporter=list ./e2e_tests/a11y_rgaa.spec.ts
```

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] Aucun

## 📆 A faire (prochaine PR)

- [ ] Aucun

Note : à coordonner avec les tickets 3313/3328 (même thématique logo ADEME/République Française, fichiers différents — voir rgaa/log.txt pour le contexte complet).
