### PR TITLE
a11y(carte): ajoute la légende et l'en-tête manquants du tableau mode liste

### DIFF
--- a/webapp/core/templatetags/carte_tags.py
+++ b/webapp/core/templatetags/carte_tags.py
@@ -275,7 +275,8 @@ def acteurs_table(context, acteurs):
     As it must be rendered with a dict, we cannot easily render complex rows."""
     return {
         "table": {
-            "header": ["Nom du lieu", "Actions", "Distance", ""],
+            "caption": "Liste des lieux et solutions correspondant à votre recherche",
+            "header": ["Nom du lieu", "Actions", "Distance", "Fiche"],
             "content": [render_acteur_table_row(acteur, context) for acteur in acteurs],
             "extra_classes": "fr-table--mode-liste fr-table--multiline qf-w-full",
         }

--- a/webapp/e2e_tests/a11y_rgaa.spec.ts
+++ b/webapp/e2e_tests/a11y_rgaa.spec.ts
@@ -20,4 +20,26 @@ test.describe("♿ RGAA", () => {
       await expect(page.locator("h3", { hasText: "Adresse" })).toHaveCount(0)
     })
   })
+  test.describe("[Carte] 5.4 / 5.6 — Titre et en-têtes du tableau mode liste", () => {
+    test("Le tableau a une légende (<caption>) non vide", async ({ page }) => {
+      await navigateTo(
+        page,
+        "/lookbook/preview/accessibilite/A11Y_15_mode_liste_table_caption_et_entetes/",
+      )
+      const caption = page.locator("table caption")
+      await expect(caption).toBeAttached()
+      await expect(caption).not.toHaveText("")
+    })
+
+    test("La colonne « Voir la fiche » a un en-tête non vide", async ({ page }) => {
+      await navigateTo(
+        page,
+        "/lookbook/preview/accessibilite/A11Y_15_mode_liste_table_caption_et_entetes/",
+      )
+      const headers = page.locator("table thead th")
+      await expect(headers).toHaveCount(4)
+      const lastHeader = headers.last()
+      await expect(lastHeader).not.toHaveText("")
+    })
+  })
 })

--- a/webapp/previews/template_preview.py
+++ b/webapp/previews/template_preview.py
@@ -1214,6 +1214,30 @@ class AccessibilitePreview(LookbookPreview):
         ) + render_to_string(
             "ui/components/acteur/tabs/sections/services_disponibles.html", context
         )
+    def A11Y_15_mode_liste_table_caption_et_entetes(self, **kwargs):
+        """RGAA 5.4 / 5.6 — titre et en-têtes du tableau mode liste.
+
+        Le tableau des résultats en mode liste avait une balise
+        `<caption>` vide et un en-tête de colonne vide pour la colonne
+        « Voir la fiche ». Le tag `acteurs_table` (carte_tags.py)
+        fournit désormais un `caption` pertinent et un intitulé
+        « Fiche » pour cette colonne.
+        """
+        acteurs = DisplayedActeur.objects.all()[:2]
+        request = RequestFactory().get("/")
+        context = Context(
+            {
+                "acteurs": acteurs,
+                "map_container_id": DEFAULT_MAP_CONTAINER_ID,
+                "forms": {"legende": LegendeForm(), "filtres_form": None},
+                "request": request,
+            }
+        )
+        template = Template("""
+            {% load carte_tags %}
+            {% acteurs_table acteurs %}
+            """)
+        return template.render(context)
 
 
 class TestsPreview(LookbookPreview):


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [Titre](__url__)

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: <!-- Quelle épic / opportinuté est concernée ? -->

**💡 quoi**: <!-- description de ce qu'on est en train de changer -->

**🎯 pourquoi**: <!-- pourquoi on fait ce changement -->

**🤔 comment**: <!-- Descrire l'ensemble des tâches réalisées (bullet points) -->

**🤓 comment tester**: <!-- Descrire les étapes pour tester la fonctionnalité -->

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>