### PR TITLE
Exclure typescript >= 7 de dependabot

### DIFF
--- a/.github/actions/setup-frontend/action.yml
+++ b/.github/actions/setup-frontend/action.yml
@@ -27,8 +27,12 @@ runs:
       id: cache-node-modules
       uses: actions/cache@v6
       with:
-        path: ${{ inputs.working-directory }}/node_modules
-        key: node-modules-${{ runner.os }}-${{ hashFiles(format('{0}/package-lock.json', inputs.working-directory)) }}
+        # npm workspace: packages are hoisted to the root node_modules and the
+        # lockfile lives at the repo root, not in the working directory
+        path: |
+          node_modules
+          ${{ inputs.working-directory }}/node_modules
+        key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
     - name: Install npm dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,7 @@ updates:
           - "patch"
 
   - package-ecosystem: "npm"
-    directory: "/webapp"
+    directory: "/"
     open-pull-requests-limit: 100
     schedule:
       interval: "weekly"
@@ -38,6 +38,11 @@ updates:
       default-days: 7
     allow:
       - dependency-type: "all"
+    ignore:
+      # TypeScript 7 (native compiler) has no JS compiler API: ts-jest and
+      # typescript-eslint require typescript <7. Drop once they support it.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       # Named groups (specific packages get their own PRs)
       babel:


### PR DESCRIPTION
# Description succincte du problème résolu

Cf https://github.com/incubateur-ademe/quefairedemesobjets/pull/3372 que j'ai du fermer

**🗺️ contexte**: Dépendances frontend

**💡 quoi**: exclure Typescript des montées de version dependabot

**🎯 pourquoi**: 
car on a des dépendances incompatibles avec TS >= 7. 


**🤔 comment**: 
- Ajout de la config nécessire dans le dependabot.yml
- Au passage : je re-situe proprement l'emplacement du manifeste des dépendances pour dependabot

**🤓 comment tester**: 

attendre que dependabot tourne :/


## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)
