### PR TITLE
Potential fix for code scanning alert no. 223: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/workflows/_e2e.yml
+++ b/.github/workflows/_e2e.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7.0.1
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.sha }}
       # The regression test files and GitHub actions may not exist on the
       # checked-out ref (e.g. main). We sparse-checkout them from the PR branch
       # and overlay them onto the working tree so both baseline and compare jobs


### PR DESCRIPTION
Potential fix for [https://github.com/incubateur-ademe/quefairedemesobjets/security/code-scanning/223](https://github.com/incubateur-ademe/quefairedemesobjets/security/code-scanning/223)

To fix this without changing intended E2E behavior, stop executing local action definitions from the untrusted/ref-specific workspace. The safest minimal change in the shown files is:

1. In `.github/workflows/_e2e.yml`, pin the first checkout to a trusted ref (`github.sha`) instead of `inputs.ref`, so local composite action code (`./.github/actions/...`) comes from the trusted workflow commit.
2. Keep using `inputs.ref` only as data input to tests (for baseline/compare logic) rather than as execution source for action code.
3. Preserve the existing “overlay regression test files from PR branch” behavior if needed for test assets, but ensure it no longer controls which action implementation is executed.

Concretely, edit the checkout step at lines 58–61 in `.github/workflows/_e2e.yml`:
- Replace `ref: ${{ inputs.ref }}` with `ref: ${{ github.sha }}`.

No changes are required in `.github/actions/setup-e2e-tools/action.yml` for this specific sink once trusted checkout is enforced in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
