### PR TITLE
Performances : Appliquer CONN_MAX_AGE aux connexions en base de données

### DIFF
--- a/webapp/settings/base.py
+++ b/webapp/settings/base.py
@@ -392,8 +392,13 @@ DATABASE_URL = decouple.config(
     cast=str,
 )
 
+CONN_MAX_AGE = decouple.config("CONN_MAX_AGE", cast=int, default=0)
+CONN_HEALTH_CHECKS = True
+
 DEFAULT_DATABASE_SETTINGS = {
-    **dj_database_url.parse(DATABASE_URL),
+    **dj_database_url.parse(
+        DATABASE_URL, conn_max_age=CONN_MAX_AGE, conn_health_checks=CONN_HEALTH_CHECKS
+    ),
     "ENGINE": "django.contrib.gis.db.backends.postgis",
 }
 
@@ -415,7 +420,11 @@ DB_WAREHOUSE = decouple.config(
 )
 
 WAREHOUSE_DATABASE_SETTINGS = {
-    **dj_database_url.parse(DB_WAREHOUSE),
+    **dj_database_url.parse(
+        DB_WAREHOUSE,
+        conn_max_age=CONN_MAX_AGE,
+        conn_health_checks=CONN_HEALTH_CHECKS,
+    ),
     "ENGINE": "django.contrib.gis.db.backends.postgis",
 }
 
@@ -429,9 +438,6 @@ REMOTE_WEBAPP_SERVERNAME = "webapp_server"
 REMOTE_WEBAPP_SCHEMANAME = "webapp_public"
 REMOTE_WAREHOUSE_SERVERNAME = "warehouse_server"
 REMOTE_WAREHOUSE_SCHEMANAME = "warehouse_public"
-
-CONN_HEALTH_CHECKS = True
-CONN_MAX_AGE = decouple.config("CONN_MAX_AGE", cast=int, default=0)
 
 
 # Password validation


### PR DESCRIPTION
# Description succincte du problème résolu


**🗺️ contexte**: Performances

**💡 quoi**: un paramètre django était mal utilisé

**🎯 pourquoi**: CONN_MAX_AGE doit être défini au sein d'une connexion en base de données, pas au niveau des settings

Cela évite d'ouvrir une connexion à chaque nouvelle requete et permet d'améliorer les performances en cas de requêtes successives (par l'utilisation de pooling)

**🤔 comment**: on applique le settings aux connexions warehouse et webapp

**🤓 comment tester**: déployer en prod / preprod, puis 

```
python webapp/manage.py shell
settings.DATABASES["default"]["CONN_MAX_AGE"] != 0
```

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

