### PR TITLE
Suppression d'une clause qui empeche les nouveaux buckets de preview de se créer

### DIFF
--- a/infrastructure/environments/preview/_template/object_storage/terragrunt.hcl
+++ b/infrastructure/environments/preview/_template/object_storage/terragrunt.hcl
@@ -9,6 +9,3 @@ include {
   path = find_in_parent_folders("root.hcl")
 }
 
-inputs = {
-  object_expiration_days = 1
-}

--- a/infrastructure/modules/preview_object_storage/main.tf
+++ b/infrastructure/modules/preview_object_storage/main.tf
@@ -9,14 +9,12 @@ resource "scaleway_object_bucket" "media" {
   # (lifecycle would reap them eventually, but we don't want to wait).
   force_destroy = true
 
-  # Object-level lifecycle: every object older than N days is auto-deleted.
-  # Acts as a safety net even if the per-PR destroy never runs.
+  # No object expiration: the scaleway provider always sends
+  # ExpiredObjectDeleteMarker alongside Days, which Scaleway now rejects
+  # (MalformedXML). force_destroy + preview-down/cleanup reap the bucket.
   lifecycle_rule {
-    id      = "expire-objects"
-    enabled = true
-    expiration {
-      days = var.object_expiration_days
-    }
+    id                                     = "abort-multipart"
+    enabled                                = true
     abort_incomplete_multipart_upload_days = 1
   }
 }

--- a/infrastructure/modules/preview_object_storage/variables.tf
+++ b/infrastructure/modules/preview_object_storage/variables.tf
@@ -7,9 +7,3 @@ variable "environment" {
   description = "Environnement de déploiement (ex: pr-123)"
   type        = string
 }
-
-variable "object_expiration_days" {
-  description = "Nombre de jours après lesquels les objets sont supprimés automatiquement"
-  type        = number
-  default     = 1
-}


### PR DESCRIPTION
# Description succincte du problème résolu

Les règles d'expiration des buckets de preview échouent depuis aujourd'hui. 
Je ne sais pas encore d'où ca vient mais je prévois de corriger certains aspects de la destruction de ressources des environnements de preview cette semaine, donc j'en profiterai pour corriger cela. 

**🗺️ contexte**: Env de preview

**💡 quoi**: Suppression de l'expiration automatique des objets

**🎯 pourquoi**: Pour résoudre une erreur qui empeche de créer de nouveaux environnements de preview

**🤔 comment**: 
modification du module concerné

**🤓 comment tester**: 
Vérifier que la PR courante est [déployée en preview](https://qfdmodpreview6b0061c2-lvao-pr-3367-webapp.functions.fnc.fr-par.scw.cloud)

## Exemple résultats / UI / Data

![image](__url__)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

