### PR TITLE
a11y(site): corrige le lien d'évitement sur Firefox

### DIFF
--- a/webapp/e2e_tests/a11y_rgaa.spec.ts
+++ b/webapp/e2e_tests/a11y_rgaa.spec.ts
@@ -42,4 +42,26 @@ test.describe("♿ RGAA", () => {
       await expect(lastHeader).not.toHaveText("")
     })
   })
+  test.describe("[Site Que faire] 12.7 — Lien d'évitement fonctionnel (bug Firefox)", () => {
+    for (const path of ["/", "/carte"]) {
+      test(`Le <main id="content"> de ${path} porte tabindex="-1"`, async ({
+        page,
+      }) => {
+        await navigateTo(page, path)
+        const main = page.locator("main#content")
+        await expect(main).toHaveAttribute("tabindex", "-1")
+      })
+    }
+
+    test('Le <nav id="fr-navigation"> porte tabindex="-1" quand il est rendu', async ({
+      page,
+    }) => {
+      await navigateTo(page, "/")
+      const nav = page.locator("nav#fr-navigation")
+      const count = await nav.count()
+      if (count > 0) {
+        await expect(nav).toHaveAttribute("tabindex", "-1")
+      }
+    })
+  })
 })

--- a/webapp/previews/template_preview.py
+++ b/webapp/previews/template_preview.py
@@ -1139,6 +1139,11 @@ class AccessibilitePreview(LookbookPreview):
         infotri). Le `<main>` du layout porte `id="content"` et
         `role="main"`, ce qui correspond à la cible définie dans le
         context processor global.
+
+        `tabindex="-1"` a été ajouté sur `<main id="content">` (et sur
+        `<nav id="fr-navigation">` dans `header_menu.html`) : un bug
+        connu de Firefox empêche le focus de se déplacer via un lien
+        d'ancrage si la cible n'est pas programmatiquement focusable.
         """
         return render_to_string(
             "ui/components/accessibilite/skip_link_demo.html",

--- a/webapp/templates/ui/components/accessibilite/skip_link_demo.html
+++ b/webapp/templates/ui/components/accessibilite/skip_link_demo.html
@@ -10,7 +10,7 @@
 
     {% dsfr_skiplinks skiplinks %}
 
-    <main id="content" role="main" class="fr-mt-3w">
+    <main id="content" role="main" tabindex="-1" class="fr-mt-3w">
         <p>
             Pour visualiser le lien, faites <kbd>Tab</kbd> depuis cette zone
             d'aperçu. Il devient visible uniquement au focus, conformément

--- a/webapp/templates/ui/components/header/header_menu.html
+++ b/webapp/templates/ui/components/header/header_menu.html
@@ -13,6 +13,7 @@
         <nav role="navigation"
              class="fr-nav"
              id="fr-navigation"
+             tabindex="-1"
              aria-label="{{ main_menu_label }}">
           <ul class="fr-nav__list">
             {% for item in menu_items %}

--- a/webapp/templates/ui/layout/assistant.html
+++ b/webapp/templates/ui/layout/assistant.html
@@ -107,7 +107,7 @@ parsing, which raises VariableDoesNotExist when seo is not in context (e.g., err
         {% endif %}
 
 
-        <main id="content" class="{% if not iframe %}qf-pb-7w{% else %}[@media(min-height:600px)]:qf-pb-2w qf-pb-3w{% endif %}" role="main">
+        <main id="content" class="{% if not iframe %}qf-pb-7w{% else %}[@media(min-height:600px)]:qf-pb-2w qf-pb-3w{% endif %}" role="main" tabindex="-1">
             {% block main %}
             {% endblock main %}
         </main>

--- a/webapp/templates/ui/layout/base.html
+++ b/webapp/templates/ui/layout/base.html
@@ -60,7 +60,7 @@
         {# Skip link for accessibility - using DSFR component (RGAA 12.7) #}
         {% dsfr_skiplinks skiplinks %}
 
-        <main id="content" class="qf-h-full qf-overflow-y-auto qf-overflow-x-hidden" role="main">
+        <main id="content" class="qf-h-full qf-overflow-y-auto qf-overflow-x-hidden" role="main" tabindex="-1">
             <noscript>
                 <div class="fr-container fr-my-3w">
                     <div class="fr-alert fr-alert--error">


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [Titre](__url__)

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: <!-- Quelle épic / opportinuté est concernée ? -->

**💡 quoi**: <!-- description de ce qu'on est en train de changer -->

**🎯 pourquoi**: <!-- pourquoi on fait ce changement -->

**🤔 comment**: <!-- Descrire l'ensemble des tâches réalisées (bullet points) -->

**🤓 comment tester**: <!-- Descrire les étapes pour tester la fonctionnalité -->

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>