### PR TITLE
Potential fix for code scanning alert no. 227: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/workflows/_e2e.yml
+++ b/.github/workflows/_e2e.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Checkout regression test files from PR branch
         uses: actions/checkout@v7.0.1
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
           sparse-checkout: |
             webapp/playwright.config.ts
             webapp/e2e_tests/


### PR DESCRIPTION
Potential fix for [https://github.com/incubateur-ademe/quefairedemesobjets/security/code-scanning/227](https://github.com/incubateur-ademe/quefairedemesobjets/security/code-scanning/227)

Best fix: stop executing local actions after untrusted repository content is checked out/overlaid. In this file, the safest minimal change is to pin the second checkout (the one used for regression overlays) to a trusted ref (`github.sha`) instead of `github.ref`, so `.github/actions/setup-e2e-tools` comes from the trusted commit that defines/runs this workflow, not from PR/head-controlled content.

Concretely, edit `.github/workflows/_e2e.yml` in the “Checkout regression test files from PR branch” step:
- Change `ref: ${{ github.ref }}` to `ref: ${{ github.sha }}`.
- Keep sparse-checkout paths unchanged to preserve behavior as much as possible.
This removes the untrusted code path into the local action execution at line 82 while keeping the workflow structure intact.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
