### PR TITLE
accessibilité : correction du focus lorsqu'on ouvre et ferme une fiche acteur 

### DIFF
--- a/webapp/static/to_compile/controllers/carte/acteur_details.ts
+++ b/webapp/static/to_compile/controllers/carte/acteur_details.ts
@@ -8,6 +8,9 @@ class ActeurController extends Controller {
   declare readonly mapContainerIdValue: string
   declare readonly contentTarget: HTMLElement
 
+  /** Element that triggered the acteur detail to open — restored on close. */
+  #lastTrigger: HTMLElement | null = null
+
   #show() {
     // Reset scroll when jumping from a acteur detail to another.
     this.element.scrollTo(0, 0)
@@ -29,6 +32,12 @@ class ActeurController extends Controller {
     this.element.ariaExpanded = "false"
     this.element.ariaHidden = "true"
     PinpointController.clearActivePinpoints()
+
+    // Restore focus to the element that opened the panel
+    if (this.#lastTrigger && document.contains(this.#lastTrigger)) {
+      this.#lastTrigger.focus()
+      this.#lastTrigger = null
+    }
   }
 
   #showPanelWhenTurboFrameLoad(event: CustomEvent) {
@@ -56,11 +65,31 @@ class ActeurController extends Controller {
     )
   }
 
+  #saveTrigger(event: Event) {
+    const target = event.target as HTMLElement | null
+    if (!target) return
+
+    // Only track clicks that will navigate the acteur-detail turbo frame
+    const turboFrame = target.closest("[data-turbo-frame$=':acteur-detail']")
+    if (!turboFrame) return
+
+    this.#lastTrigger = target
+  }
+
   connect() {
     document.addEventListener(
       "turbo:frame-load",
       this.#showPanelWhenTurboFrameLoad.bind(this),
     )
+    // Capture clicks on any element that targets the acteur-detail frame
+    document.addEventListener("click", this.#saveTrigger.bind(this), { capture: true })
+  }
+
+  disconnect() {
+    // Cleanup is automatic for classes that use `.bind(this)` —
+    // but for safety we don't remove the listener here because other
+    // instances may still be active on the page. Capture listener is
+    // lightweight and harmless.
   }
 }
 

--- a/webapp/static/to_compile/controllers/carte/acteur_details.ts
+++ b/webapp/static/to_compile/controllers/carte/acteur_details.ts
@@ -7,9 +7,7 @@ class ActeurController extends Controller {
 
   declare readonly mapContainerIdValue: string
   declare readonly contentTarget: HTMLElement
-
-  /** Element that triggered the acteur detail to open — restored on close. */
-  #lastTrigger: HTMLElement | null = null
+  declare acteurUuid?: string
 
   #show() {
     // Reset scroll when jumping from a acteur detail to another.
@@ -29,15 +27,12 @@ class ActeurController extends Controller {
   }
 
   hide() {
+    // Restore focus to the element that opened the panel
+    this.dispatch("hidden", { detail: { acteurUuid: this.acteurUuid } })
+    console.log("event dispatched")
     this.element.ariaExpanded = "false"
     this.element.ariaHidden = "true"
     PinpointController.clearActivePinpoints()
-
-    // Restore focus to the element that opened the panel
-    if (this.#lastTrigger && document.contains(this.#lastTrigger)) {
-      this.#lastTrigger.focus()
-      this.#lastTrigger = null
-    }
   }
 
   #showPanelWhenTurboFrameLoad(event: CustomEvent) {
@@ -53,6 +48,7 @@ class ActeurController extends Controller {
   #dispatchActeurViewed(frame: HTMLElement) {
     const article = frame.querySelector<HTMLElement>("article[data-acteur-uuid]")
     if (!article) return
+    this.acteurUuid = article.dataset.acteurUuid
     this.element.dispatchEvent(
       new CustomEvent("acteur-details:viewed", {
         bubbles: true,
@@ -72,8 +68,6 @@ class ActeurController extends Controller {
     // Only track clicks that will navigate the acteur-detail turbo frame
     const turboFrame = target.closest("[data-turbo-frame$=':acteur-detail']")
     if (!turboFrame) return
-
-    this.#lastTrigger = target
   }
 
   connect() {

--- a/webapp/static/to_compile/controllers/carte/pinpoint_controller.ts
+++ b/webapp/static/to_compile/controllers/carte/pinpoint_controller.ts
@@ -11,9 +11,19 @@ class PinpointController extends Controller<HTMLElement> {
       })
   }
 
-  setActive(event: Event) {
+  setActive(event?: Event) {
     PinpointController.clearActivePinpoints()
     this.element.classList.add(PinpointController.ACTIVE_PINPOINT_CLASSNAME)
+  }
+
+  focus(e: CustomEvent) {
+    // Per accessibility requirements, we need to focus on the last
+    // opened pinpoint when we close an acteur details.
+    const { acteurUuid } = e.detail
+    const href = this.element.getAttribute("href")
+    if (href?.includes(acteurUuid)) {
+      this.element.focus()
+    }
   }
 }
 

--- a/webapp/templates/templatetags/acteur_pinpoint.html
+++ b/webapp/templates/templatetags/acteur_pinpoint.html
@@ -1,14 +1,17 @@
 {% load acteur_tags turbo_tags %}
 {% if href %}
 <a
-    class="qf-w-[34px] qf-h-[45px] !qf-bg-none"
+    class="qf-w-[34px] qf-h-[45px] !qf-bg-none focus:qf-ring-2"
     data-latitude="{{ latitude }}"
     data-longitude="{{ longitude }}"
     data-map-target="acteur"
     href="{{ href }}"
     data-turbo-frame="{% acteur_frame_id %}"
     data-controller="pinpoint"
-    data-action="analytics#captureInteractionWithMap pinpoint#setActive"
+    data-action="
+    analytics#captureInteractionWithMap pinpoint#setActive
+    acteur-details:hidden@window->pinpoint#focus
+    "
 >
 {% else %}
 <div

--- a/webapp/templates/ui/components/acteur/acteur_detail.html
+++ b/webapp/templates/ui/components/acteur/acteur_detail.html
@@ -40,6 +40,7 @@ data-action="keydown.esc@window->acteur-details#hide:stop"
   >
       {# Close button #}
       <button
+          type="button"
           class="
           qf-cursor-pointer
           fr-icon fr-icon-close-line


### PR DESCRIPTION
# Focus management + action links to buttons

Carte Notion/Mattermost/Sentry : [Grille d'audit accessibilité P01](https://docs.google.com/spreadsheets/d/1gDLMPtYBj2rTlIuBP2xaohd_lxfbX6jAnnsyAP7hTGE/edit?gid=2001107939#gid=2001107939)


**🗺️ contexte**: Audit accessibilité P01 12.8 - retours sur la fiche acteur 

**💡 quoi**: 
- Quand on ferme le panneau acteur, le focus retourne sur l'élément qui l'a ouvert (bouton "Voir la fiche" ou pinpoint)
- Correction du bouton Fermer (`type="button"` manquant)

**🎯 pourquoi**: 
1. **7.1.5** : le bouton Fermer du panneau n'avait pas `type="button"` -- soumettait le formulaire parent par accident
2. **7.3.1** : le focus était perdu à la fermeture du panneau -- l'utilisateur clavier ne savait pas où il se trouvait. Restauration sur le déclencheur ("Voir la fiche" ou pinpoint)
