### PR TITLE
Amélioration des performances docker pour les DBs Postgis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ DB_URL := postgres://webapp:webapp@localhost:6543/webapp# pragma: allowlist secr
 PYTHON := uv run python
 SAMPLE_DB_URL ?= $(if $(DB_WEBAPP_SAMPLE),$(DB_WEBAPP_SAMPLE),$(DB_URL))
 SAMPLE_DUMP_FILE ?= tmpbackup-sample/sample.custom
+PG_RESTORE_JOBS ?= 1
 WAGTAIL_FRENCH_SQL := webapp/qfdmd/migrations/sql/create_wagtail_french_config.sql
 
 # Loading environment variables
@@ -264,14 +265,14 @@ load-sample-dump:
 
 .PHONY: load-dump-to-loc
 load-dump-to-loc:
-	./scripts/db_restore.sh $(ENV) $(TMPDIR)
+	./scripts/db_restore.sh $(ENV) $(TMPDIR) $(PG_RESTORE_JOBS)
 
 .PHONY: db-restore-local-from
 db-restore-local-from:
 	@ENV=$(env) $(MAKE) dump-$(env)
 	@$(MAKE) drop-schema-public
 	@$(MAKE) create-schema-public
-	@ENV=$(env) TMPDIR=tmpbackup-$(env) $(MAKE) load-dump-to-loc
+	@ENV=$(env) TMPDIR=tmpbackup-$(env) PG_RESTORE_JOBS=$(PG_RESTORE_JOBS) $(MAKE) load-dump-to-loc
 	@$(MAKE) webapp-migrate
 ifeq ($(env),prod)
 	@$(MAKE) webapp-create-remote-db-server
@@ -279,7 +280,7 @@ endif
 
 .PHONY: db-restore-local-from-prod
 db-restore-local-from-prod:
-	$(MAKE) db-restore-local-from env=prod
+	$(MAKE) db-restore-local-from env=prod PG_RESTORE_JOBS=$(PG_RESTORE_JOBS)
 
 .PHONY: db-restore-local-from-preprod
 db-restore-local-from-preprod:

--- a/data-platform/dags/.env.template
+++ b/data-platform/dags/.env.template
@@ -9,6 +9,9 @@ SECRET_KEY='my-secret-key' # pragma: allowlist secret
 _AIRFLOW_DB_MIGRATE=true
 _AIRFLOW_WWW_USER_CREATE=true
 
+_AIRFLOW_WWW_USER_USERNAME=airflow
+_AIRFLOW_WWW_USER_PASSWORD=airflow
+
 ## CORE
 AIRFLOW__CORE__DAGS_FOLDER=/opt/airflow/dags
 # following https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/fernet.html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,7 +166,7 @@ services:
       timeout: 10s
       retries: 5
       start_period: 30s
-    restart: always
+    restart: unless-stopped
     depends_on:
       <<: *airflow-common-depends-on
       airflow-webserver:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
 
   lvao-webapp-db:
     platform: ${POSTGIS_IMAGE_PLATFORM:-linux/amd64}
-    image: imresamu/postgis:16-3.5-alpine
+    image: imresamu/postgis:16-3.5-alpine # We use imresamu image because official Postgis image does not ship ARM builds
     environment:
       - POSTGRES_USER=webapp
       - POSTGRES_PASSWORD=webapp # pragma: allowlist secret
@@ -64,7 +64,7 @@ services:
 
   lvao-warehouse-db:
     platform: ${POSTGIS_IMAGE_PLATFORM:-linux/amd64}
-    image: imresamu/postgis:15-3.3-alpine
+    image: imresamu/postgis:15-3.3-alpine # We use imresamu image because official Postgis image does not ship ARM builds
     environment:
       - POSTGRES_USER=warehouse
       - POSTGRES_PASSWORD=warehouse # pragma: allowlist secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,13 +48,12 @@ services:
     profiles: [lvao]
 
   lvao-webapp-db:
-    platform: linux/amd64
-    image: postgis/postgis:16-3.5-alpine
+    platform: ${POSTGIS_IMAGE_PLATFORM:-linux/amd64}
+    image: imresamu/postgis:16-3.5-alpine
     environment:
       - POSTGRES_USER=webapp
       - POSTGRES_PASSWORD=webapp # pragma: allowlist secret
       - POSTGRES_DB=webapp
-      - POSTGRES_MULTIPLE_EXTENSIONS=postgis
     volumes:
       - webapp_dbdata:/var/lib/postgresql/data:delegated
     expose:
@@ -64,8 +63,8 @@ services:
     profiles: [lvao, airflow]
 
   lvao-warehouse-db:
-    platform: linux/amd64
-    image: postgis/postgis:15-3.3-alpine
+    platform: ${POSTGIS_IMAGE_PLATFORM:-linux/amd64}
+    image: imresamu/postgis:15-3.3-alpine
     environment:
       - POSTGRES_USER=warehouse
       - POSTGRES_PASSWORD=warehouse # pragma: allowlist secret

--- a/scripts/db_restore.sh
+++ b/scripts/db_restore.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
-# Usage: sh scripts/db_restore.sh <db_label> [dump_dir]
+# Usage: sh scripts/db_restore.sh <db_label> [dump_dir] [jobs]
 #
 # Restore a PostgreSQL custom-format dump into a Docker database container.
 #
 #   db_label   - one of: prod, preprod, sample
 #   dump_dir   - directory containing .custom dump files (default: tmpbackup-<db_label>)
+#   jobs       - pg_restore --jobs value (default: 1)
 #
 # Runs psql and pg_restore inside the matching Docker PostgreSQL container
 # to avoid version mismatches between host and remote pg_dump versions.
@@ -13,6 +14,7 @@ set -euo pipefail
 
 DB_LABEL="${1:-}"
 DUMP_DIR="${2:-tmpbackup-${DB_LABEL}}"
+JOBS="${3:-1}"
 
 if [ -z "$DB_LABEL" ]; then
     echo "Usage: sh scripts/db_restore.sh <db_label> [dump_dir]" >&2
@@ -47,9 +49,17 @@ echo "Restoring $DUMP_FILE into docker:$DOCKER_SERVICE ($DB_NAME)…"
 echo "  Creating extensions…"
 docker compose exec -T "$DOCKER_SERVICE" psql -U "$DB_USER" -d "$DB_NAME" -f /dev/stdin < scripts/sql/create_extensions.sql
 
-# 2. Restore the dump inside the container (same psql/pg_restore version as the DB)
+# 2. Copy file into container
+echo "  Copying file into container..."
+docker compose cp  "$DUMP_FILE" "$DOCKER_SERVICE":'/home/"$DUMP_FILE"'
+
+# 3. Restore the dump inside the container (same psql/pg_restore version as the DB)
 echo "  Restoring dump…"
 docker compose exec -T "$DOCKER_SERVICE" pg_restore -v -d "$DB_NAME" -U "$DB_USER" \
-    --schema=public --clean --no-acl --no-owner --no-privileges < "$DUMP_FILE"
+    --schema=public --clean --no-acl --no-owner --no-privileges --jobs "$JOBS" '/home/"$DUMP_FILE"'
+
+# 4. Deleting backup file inside container
+echo "  Deleting dumpfile inside container…"
+docker compose exec -T "$DOCKER_SERVICE" rm -r '/home/"$DUMP_FILE"'
 
 echo "✅ Restore complete: $DB_LABEL"


### PR DESCRIPTION
# Description succincte du problème résolu

Amélioration des performances en local des containers Postgis sur plateforme ARM et amélioration des performances du restore des dump Posgtres.

**🗺️ contexte**: <!-- Quelle épic / opportinuté est concernée ? -->
Environnement de développement local.

**💡 quoi**: <!-- description de ce qu'on est en train de changer -->
Le `docker-compose.yml` et le `MakeFile`.

**🎯 pourquoi**: <!-- pourquoi on fait ce changement -->
De meilleurs performances en local.

**🤔 comment**: <!-- Descrire l'ensemble des tâches réalisées (bullet points) -->
1. ajout de `platform: ${POSTGIS_IMAGE_PLATFORM:-linux/amd64}` dans `docker-compose.yml`
2. Ajout d'un paramètre `PG_RESTORE_JOBS` dans le `MakeFile`
3. Modification du script `scripts/db_restore.sh`

**🤓 comment tester**: <!-- Descrire les étapes pour tester la fonctionnalité -->
Être sur une plateforme ARM.
Partir d'un environnement propre (nouveau git worktree).
Effectuer les étapes pour créer l'environnement de dev en changeant l'étape de run docker :
`POSTGIS_IMAGE_PLATFORM=linux/arm64 docker compose --profile lvao --profile airflow up --build -d`

À l'étape du restore de la DB depuis le dump de prod, utiliser la commande suivante :
`make db-restore-local-from-prod PG_RESTORE_JOBS=8`
Veillez bien à adapter le nombre de jobs au nombre de CPUs configurés dans Docker.

## Auto-review

Les trucs à faire avant de demander une review :

- [X] J'ai bien relu mon code
- [ ] La CI passe bien
- [X] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)