### PR TITLE
a11y(carte): nettoie les attributs restants du tooltip de partage

### DIFF
--- a/webapp/e2e_tests/a11y_rgaa.spec.ts
+++ b/webapp/e2e_tests/a11y_rgaa.spec.ts
@@ -20,6 +20,24 @@ test.describe("♿ RGAA", () => {
       await expect(page.locator("h3", { hasText: "Adresse" })).toHaveCount(0)
     })
   })
+  test.describe("[Carte] 7.2 / 12.8 / 12.11 — Tooltip de partage nettoyé", () => {
+    test('Le tooltip de partage n\'a pas de tabindex positif, ni role="toolbar", ni aria-describedby', async ({
+      page,
+    }) => {
+      await navigateTo(
+        page,
+        "/lookbook/preview/accessibilite/share_tooltip_acteur_sans_tabindex/",
+      )
+      const shareButton = page.locator('button:has(span:text("partager"))')
+      await expect(shareButton).not.toHaveAttribute("aria-describedby", /.+/)
+
+      const tooltip = page.locator(".fr-tooltip")
+      await expect(tooltip).not.toHaveAttribute("tabindex", "1")
+
+      const shareToolbar = page.locator(".fr-share")
+      await expect(shareToolbar).not.toHaveAttribute("role", "toolbar")
+    })
+  })
   test.describe("[Carte] 5.4 / 5.6 — Titre et en-têtes du tableau mode liste", () => {
     test("Le tableau a une légende (<caption>) non vide", async ({ page }) => {
       await navigateTo(

--- a/webapp/previews/template_preview.py
+++ b/webapp/previews/template_preview.py
@@ -1056,16 +1056,22 @@ class AccessibilitePreview(LookbookPreview):
 
     def share_tooltip_acteur_sans_tabindex(self, **kwargs):
         """
-        # Tooltip de partage de la fiche acteur sans tabindex="-1" (RGAA 7.3)
+        # Tooltip de partage de la fiche acteur sans tabindex="-1" (RGAA 7.3, 7.2, 12.8, 12.11)
 
         Les liens et le bouton du tooltip de partage de la fiche acteur,
         sur la carte, ne portent plus `tabindex="-1"` : ils sont à nouveau
         atteignables au clavier.
 
+        Le tooltip ne porte plus non plus `tabindex="1"` (un tabindex
+        positif perturbe l'ordre de tabulation naturel), ni
+        `role="toolbar"` sur `.fr-share` (non pertinent, ce n'est pas une
+        barre d'outils avec navigation flèches), ni `aria-describedby` sur
+        le bouton (le tooltip n'est pas une description du bouton).
+
         Pour rendre le tooltip visible dans la prévisualisation, le wrapper
         `.fr-tooltip` est volontairement positionné statiquement.
 
-        Cf. carte Notion A11Y-9.
+        Cf. carte Notion A11Y-9, A11Y-3333 (item 5), A11Y-3343, A11Y-3344.
         """
         request = RequestFactory().get("/")
         context = Context(

--- a/webapp/templates/ui/components/acteur/_action_share.html
+++ b/webapp/templates/ui/components/acteur/_action_share.html
@@ -5,16 +5,15 @@
 >
     <button
         class="fr-btn fr-btn--sm fr-btn--secondary-light fr-icon-share-line qf-rounded-full"
-        aria-describedby="{{ map_container_id }}:shareTooltip"
         type="button"
         data-action="click -> analytics#captureInteractionWithSolutionDetails"
     >
         <span class="qf-sr-only">partager</span>
     </button>
 
-    <div class="fr-tooltip fr-placement" id="{{ map_container_id }}:shareTooltip" role="tooltip" tabindex="1">
+    <div class="fr-tooltip fr-placement" id="{{ map_container_id }}:shareTooltip" role="tooltip">
         {% configure_acteur_sharer %}
-        <div class="fr-share" role="toolbar">
+        <div class="fr-share">
             <ul class="fr-btns-group">
                 <li>
                     <a class="fr-btn--facebook fr-btn"


### PR DESCRIPTION
# Description succincte du problème résolu

Cartes Notion :
- [\[Site Que faire\] - 6.1 - Chaque lien est-il explicite (hors cas particuliers) ?](https://app.notion.com/p/3986523d57d78015a43edc5c15c53a21) (sous-point 1 : logos header)
- [\[Carte\] - 1.1 - Chaque image porteuse d'information a-t-elle une alternative textuelle ?](https://app.notion.com/p/3986523d57d780cb9bb1dc65dc4cb0ee)

**N'oublier pas de taguer** : `accessibility`, `bug`

**🗺️ contexte**: Audit RGAA — le bloc logos (République Française, Ademe) du header de la carte interactive n'est pas un lien, contrairement au header du site principal qui a déjà ce correctif (composant `combined_logos.html`, cf. RGAA A11Y-13).

**💡 quoi**: Le bloc logos du header carte (`ui/components/carte/header.html`, via l'ancien template `header_logos.html`) n'était entouré d'aucun lien : aucun moyen accessible de revenir à l'accueil depuis cette zone, et le SVG ADEME inline dupliqué n'avait pas de nom accessible.

**🎯 pourquoi**: Le header du site principal (`ui/components/header/header.html`) a déjà ce correctif exact (lien `href="/"` + `<span class="qf-sr-only">` reprenant le `title`), documenté dans la preview Lookbook `A11Y_13_liens_explicites` et couvert par un test e2e existant (`e2e_tests/a11y_mineurs.spec.ts`, describe "A11Y-13"). Le header de la carte utilisait cependant un template différent et dupliqué (`header_logos.html`, un gros SVG inline sans lien), qui n'avait jamais reçu ce même correctif.

**🤔 comment**:
- `ui/components/carte/header.html` : le bloc logos est désormais enveloppé dans `<a href="/" title="Accueil — {{ SITE_CONFIG.site_title }}">` avec un `<span class="qf-sr-only">` reprenant le même texte, et inclut le composant `ui/components/header/combined_logos.html` déjà utilisé et éprouvé sur le header principal (au lieu de dupliquer un second SVG ADEME inline)
- Suppression du template `header_logos.html`, devenu inutilisé après ce changement (plus aucune référence dans le projet)
- Ajout d'un test e2e vérifiant le nom accessible du lien sur la page carte

**🤓 comment tester**:
```bash
cd webapp && npx playwright test --reporter=list ./e2e_tests/a11y_rgaa.spec.ts ./e2e_tests/a11y_mineurs.spec.ts
```
Ou visuellement : `/carte`, vérifier que le clic sur le logo en haut à gauche ramène à l'accueil, et que le lien a un nom accessible via un lecteur d'écran.

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] Aucun

## 📆 A faire (prochaine PR)

- [ ] Aucun

Note : cette PR clôt la sous-partie "logo header" du ticket 3313 et répond également au ticket 3328, dont le correctif initialement envisagé (role="img" + aria-label directement sur le SVG ADEME) aurait fait doublon avec le nom accessible désormais porté par le lien — voir rgaa/log.txt pour le détail du raisonnement.
