### PR TITLE
a11y(produit): fait correspondre le title du lien info-tri à son intitulé

### DIFF
--- a/webapp/e2e_tests/a11y_rgaa.spec.ts
+++ b/webapp/e2e_tests/a11y_rgaa.spec.ts
@@ -72,4 +72,14 @@ test.describe("♿ RGAA", () => {
       await expect(page).toHaveTitle(/carte interactive/i)
     })
   })
+  test.describe("[Site Que faire] 6.1 — Lien info-tri explicite", () => {
+    test("Le title du lien info-tri reprend son intitulé visible", async ({ page }) => {
+      await navigateTo(page, "/lookbook/preview/pages/produit/")
+      const link = page.getByTestId("infotri-link")
+      await expect(link).toBeVisible()
+      const text = (await link.textContent())?.trim()
+      const title = await link.getAttribute("title")
+      expect(title).toBe(`${text} - Nouvelle fenêtre`)
+    })
+  })
 })

--- a/webapp/templates/ui/components/produit/_infotri.html
+++ b/webapp/templates/ui/components/produit/_infotri.html
@@ -11,7 +11,7 @@
         </div>
 
         <p class="qf-m-0 qf-ml-auto">
-            <a href="{{ ASSISTANT.infotri.lien }}" class="fr-link" rel="noopener external" target="_blank" title="Lien vers les infotris - Nouvelle fenêtre" data-testid="infotri-link">{{ ASSISTANT.infotri.texte_du_lien }}</a>
+            <a href="{{ ASSISTANT.infotri.lien }}" class="fr-link" rel="noopener external" target="_blank" title="{{ ASSISTANT.infotri.texte_du_lien }} - Nouvelle fenêtre" data-testid="infotri-link">{{ ASSISTANT.infotri.texte_du_lien }}</a>
         </p>
     </div>
 {% endif %}


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Notion/Mattermost/Sentry : [Titre](__url__)

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies`

**🗺️ contexte**: <!-- Quelle épic / opportinuté est concernée ? -->

**💡 quoi**: <!-- description de ce qu'on est en train de changer -->

**🎯 pourquoi**: <!-- pourquoi on fait ce changement -->

**🤔 comment**: <!-- Descrire l'ensemble des tâches réalisées (bullet points) -->

**🤓 comment tester**: <!-- Descrire les étapes pour tester la fonctionnalité -->

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>