### PR TITLE
Détruire les environnements de preview plus proprement et garbage-collecter les PRs fermées

### DIFF
--- a/.github/workflows/_terragrunt-apply.yml
+++ b/.github/workflows/_terragrunt-apply.yml
@@ -1,22 +1,16 @@
-name: 🧱 Terragrunt apply/destroy
+name: 🧱 Terragrunt apply
 
 on:
   workflow_call:
     inputs:
-      command:
-        description: "terragrunt command (apply or destroy)"
-        type: string
-        required: false
-        default: apply
       pr_number:
         description: "Pull request number — materialises infrastructure/environments/preview/pr-<n> from _template, exposed as PR_NUMBER"
         type: string
         required: true
       image_tag:
-        description: "Webapp image tag to deploy (e.g. pr-123-abc1234). Not needed for destroy."
+        description: "Webapp image tag to deploy (e.g. pr-123-abc1234)"
         type: string
-        required: false
-        default: "unused"
+        required: true
       environment:
         description: "GitHub environment to load secrets from (e.g. preview)"
         type: string
@@ -33,12 +27,12 @@ on:
         default: "false"
     outputs:
       endpoint:
-        description: "Public URL of the preview container (apply only)"
+        description: "Public URL of the preview container"
         value: ${{ jobs.terragrunt.outputs.endpoint }}
 
 jobs:
   terragrunt:
-    name: 🧱 Terragrunt ${{ inputs.command }} (pr-${{ inputs.pr_number }})
+    name: 🧱 Terragrunt apply (pr-${{ inputs.pr_number }})
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     outputs:
@@ -79,12 +73,6 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Validate command input
-        run: |
-          CMD="${{ inputs.command }}"
-          [[ "$CMD" == "apply" || "$CMD" == "destroy" ]] \
-            || { echo "Invalid command: $CMD (must be 'apply' or 'destroy')"; exit 1; }
-
       - name: Install OpenTofu
         uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2.0.2
         with:
@@ -108,7 +96,6 @@ jobs:
         uses: scaleway/action-scw@2e34a1eb35cf3cac627f24643a101fea269cbd83
 
       - name: Login to Scaleway Container Registry
-        if: inputs.command == 'apply'
         run: echo "${{ secrets.SCW_SECRET_KEY }}" | docker login rg.fr-par.scw.cloud -u nologin --password-stdin
 
       - name: Materialise per-PR terragrunt stack from _template
@@ -116,33 +103,23 @@ jobs:
           set -euo pipefail
           SRC="infrastructure/environments/preview/_template"
           DST="infrastructure/environments/preview/pr-${{ inputs.pr_number }}"
-          if [[ "${{ inputs.command }}" == "destroy" && ! -d "$DST" ]]; then
-            echo "No preview directory at $DST, nothing to destroy."
-            exit 0
-          fi
-          if [[ ! -d "$DST" ]]; then
-            cp -r "$SRC" "$DST"
-            echo "Materialised $DST from $SRC"
-          else
-            echo "$DST already exists, leaving as-is"
-          fi
+          cp -r "$SRC" "$DST"
           ls -la "$DST"
 
-      - name: Terragrunt ${{ inputs.command }}
+      - name: Terragrunt apply
         working-directory: infrastructure/environments/preview/pr-${{ inputs.pr_number }}
         run: |
           set -euo pipefail
-          CMD="${{ inputs.command }}"
 
           # run --all walks the unit DAG: apply in dependency order
-          # (database → object_storage → container), destroy in reverse.
-          # Init is implicit (auto-init) and -auto-approve is added
-          # automatically in --all mode; TG_NON_INTERACTIVE is set job-wide.
-          # --queue-exclude-external keeps the shared ../../namespace unit
-          # out of the queue: it must never be destroyed by a PR teardown.
-          terragrunt run --all --queue-exclude-external -- "$CMD" 2>&1 | tee apply.log
+          # (database → object_storage → container). Init is implicit
+          # (auto-init) and -auto-approve is added automatically in --all
+          # mode; TG_NON_INTERACTIVE is set job-wide. --queue-exclude-external
+          # keeps the shared ../../namespace unit out of the queue.
+          # Teardown is not done with terragrunt: see preview-down.yml.
+          terragrunt run --all --queue-exclude-external -- apply 2>&1 | tee apply.log
           {
-            echo "## Terragrunt $CMD (pr-${{ inputs.pr_number }})"
+            echo "## Terragrunt apply (pr-${{ inputs.pr_number }})"
             echo
             echo '```'
             tail -n 100 apply.log
@@ -151,7 +128,6 @@ jobs:
 
       - name: Read container public endpoint
         id: endpoint
-        if: inputs.command == 'apply'
         working-directory: infrastructure/environments/preview/pr-${{ inputs.pr_number }}/container
         run: |
           set -euo pipefail

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,8 +1,11 @@
-name: 🧹 Preview environment - daily cleanup
+name: 🧹 Preview environment - daily garbage collection
 
-# Safety net only: previews are normally destroyed when their PR is closed
-# or unlabeled (preview-down.yml). This cron reaps environments whose
-# destroy never ran (workflow failure, force-deleted branch, …).
+# Safety net for preview-down.yml: every day, list every preview resource
+# still in Scaleway (containers, databases, buckets), map it to its PR, and
+# destroy it when the PR no longer wants a preview:
+#   - PR closed or merged for more than GRACE_HOURS (default 24h)
+#   - PR open but without the `preview` label
+# Open PRs carrying the `preview` label are always kept.
 
 on:
   schedule:
@@ -10,24 +13,24 @@ on:
     - cron: "0 3 * * *"
   workflow_dispatch:
     inputs:
-      ttl_hours:
-        description: "TTL in hours; previews older than this are destroyed"
+      grace_hours:
+        description: "Destroy previews of PRs closed for more than this many hours"
         required: false
-        default: "168"
+        default: "24"
         type: string
       dry_run:
-        description: "List candidates without dispatching destroys"
+        description: "List candidates without destroying anything"
         required: false
         default: "false"
         type: string
 
 permissions:
   contents: read
-  actions: write
+  pull-requests: read
 
 jobs:
-  cleanup:
-    name: 🧹 Find and destroy stale previews
+  gc:
+    name: 🧹 Destroy previews of closed or unlabeled PRs
     runs-on: ubuntu-latest
     environment: preview
     env:
@@ -36,70 +39,63 @@ jobs:
       SCW_DEFAULT_PROJECT_ID: ${{ secrets.SCW_DEFAULT_PROJECT_ID }}
       SCW_DEFAULT_ORGANIZATION_ID: ${{ secrets.SCW_DEFAULT_ORGANIZATION_ID }}
       SCW_DEFAULT_REGION: fr-par
-      # 168h = 7 days
-      TTL_HOURS: ${{ inputs.ttl_hours || '168' }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.SCW_ACCESS_KEY }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.SCW_SECRET_KEY }}
+      AWS_DEFAULT_REGION: fr-par
+      GH_TOKEN: ${{ github.token }}
+      GRACE_HOURS: ${{ inputs.grace_hours || '24' }}
       DRY_RUN: ${{ inputs.dry_run || 'false' }}
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - uses: actions/checkout@v7.0.1
+
       - name: Setup Scaleway CLI
         uses: scaleway/action-scw@2e34a1eb35cf3cac627f24643a101fea269cbd83
 
-      - name: Find stale previews and dispatch destroys
+      - name: Find previews to destroy
+        id: find
         run: |
           set -euo pipefail
+          NAMESPACE_ID=$(scw container namespace list name=qfdmod-preview -o json | jq -r '.[0].id')
+          INSTANCE_ID=$(scw rdb instance list name=lvao-preprod-webapp -o json | jq -r '.[0].id')
 
-          NOW=$(date +%s)
-          CUTOFF=$((NOW - TTL_HOURS * 3600))
-          echo "Current time: $NOW (cutoff: $CUTOFF, TTL: ${TTL_HOURS}h)"
+          # PR numbers of every preview resource still around, deduplicated.
+          prs=$( {
+            scw container container list namespace-id="$NAMESPACE_ID" -o json | jq -r '.[].name' | sed -n 's/^lvao-pr-\([0-9]*\)-webapp$/\1/p'
+            scw rdb database list instance-id="$INSTANCE_ID" skip-size-retrieval=true -o json | jq -r '.[].name' | sed -n 's/^preview_pr_\([0-9]*\)$/\1/p'
+            scw object bucket list -o json | jq -r '.[].Name' | sed -n 's/^lvao-pr-\([0-9]*\)-media$/\1/p'
+          } | sort -un )
 
-          # List preview-tagged containers in the project. Scaleway returns
-          # JSON with a `tags` array per container.
-          containers=$(scw container container list \
-            tags.0=preview \
-            region=$SCW_DEFAULT_REGION \
-            -o json)
-
-          count=$(echo "$containers" | jq 'length')
-          echo "Found $count container(s) tagged 'preview'"
-
-          stale_prs=()
-          while IFS= read -r row; do
-            name=$(echo "$row" | jq -r '.name')
-            tags=$(echo "$row" | jq -r '.tags[]')
-
-            pr=$(echo "$tags" | sed -n 's/^preview-pr-//p' | head -n1)
-            created_at=$(echo "$tags" | sed -n 's/^created-at-//p' | head -n1)
-
-            if [[ -z "$pr" || -z "$created_at" ]]; then
-              echo "  - $name: missing required tags, skipping"
+          cutoff=$(( $(date +%s) - GRACE_HOURS * 3600 ))
+          to_destroy=()
+          for pr in $prs; do
+            if ! info=$(gh pr view "$pr" --repo "$GITHUB_REPOSITORY" --json state,closedAt,labels 2>/dev/null); then
+              echo "  - pr-$pr: not a pull request, skipping"
               continue
             fi
+            state=$(jq -r .state <<< "$info")
+            labeled=$(jq -r '[.labels[].name] | index("preview") != null' <<< "$info")
+            closed_at=$(jq -r '.closedAt // empty' <<< "$info")
 
-            age_h=$(( (NOW - created_at) / 3600 ))
-            if (( created_at < CUTOFF )); then
-              echo "  - $name (pr=$pr): age=${age_h}h → STALE"
-              stale_prs+=("$pr")
+            if [[ "$state" == "OPEN" && "$labeled" == "true" ]]; then
+              echo "  - pr-$pr: open and labeled → keep"
+            elif [[ "$state" == "OPEN" ]]; then
+              echo "  - pr-$pr: open without preview label → DESTROY"
+              to_destroy+=("$pr")
+            elif (( $(date -d "$closed_at" +%s) < cutoff )); then
+              echo "  - pr-$pr: $state at $closed_at → DESTROY"
+              to_destroy+=("$pr")
             else
-              echo "  - $name (pr=$pr): age=${age_h}h → keep"
+              echo "  - pr-$pr: $state at $closed_at, within grace period → keep"
             fi
-          done < <(echo "$containers" | jq -c '.[]')
-
-          if [[ ${#stale_prs[@]} -eq 0 ]]; then
-            echo "No stale previews."
-            exit 0
-          fi
-
-          echo
-          echo "Stale previews to destroy: ${stale_prs[*]}"
-
-          if [[ "$DRY_RUN" == "true" ]]; then
-            echo "DRY_RUN=true, not dispatching."
-            exit 0
-          fi
-
-          for pr in "${stale_prs[@]}"; do
-            echo "→ Dispatching preview-down for pr=$pr"
-            gh workflow run preview-down.yml \
-              --repo "${{ github.repository }}" \
-              -f "pr_number=$pr"
           done
+
+          echo "to_destroy=${to_destroy[*]:-}" >> "$GITHUB_OUTPUT"
+
+      - name: Destroy
+        if: steps.find.outputs.to_destroy != ''
+        run: |
+          set -euo pipefail
+          flag=""
+          [[ "$DRY_RUN" == "true" ]] && flag="--dry-run"
+          # shellcheck disable=SC2086
+          scripts/infrastructure/preview_destroy.sh $flag ${{ steps.find.outputs.to_destroy }}

--- a/.github/workflows/preview-down.yml
+++ b/.github/workflows/preview-down.yml
@@ -15,66 +15,49 @@ concurrency:
   cancel-in-progress: false
 
 # Gate:
-# - closed: only if the PR carried the preview label (otherwise there is
-#   nothing to destroy; the terragrunt destroy would be a costly no-op)
+# - closed: only if the PR carried the preview label (otherwise nothing to destroy)
 # - unlabeled: only when the preview label itself is removed
-# - workflow_dispatch: always (manual destroy, used by preview-cleanup.yml)
+# - workflow_dispatch: always (manual destroy)
+# Resources are looked up by naming convention and deleted with the Scaleway
+# CLI (scripts/infrastructure/preview_destroy.sh), no terraform state needed.
+# preview-cleanup.yml runs the same script daily for anything missed here.
 jobs:
-  resolve:
-    name: 📌 Resolve PR number
+  destroy:
+    name: 🧱 Destroy preview resources
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.action == 'unlabeled' && github.event.label.name == 'preview') ||
       (github.event.action == 'closed' &&
        contains(github.event.pull_request.labels.*.name, 'preview'))
     runs-on: ubuntu-latest
-    outputs:
-      pr_number: ${{ steps.out.outputs.pr_number }}
-    steps:
-      - id: out
-        run: |
-          PR_NUMBER="${{ inputs.pr_number || github.event.pull_request.number }}"
-          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-
-  destroy:
-    name: 🧱 Destroy preview infra
-    needs: [resolve]
-    uses: ./.github/workflows/_terragrunt-apply.yml
-    secrets: inherit # pragma: allowlist secret
-    with:
-      command: destroy
-      pr_number: ${{ needs.resolve.outputs.pr_number }}
-      environment: preview
-
-  cleanup-state:
-    name: 🧹 Delete terraform state objects
-    needs: [resolve, destroy]
-    runs-on: ubuntu-latest
     environment: preview
+    permissions:
+      contents: read
+      deployments: write
     env:
+      PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+      SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
+      SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
+      SCW_DEFAULT_PROJECT_ID: ${{ secrets.SCW_DEFAULT_PROJECT_ID }}
+      SCW_DEFAULT_ORGANIZATION_ID: ${{ secrets.SCW_DEFAULT_ORGANIZATION_ID }}
+      SCW_DEFAULT_REGION: fr-par
       AWS_ACCESS_KEY_ID: ${{ secrets.SCW_ACCESS_KEY }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.SCW_SECRET_KEY }}
       AWS_DEFAULT_REGION: fr-par
     steps:
-      - name: Remove state files for pr-${{ needs.resolve.outputs.pr_number }}
-        run: |
-          set -euo pipefail
-          aws --endpoint-url=https://s3.fr-par.scw.cloud s3 rm \
-            "s3://lvao-terraform-state/preview/pr-${{ needs.resolve.outputs.pr_number }}/" \
-            --recursive
+      - uses: actions/checkout@v7.0.1
 
-  mark-inactive:
-    name: 🏷️ Mark deployment as inactive
-    needs: [resolve, cleanup-state]
-    runs-on: ubuntu-latest
-    permissions:
-      deployments: write
-    steps:
-      - uses: actions/github-script@v9
+      - name: Setup Scaleway CLI
+        uses: scaleway/action-scw@2e34a1eb35cf3cac627f24643a101fea269cbd83
+
+      - name: Destroy pr-${{ inputs.pr_number || github.event.pull_request.number }}
+        run: scripts/infrastructure/preview_destroy.sh "$PR_NUMBER"
+
+      - name: Mark deployment as inactive
+        uses: actions/github-script@v9
         with:
           script: |
-            const prNumber = Number("${{ needs.resolve.outputs.pr_number }}");
-
+            const prNumber = Number(process.env.PR_NUMBER);
             const { data: deployments } = await github.rest.repos.listDeployments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -82,7 +65,6 @@ jobs:
               task: `pr-${prNumber}`,
               per_page: 10,
             });
-
             for (const d of deployments) {
               await github.rest.repos.createDeploymentStatus({
                 owner: context.repo.owner,

--- a/.github/workflows/preview-up.yml
+++ b/.github/workflows/preview-up.yml
@@ -79,7 +79,6 @@ jobs:
     uses: ./.github/workflows/_terragrunt-apply.yml
     secrets: inherit # pragma: allowlist secret
     with:
-      command: apply
       pr_number: ${{ needs.resolve.outputs.pr_number }}
       image_tag: ${{ needs.resolve.outputs.image_tag }}
       environment: preview

--- a/docs/reference/infrastructure/preview-environments.md
+++ b/docs/reference/infrastructure/preview-environments.md
@@ -11,19 +11,21 @@ OpenTofu/Terragrunt from CI.
 3. Every push to the PR rebuilds the image and redeploys the same
    environment (same URL).
 4. The environment is destroyed when the PR is closed or the `preview`
-   label is removed. A nightly cron also reaps any preview older than
-   7 days as a safety net.
+   label is removed. A nightly garbage collector also destroys any preview
+   whose PR has been closed for more than 24 hours, or is open without the
+   `preview` label.
 
 ## Decisions
 
-| Topic               | Decision                                 | Rationale                                                                                                                                                               |
-| ------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Env keying          | **PR number** (`pr-<n>`)                 | Stable URL across pushes, one env per PR, destroyed on close.                                                                                                           |
-| Trigger             | **Label-gated** (`preview` label)        | Each up run builds a Docker image and seeds a DB: real cost, several minutes. Labeling opts a PR in.                                                                    |
-| Hostname            | **Scaleway generated domain**            | No DNS to manage. The hostname is unknown before apply, so the container runs with `ALLOWED_HOSTS` relaxed to `.functions.fnc.fr-par.scw.cloud`.                        |
-| Container namespace | **Dedicated `qfdmod-preview` namespace** | Isolation from preprod; the cleanup cron can list it exhaustively.                                                                                                      |
-| DB seeding          | **`pg_dump` sample DB → `pg_restore`**   | Realistic data on the carte from the preprod sample database.                                                                                                           |
-| Cleanup TTL         | **7 days** (nightly cron)                | With PR keying + destroy-on-close the cron is only a safety net for missed destroys. A shorter TTL would kill envs of still-open PRs and dead URLs in their PR comment. |
+| Topic               | Decision                                 | Rationale                                                                                                                                                           |
+| ------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Env keying          | **PR number** (`pr-<n>`)                 | Stable URL across pushes, one env per PR, destroyed on close.                                                                                                       |
+| Trigger             | **Label-gated** (`preview` label)        | Each up run builds a Docker image and seeds a DB: real cost, several minutes. Labeling opts a PR in.                                                                |
+| Hostname            | **Scaleway generated domain**            | No DNS to manage. The hostname is unknown before apply, so the container runs with `ALLOWED_HOSTS` relaxed to `.functions.fnc.fr-par.scw.cloud`.                    |
+| Container namespace | **Dedicated `qfdmod-preview` namespace** | Isolation from preprod; the cleanup cron can list it exhaustively.                                                                                                  |
+| DB seeding          | **`pg_dump` sample DB → `pg_restore`**   | Realistic data on the carte from the preprod sample database.                                                                                                       |
+| Teardown            | **Scaleway CLI by naming convention**    | No terraform state needed to destroy, so a failed or partial apply can always be cleaned up. `preview_destroy.sh` is shared by destroy-on-close and the nightly GC. |
+| GC rule             | **PR state, not resource age**           | A preview is wanted iff its PR is open and labeled `preview`. Closed PRs get a 24h grace so a reopened PR keeps its environment.                                    |
 
 ## Architecture
 
@@ -50,8 +52,7 @@ Per-PR resources (state: lvao-terraform-state/preview/pr-<n>/…):
 │                   see Limitations)
 └── container       serverless container in the shared
                     qfdmod-preview namespace, min_scale=0,
-                    tagged preview / preview-pr-<n> /
-                    created-at-<unix>
+                    tagged preview / preview-pr-<n>
 
 Shared (one-time):
 └── qfdmod-preview container namespace
@@ -66,12 +67,16 @@ State keys and the `environment` terragrunt input (`pr-<n>`) derive from
 the materialised directory path through `root.hcl` — the per-PR stacks
 carry no backend overrides.
 
-Teardown paths, all converging on `terragrunt run-all destroy` plus state
-object deletion:
+Teardown does not use terragrunt: `scripts/infrastructure/preview_destroy.sh`
+finds the container, database, user, bucket and state objects of a PR by
+name and deletes them with the `scw`/`aws` CLIs. It is idempotent and takes
+`--dry-run`. Three paths call it:
 
 1. PR closed or `preview` label removed → `preview-down.yml`
-2. Nightly cron (`preview-cleanup.yml`) dispatches `preview-down.yml` for
-   anything whose `created-at-<unix>` tag is older than 7 days
+2. Nightly GC (`preview-cleanup.yml`): lists every preview resource left in
+   Scaleway, and destroys those whose PR is closed for more than 24h
+   (`grace_hours` input) or open without the `preview` label. Supports
+   `dry_run=true`.
 3. Manual `workflow_dispatch` of `preview-down.yml` with a PR number
 
 Old `pr-*` image tags are reaped by the existing weekly
@@ -114,8 +119,8 @@ On a test PR:
 - [ ] A second push updates the same env, same URL
 - [ ] Removing the label (or closing the PR) destroys all three stacks
 - [ ] State objects gone from `lvao-terraform-state/preview/pr-<n>/`
-- [ ] Cron dry-run (`preview-cleanup.yml` with `dry_run=true`) lists an
-      artificially aged container as stale
+- [ ] GC dry-run (`preview-cleanup.yml` with `dry_run=true`) lists the
+      previews of closed PRs and keeps open labeled ones
 
 ## Limitations / out of scope
 

--- a/infrastructure/modules/webapp_container/main.tf
+++ b/infrastructure/modules/webapp_container/main.tf
@@ -1,7 +1,3 @@
-# Captured once on first apply, preserved across re-applies of the same stack.
-# Used by the cleanup workflow to age previews.
-resource "time_static" "created_at" {}
-
 resource "scaleway_container" "webapp" {
   name = "${var.prefix}-${var.environment}-webapp"
   tags = concat(
@@ -9,7 +5,6 @@ resource "scaleway_container" "webapp" {
       var.environment,
       var.prefix,
       "webapp",
-      "created-at-${time_static.created_at.unix}",
     ],
     var.extra_tags,
   )

--- a/scripts/infrastructure/preview_destroy.sh
+++ b/scripts/infrastructure/preview_destroy.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Destroy the Scaleway resources of one or more preview environments,
+# looked up by naming convention (no terraform state needed):
+#   container  lvao-pr-<n>-webapp   in the qfdmod-preview namespace
+#   database   preview_pr_<n>       on the lvao-preprod-webapp RDB instance
+#   user       preview_pr_<n>       idem
+#   bucket     lvao-pr-<n>-media
+#   tf state   s3://lvao-terraform-state/preview/pr-<n>/
+#
+# Usage: preview_destroy.sh [--dry-run] <pr_number> [<pr_number> ...]
+# Needs: scw (authenticated), aws (S3 creds in AWS_* env vars), jq.
+# Every step is idempotent: a missing resource is not an error.
+set -euo pipefail
+
+DRY_RUN=false
+if [[ "${1:-}" == "--dry-run" ]]; then DRY_RUN=true; shift; fi
+[[ $# -ge 1 ]] || { echo "usage: $0 [--dry-run] <pr_number>..." >&2; exit 2; }
+
+REGION="${SCW_DEFAULT_REGION:-fr-par}"
+S3_ENDPOINT="https://s3.${REGION}.scw.cloud"
+STATE_BUCKET="lvao-terraform-state"
+
+NAMESPACE_ID=$(scw container namespace list name=qfdmod-preview region="$REGION" -o json | jq -r '.[0].id')
+INSTANCE_ID=$(scw rdb instance list name=lvao-preprod-webapp region="$REGION" -o json | jq -r '.[0].id')
+[[ "$NAMESPACE_ID" != "null" && "$INSTANCE_ID" != "null" ]] \
+  || { echo "ERROR: preview namespace or preprod RDB instance not found" >&2; exit 1; }
+
+run() {
+  if $DRY_RUN; then echo "    [dry-run] $*"; else "$@" > /dev/null; fi
+}
+
+for pr in "$@"; do
+  [[ "$pr" =~ ^[0-9]+$ ]] || { echo "ERROR: invalid PR number '$pr'" >&2; exit 2; }
+  echo "→ pr-$pr"
+
+  container_id=$(scw container container list namespace-id="$NAMESPACE_ID" name="lvao-pr-$pr-webapp" region="$REGION" -o json \
+    | jq -r '.[0].id // empty')
+  if [[ -n "$container_id" ]]; then
+    echo "  container lvao-pr-$pr-webapp ($container_id)"
+    run scw container container delete "$container_id" region="$REGION"
+  fi
+
+  if scw rdb database list instance-id="$INSTANCE_ID" name="preview_pr_$pr" -o json \
+       | jq -e --arg n "preview_pr_$pr" 'any(.[]; .name == $n)' > /dev/null; then
+    echo "  database preview_pr_$pr"
+    run scw rdb database delete instance-id="$INSTANCE_ID" name="preview_pr_$pr"
+  fi
+
+  if scw rdb user list instance-id="$INSTANCE_ID" name="preview_pr_$pr" -o json \
+       | jq -e --arg n "preview_pr_$pr" 'any(.[]; .name == $n)' > /dev/null; then
+    echo "  user preview_pr_$pr"
+    run scw rdb user delete instance-id="$INSTANCE_ID" name="preview_pr_$pr"
+  fi
+
+  if scw object bucket list region="$REGION" -o json | jq -e --arg b "lvao-pr-$pr-media" 'any(.[]; .Name == $b)' > /dev/null; then
+    echo "  bucket lvao-pr-$pr-media"
+    run scw object bucket delete "lvao-pr-$pr-media" region="$REGION"
+  fi
+
+  echo "  state s3://$STATE_BUCKET/preview/pr-$pr/"
+  run aws --endpoint-url "$S3_ENDPOINT" s3 rm "s3://$STATE_BUCKET/preview/pr-$pr/" --recursive --quiet
+done


### PR DESCRIPTION
# Description succincte du problème résolu


**🗺️ contexte**: Meilleure gestion des environnements de preview

**💡 quoi**: Purge hebdomadaire des environnements de preview

**🎯 pourquoi**: pour éviter le billing lié au stockage s3 et conteneurs de preview

Et car la solution initialement envisagée n'était pas fonctionnelle :D

**🤔 comment**: 
On définit tout dans une action / script dédiés
On résout les numéros de PR et on déduit tout de ceux-ci

**🤓 comment tester**: 
merger la PR et attendre une nuit 😬 


## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code
- [ ] En cas d'ajout de dépendance, j'ai bien respecté un cooldown de 7 jours pour éviter les [Supply Chain Attacks](https://cheatsheetseries.owasp.org/cheatsheets/Software_Supply_Chain_Security_Cheat_Sheet.html)

## ✅ Reste à faire (PR en cours)

- [ ] <!-- Ajouter les tâches qui restent à faire dans cette PR -->

## 📆 A faire (prochaine PR)

- [ ] <!-- Ajouter les tâches qui devront être faites dans une prochaine PR -->
