### PR TITLE
Définition de l'url de base (BASE_URL) sur les environnements de preview

### DIFF
--- a/infrastructure/environments/preview/_template/container/terragrunt.hcl
+++ b/infrastructure/environments/preview/_template/container/terragrunt.hcl
@@ -61,7 +61,7 @@ inputs = {
   # The actual probe uses a dynamic internal IP (e.g. 100.96.x.x:8000) which
   # varies per deployment — "*" allows any host for ephemeral previews.
   ALLOWED_HOSTS = "*"
-  BASE_URL = format("https://qfdmodpreview6b0061c2-lvao-pr-%s-webapp.functions.fnc.fr-par.scw.cloud", local.pr_number)
+  BASE_URL      = format("https://qfdmodpreview6b0061c2-lvao-pr-%s-webapp.functions.fnc.fr-par.scw.cloud", local.pr_number)
 
   DATABASE_URL = dependency.preview_database.outputs.database_url
   SECRET_KEY   = get_env("PREVIEW_SECRET_KEY")

--- a/infrastructure/environments/preview/_template/container/terragrunt.hcl
+++ b/infrastructure/environments/preview/_template/container/terragrunt.hcl
@@ -61,6 +61,7 @@ inputs = {
   # The actual probe uses a dynamic internal IP (e.g. 100.96.x.x:8000) which
   # varies per deployment — "*" allows any host for ephemeral previews.
   ALLOWED_HOSTS = "*"
+  BASE_URL = format("https://qfdmodpreview6b0061c2-lvao-pr-%s-webapp.functions.fnc.fr-par.scw.cloud", local.pr_number)
 
   DATABASE_URL = dependency.preview_database.outputs.database_url
   SECRET_KEY   = get_env("PREVIEW_SECRET_KEY")

--- a/infrastructure/modules/webapp_container/main.tf
+++ b/infrastructure/modules/webapp_container/main.tf
@@ -47,7 +47,7 @@ resource "scaleway_container" "webapp" {
   environment_variables = merge(
     {
       ENVIRONMENT             = var.environment
-      BASE_URL = var.BASE_URL
+      BASE_URL                = var.BASE_URL
       ALLOWED_HOSTS           = var.ALLOWED_HOSTS
       AWS_STORAGE_BUCKET_NAME = var.AWS_STORAGE_BUCKET_NAME
       AWS_S3_REGION_NAME      = var.AWS_S3_REGION_NAME

--- a/infrastructure/modules/webapp_container/main.tf
+++ b/infrastructure/modules/webapp_container/main.tf
@@ -47,6 +47,7 @@ resource "scaleway_container" "webapp" {
   environment_variables = merge(
     {
       ENVIRONMENT             = var.environment
+      BASE_URL = var.BASE_URL
       ALLOWED_HOSTS           = var.ALLOWED_HOSTS
       AWS_STORAGE_BUCKET_NAME = var.AWS_STORAGE_BUCKET_NAME
       AWS_S3_REGION_NAME      = var.AWS_S3_REGION_NAME

--- a/infrastructure/modules/webapp_container/variables.tf
+++ b/infrastructure/modules/webapp_container/variables.tf
@@ -82,7 +82,7 @@ variable "AWS_STORAGE_BUCKET_NAME" {
 }
 
 variable "BASE_URL" {
-  type = string
+  type    = string
   default = ""
 }
 

--- a/infrastructure/modules/webapp_container/variables.tf
+++ b/infrastructure/modules/webapp_container/variables.tf
@@ -81,6 +81,11 @@ variable "AWS_STORAGE_BUCKET_NAME" {
   default = ""
 }
 
+variable "BASE_URL" {
+  type = string
+  default = ""
+}
+
 variable "AWS_S3_REGION_NAME" {
   type    = string
   default = "fr-par"


### PR DESCRIPTION
# Description succincte du problème résolu

La variable BASE_URL n'est pas définie sur les environnements de preview ce qui a pour consequence de foirer la genération des liens dans la webapp. 


**🗺️ contexte**: environnements de preview

**💡 quoi**: génération dynamique de BASE_URL à partir du numéro de PR

**🎯 pourquoi**: 
actuellement l'absence de BASE_URL empeche d'ouvrir les fiches acteurs sur la carte car elles utilisent des liens 

**🤔 comment**: 

- génération d'une url formattée à partir de l'url scaleway + numéro de PR 

**🤓 comment tester**: 
- aller sur une fiche déchet sur la preview
- chercher des acteurs sur Auray 
- vérifier qu'on peut bien ouvrir un acteur 


## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

