### PR TITLE
Potential fix for code scanning alert no. 224: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/workflows/_e2e.yml
+++ b/.github/workflows/_e2e.yml
@@ -80,7 +80,7 @@ jobs:
           rm -rf __regression_tests__
 
       - name: Setup E2E tools
-        uses: ./.github/actions/setup-e2e-tools
+        uses: ${{ github.repository }}/.github/actions/setup-e2e-tools@main
         with:
           build-frontend: "true"
           base-url: ${{ inputs.base-url || 'http://localhost:8888' }}


### PR DESCRIPTION
Potential fix for [https://github.com/incubateur-ademe/quefairedemesobjets/security/code-scanning/224](https://github.com/incubateur-ademe/quefairedemesobjets/security/code-scanning/224)

To fix this without changing intended test behavior, stop invoking local composite actions via relative paths in the tainted workflow job, and instead invoke those actions from a **trusted, immutable source** (same repo pinned to default branch/ref or ideally a commit SHA). This prevents attacker-controlled checked-out content from redefining action code under `.github/actions/...`.

Best single change in shown files:
- In `.github/workflows/_e2e.yml`, update the `Setup E2E tools` step to use a trusted remote reference instead of `./.github/actions/setup-e2e-tools`.
- Since only provided snippets may be edited, keep all behavior/inputs identical and only change the `uses:` target.

This addresses all reported variants because they share the same taint path into execution of local action code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
