### PR TITLE
Execution des commandes django dans webapp lors de la synchro des DB

### DIFF
--- a/.github/workflows/sync_databases.yml
+++ b/.github/workflows/sync_databases.yml
@@ -2,6 +2,11 @@ name: "Sync prod > preprod"
 
 on:
   workflow_dispatch:
+    inputs:
+      use_latest_backup:
+        description: "Réutiliser le dernier backup prod au lieu d'en créer un"
+        type: boolean
+        default: false
   schedule:
   - cron: "0 0 * * SUN"
 
@@ -49,17 +54,13 @@ jobs:
           default-project-id: ${{ env.SCW_DEFAULT_PROJECT_ID }}
           default-organization-id: ${{ env.SCW_DEFAULT_ORGANIZATION_ID }}
       - name: Restore DB from prod to preprod
+        env:
+          USE_LATEST_BACKUP: ${{ inputs.use_latest_backup }}
         run: |
           DB_URL=${PREPROD_DB_WEBAPP_DSN} make -e db-restore-preprod-from-prod
-      - name: Execute migrations in one-off container
+      - name: Run post-restore Django commands
         run: |
-          scalingo --app ${PREPROD_APP} run cd webapp && python manage.py migrate
-      - name: Truncate the suggestions table
-        run: |
-          scalingo --app ${PREPROD_APP} run cd webapp && python manage.py reinitialize_suggestions
-      - name: Create remote db server between webapp and warehouse
-        run: |
-          scalingo --app ${PREPROD_APP} run cd webapp && python manage.py create_remote_db_server
+          scalingo --app ${PREPROD_APP} run "cd webapp && python manage.py migrate && python manage.py reinitialize_suggestions && python manage.py create_remote_db_server"
 
   sync_prod_to_preprod_s3:
     name: Copy Prod s3 bucket to Copy Preprod s3 bucket

--- a/.github/workflows/sync_databases.yml
+++ b/.github/workflows/sync_databases.yml
@@ -53,13 +53,13 @@ jobs:
           DB_URL=${PREPROD_DB_WEBAPP_DSN} make -e db-restore-preprod-from-prod
       - name: Execute migrations in one-off container
         run: |
-          scalingo --app ${PREPROD_APP} run python manage.py migrate
+          scalingo --app ${PREPROD_APP} run cd webapp && python manage.py migrate
       - name: Truncate the suggestions table
         run: |
-          scalingo --app ${PREPROD_APP} run python manage.py reinitialize_suggestions
+          scalingo --app ${PREPROD_APP} run cd webapp && python manage.py reinitialize_suggestions
       - name: Create remote db server between webapp and warehouse
         run: |
-          scalingo --app ${PREPROD_APP} run python manage.py create_remote_db_server
+          scalingo --app ${PREPROD_APP} run cd webapp && python manage.py create_remote_db_server
 
   sync_prod_to_preprod_s3:
     name: Copy Prod s3 bucket to Copy Preprod s3 bucket

--- a/Makefile
+++ b/Makefile
@@ -219,9 +219,11 @@ dump-prod:
 dump-preprod:
 	bash scripts/infrastructure/backup-db.sh --quiet --env preprod
 
+# USE_LATEST_BACKUP=true réutilise le dernier backup Scaleway prêt
+# au lieu d'en créer un nouveau (évite la création + polling).
 .PHONY: dump-prod-quiet
 dump-prod-quiet:
-	bash scripts/infrastructure/backup-db.sh --quiet
+	bash scripts/infrastructure/backup-db.sh --quiet $(if $(filter true,$(USE_LATEST_BACKUP)),--latest)
 
 .PHONY: dump-sample
 dump-sample:
@@ -240,7 +242,7 @@ load-prod-dump:
 	@DUMP_FILE=$$(find tmpbackup-prod -type f -name "*.custom" -print -quit); \
 	psql -d '$(DB_URL)' -f scripts/sql/create_extensions.sql && \
 	psql -d '$(DB_URL)' -f $(WAGTAIL_FRENCH_SQL) && \
-	pg_restore -d '$(DB_URL)' --schema=public --clean --if-exists --no-acl --no-owner --no-privileges "$$DUMP_FILE"
+	pg_restore -d '$(DB_URL)' --schema=public --clean --if-exists --no-acl --no-owner --no-privileges --jobs=4 "$$DUMP_FILE"
 
 .SILENT:
 .PHONY: load-preprod-dump
@@ -286,7 +288,7 @@ db-restore-local-from-preprod:
 
 .PHONY: db-restore-preprod-from-prod
 db-restore-preprod-from-prod:
-	$(MAKE) dump-prod-quiet
+	$(MAKE) dump-prod-quiet USE_LATEST_BACKUP=$(USE_LATEST_BACKUP)
 	$(MAKE) drop-all-tables
 	$(MAKE) load-prod-dump
 

--- a/scripts/infrastructure/backup-db.sh
+++ b/scripts/infrastructure/backup-db.sh
@@ -4,6 +4,7 @@
 # Initialiser les variables
 QUIET=false
 ENV="prod"
+LATEST=false
 
 # Traitement des arguments
 while [[ $# -gt 0 ]]; do
@@ -16,10 +17,15 @@ while [[ $# -gt 0 ]]; do
             ENV="$2"
             shift 2
             ;;
+        --latest|-l)
+            LATEST=true
+            shift
+            ;;
         --help|-h)
-            echo "Usage: $0 [--quiet|-q] [--env|-e ENV] [--help|-h]"
+            echo "Usage: $0 [--quiet|-q] [--env|-e ENV] [--latest|-l] [--help|-h]"
             echo "  --quiet, -q:        Ne pas poser de question de confirmation"
             echo "  --env, -e ENV:      Environnement à utiliser (défaut: production)"
+            echo "  --latest, -l:       Réutiliser le dernier backup prêt au lieu d'en créer un"
             echo "  --help, -h:         Afficher cette aide"
             exit 0
             ;;
@@ -31,6 +37,16 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+download_backup() {
+    echo "Téléchargement du backup..."
+    mkdir -p tmpbackup-${ENV}
+    cd tmpbackup-${ENV}
+    rm -rf ./*.custom
+    scw rdb backup download "$1"
+    cd ..
+    echo "Backup terminé et téléchargé avec succès !"
+}
+
 # Récupérer l'ID de l'instance
 INSTANCE_ID=$(scw rdb instance list | grep "lvao-${ENV}-webapp" | awk '{print $1}')
 TODAY=$(date +%Y%m%d)
@@ -39,6 +55,19 @@ EXISTING_BACKUPS=$(scw rdb backup list instance-id=$INSTANCE_ID | grep "$TODAY")
 if [ -z "$INSTANCE_ID" ]; then
     echo "Instance lvao-${ENV}-webapp non trouvée"
     exit 1
+fi
+
+if [ "$LATEST" = true ]; then
+    # Le plus récent backup "ready" existant, sans en créer un nouveau.
+    BACKUP_ID=$(scw rdb backup list instance-id=$INSTANCE_ID order-by=created_at_desc \
+        | awk '$0 ~ /ready/ {print $1; exit}')
+    if [ -z "$BACKUP_ID" ]; then
+        echo "Aucun backup prêt trouvé pour lvao-${ENV}-webapp"
+        exit 1
+    fi
+    echo "Réutilisation du backup $BACKUP_ID"
+    download_backup "$BACKUP_ID"
+    exit 0
 fi
 
 if [ "$QUIET" = false ]; then
@@ -84,15 +113,4 @@ while true; do
     sleep 10
 done
 
-# Télécharger le backup
-echo "Téléchargement du backup..."
-
-mkdir -p tmpbackup-${ENV}
-cd tmpbackup-${ENV}
-
-rm -rf *.custom
-
-scw rdb backup download $BACKUP_ID
-cd ..
-
-echo "Backup terminé et téléchargé avec succès !"
+download_backup "$BACKUP_ID"


### PR DESCRIPTION
# Description succincte du problème résolu

Technique, correction qui fait suite à la réorganisation du dossier

**🗺️ contexte**: Github action - Sync DB prod to preprod

**💡 quoi**: correction des script exécuté après la synchro de la DB

**🎯 pourquoi**: car les commandes django doivent être exécutées dans le dossier `webapp`

**🤔 comment**: se déplacer dans le dossier `webapp` avant de lancer les commande Django

**🤓 comment tester**: 

Lancer la Github action `Sync prod > preprod`

https://github.com/incubateur-ademe/quefairedemesobjets/actions/runs/34134169391/job/101781103957

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)
