### PR TITLE
mise à jour de Apache Airflow en version 3.3.1

### DIFF
--- a/data-platform/airflow-dag-processor.Dockerfile
+++ b/data-platform/airflow-dag-processor.Dockerfile
@@ -1,6 +1,6 @@
 # Builder python
 # --- --- --- ---
-FROM apache/airflow:slim-3.1.7-python3.12 AS python-builder
+FROM apache/airflow:slim-3.3.1-python3.12 AS python-builder
 
 # system dependencies
 USER root
@@ -38,7 +38,7 @@ RUN uv sync --project data-platform --frozen --no-editable
 
 # Runtime
 # --- --- --- ---
-FROM apache/airflow:slim-3.1.7-python3.12 AS dag-processor
+FROM apache/airflow:slim-3.3.1-python3.12 AS dag-processor
 
 USER root
 

--- a/data-platform/airflow-scheduler.Dockerfile
+++ b/data-platform/airflow-scheduler.Dockerfile
@@ -1,6 +1,6 @@
 # Builder python
 # --- --- --- ---
-FROM apache/airflow:slim-3.1.7-python3.12 AS python-builder
+FROM apache/airflow:slim-3.3.1-python3.12 AS python-builder
 
 # system dependencies
 USER root
@@ -38,7 +38,7 @@ RUN uv sync --project data-platform --frozen --no-editable
 
 # Runtime
 # --- --- --- ---
-FROM apache/airflow:slim-3.1.7-python3.12 AS scheduler
+FROM apache/airflow:slim-3.3.1-python3.12 AS scheduler
 
 USER root
 

--- a/data-platform/airflow-webserver.Dockerfile
+++ b/data-platform/airflow-webserver.Dockerfile
@@ -1,6 +1,6 @@
 # Builder python
 # --- --- --- ---
-FROM apache/airflow:slim-3.1.7-python3.12 AS python-builder
+FROM apache/airflow:slim-3.3.1-python3.12 AS python-builder
 
 # system dependencies
 USER root
@@ -38,7 +38,7 @@ RUN uv sync --project data-platform --frozen --no-editable
 
 # Runtime
 # --- --- --- ---
-FROM apache/airflow:slim-3.1.7-python3.12 AS webserver
+FROM apache/airflow:slim-3.3.1-python3.12 AS webserver
 
 USER ${AIRFLOW_UID:-50000}
 

--- a/data-platform/pyproject.toml
+++ b/data-platform/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
   "apache-airflow-providers-fab>=3.7.0",
   "apache-airflow-providers-postgres>=6.8.0,<7",
   "apache-airflow-providers-standard>=1.15.0",
-  "apache-airflow>3.3.0,<4",
+  "apache-airflow>=3.3.1,<4",
   "boto3>=1.43.36",
   "dbt-core>=1.11.11,<2",
   "dbt-postgres>=1.10.2,<2",

--- a/uv.lock
+++ b/uv.lock
@@ -916,7 +916,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "apache-airflow", specifier = ">3.3.0,<4" },
+    { name = "apache-airflow", specifier = ">=3.3.1,<4" },
     { name = "apache-airflow-providers-amazon", specifier = ">=9.31.0" },
     { name = "apache-airflow-providers-fab", specifier = ">=3.7.0" },
     { name = "apache-airflow-providers-postgres", specifier = ">=6.8.0,<7" },


### PR DESCRIPTION
# Description succincte du problème résolu

Mise à jour de Apache Airflow en version 3.3.1 + alignement des Dockerfile

**🗺️ contexte**: Apache Airflow + Docker

**💡 quoi**: Mise à jour de Apache Airflow en version 3.3.1

**🎯 pourquoi**: Airflow était désaligné entre l'image docker et la version du package python

**🤔 comment**: 

Mise à jour du package
Mise à jour de l'image Docker de base pour les 3 container Airflow

**🤓 comment tester**: 

- `docker compose --profile lvao --profile airflow build`
- `docker compose --profile lvao --profile airflow up`
- Valider que tout marche coté Airflow : localhost:8080

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)
