### PR TITLE
Execution des commandes django dans webapp lors de la synchro des DB

### DIFF
--- a/.github/workflows/sync_databases.yml
+++ b/.github/workflows/sync_databases.yml
@@ -53,13 +53,13 @@ jobs:
           DB_URL=${PREPROD_DB_WEBAPP_DSN} make -e db-restore-preprod-from-prod
       - name: Execute migrations in one-off container
         run: |
-          scalingo --app ${PREPROD_APP} run python manage.py migrate
+          scalingo --app ${PREPROD_APP} run 'cd webapp && python manage.py migrate'
       - name: Truncate the suggestions table
         run: |
-          scalingo --app ${PREPROD_APP} run python manage.py reinitialize_suggestions
+          scalingo --app ${PREPROD_APP} run 'cd webapp && python manage.py reinitialize_suggestions'
       - name: Create remote db server between webapp and warehouse
         run: |
-          scalingo --app ${PREPROD_APP} run python manage.py create_remote_db_server
+          scalingo --app ${PREPROD_APP} run 'cd webapp && python manage.py create_remote_db_server'
 
   sync_prod_to_preprod_s3:
     name: Copy Prod s3 bucket to Copy Preprod s3 bucket


### PR DESCRIPTION
# Description succincte du problème résolu

Technique, correction qui fait suite à la réorganisation du dossier

**🗺️ contexte**: Github action - Sync DB prod to preprod

**💡 quoi**: correction des script exécuté après la synchro de la DB

**🎯 pourquoi**: car les commandes django doivent être exécutées dans le dossier `webapp`

**🤔 comment**: se déplacer dans le dossier `webapp` avant de lancer les commande Django

**🤓 comment tester**: 

Lancer la Github action `Sync prod > preprod`

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)
